### PR TITLE
Update outbound-calls.md

### DIFF
--- a/_documentation/voice/voice-api/guides/outbound-calls.md
+++ b/_documentation/voice/voice-api/guides/outbound-calls.md
@@ -11,16 +11,16 @@ The workflow to make a Call using the Voice API is:
 
 1. You make an [authenticated](/concepts/guides/applications#minting) Call request to the Voice API.
 2. Nexmo accepts the request and sends response information.  
-3. Nexmo makes a GET request to retrieve an NCCO from your *answer_url* webhook endpoint.
-4. Nexmo places a call and follows the actions in your NCCO.
-4. Nexmo sends POST request to your *event_url* webhook endpoint when the Call status changes.
+3. Nexmo places a call and makes a GET request to retrieve an NCCO from your *answer_url* webhook endpoint.
+4. Nexmo follows the actions in your NCCO.
+5. Nexmo sends POST request to your *event_url* webhook endpoint when the Call status changes.
  For more advanced systems, depending on the input from your user, you can return an NCCO to customize their experience.
 
 To create a Call using the Voice API:
 
 
 1. [Create a Nexmo application](/concepts/guides/applications#apps_quickstart).</li>
-2. Create the NCCOs for the business logic you are implementing in your Voice app:
+2. Create the NCCOs for the business logic you are implementing in your Voice app: 
 
     ```tabbed_content
     source: '_examples/voice/guides/outbound-calls/ncco'


### PR DESCRIPTION
the top level flow of a VAPI Outbound call (https://docs.nexmo.com/voice/voice-api/calls) .. steps 1 thru 5... says (step 3) that Nexmo GET the NCCO from the answer_url BEFORE (step 4) placing the outbound call
this is wrong right? the NCCO fetch happens after the answer event

i've edited the text above but the graphic needs updating to match

## Description

Please describe what the changes are made in this pull request and why the change was necessary.

## Deploy Notes

Notes regarding deployment the contained body of work. These should note any db migrations, etc.
