### PR TITLE
NI Basic POST cURL example

### DIFF
--- a/_examples/number-insight/basic/cURL
+++ b/_examples/number-insight/basic/cURL
@@ -1,1 +1,4 @@
-curl "https://api.nexmo.com/ni/basic/json/?api_key=API_KEY&api_secret=API_SECRET&number=447700900000"
+curl -X "POST" "https://api.nexmo.com/ni/basic/json" \
+-d "api_key=API_KEY" \
+-d "api_secret=API_SECRET" \
+-d "number=447700900000"


### PR DESCRIPTION
## Description

Update NI Basic example to use `POST` instead of `GET`.