### PR TITLE
Move tutorials to its own main section

### DIFF
--- a/app/controllers/markdown_controller.rb
+++ b/app/controllers/markdown_controller.rb
@@ -29,9 +29,6 @@ class MarkdownController < ApplicationController
 
   def set_navigation
     @navigation = :documentation
-    @side_navigation_extra_links = {
-      'Tutorials' => '/tutorials',
-    }
   end
 
   def set_product

--- a/app/controllers/tutorials_controller.rb
+++ b/app/controllers/tutorials_controller.rb
@@ -32,7 +32,7 @@ class TutorialsController < ApplicationController
 
     @title = 'Tutorials'
 
-    render layout: 'documentation-index'
+    render layout: 'page'
   end
 
   def show
@@ -57,7 +57,7 @@ class TutorialsController < ApplicationController
   end
 
   def set_navigation
-    @navigation = :documentation
+    @navigation = :tutorials
     @side_navigation_extra_links = {
       'Tutorials' => '/tutorials',
     }

--- a/app/views/layouts/partials/_header.html.erb
+++ b/app/views/layouts/partials/_header.html.erb
@@ -17,6 +17,7 @@
 <nav id="subnav" data-turbolinks="false">
   <div class="container">
     <a href="/documentation" class="<%= @navigation == :documentation ? 'active' : '' %>">Documentation</a>
+    <a href="/tutorials" class="<%= @navigation == :tutorials ? 'active' : '' %>">Tutorials</a>
     <a href="/api" class="<%= @navigation == :api ? 'active' : '' %>">API Reference</a>
     <a href="/tools" class="<%= @navigation == :tools ? 'active' : '' %>">SDKs &amp; Tools</a>
     <a href="/community" class="<%= @navigation == :community ? 'active' : '' %>">Community</a>


### PR DESCRIPTION
## Description

- Adds tutorials to its own header section
- Removes main tutorials link from main sidebar in docs (product tutorial links kept)

Fixes #157

## Deploy Notes

None
