### PR TITLE
Fixes to language ordering & tabbed examples

### DIFF
--- a/app/filters/tabbed_content_filter.rb
+++ b/app/filters/tabbed_content_filter.rb
@@ -20,7 +20,17 @@ class TabbedContentFilter < Banzai::Filter
 
   def sort_contents(contents)
     contents.sort_by do |content|
-      content[:frontmatter]['menu_weight'] || 999
+      case content[:frontmatter]['title'].downcase
+      when 'curl' then 1
+      when 'node' then 2
+      when 'node.js' then 2
+      when 'java' then 3
+      when 'c#' then 4
+      when 'php' then 5
+      when 'python' then 6
+      when 'ruby' then 7
+      else content[:frontmatter]['menu_weight'] || 999
+      end
     end
   end
 

--- a/app/filters/tabbed_examples_filter.rb
+++ b/app/filters/tabbed_examples_filter.rb
@@ -41,11 +41,11 @@ class TabbedExamplesFilter < Banzai::Filter
       case example[:language].downcase
       when 'curl' then 1
       when 'node' then 2
-      when 'ruby' then 3
-      when 'python' then 4
+      when 'java' then 3
+      when 'c#' then 4
       when 'php' then 5
-      when 'java' then 6
-      when 'c#' then 7
+      when 'python' then 6
+      when 'ruby' then 7
       else 1000
       end
     end


### PR DESCRIPTION
## Description

- Fixes language ordering when `tabbed_examples` is used.
- Changes order of languages to match list in #158

Fixes #158

## Deploy Notes

None
