### PR TITLE
Fix incorrect page title

### DIFF
--- a/_documentation/voice/building-blocks/receive-a-phone-call.md
+++ b/_documentation/voice/building-blocks/receive-a-phone-call.md
@@ -3,7 +3,7 @@ title: Receive a phone call
 navigation_weight: 2
 ---
 
-# Make a phone call
+# Receive a phone call
 
 ```tabbed_examples
 tabs:


### PR DESCRIPTION
## Description

We incorrectly described the building block for handling incoming phone calls as "Make a phone call".

Improved while handling #193.

## Deploy Notes

None.