### PR TITLE
Fix missing redirects introduced with SIP addition

### DIFF
--- a/_tutorials/add-a-call-whisper-to-an-inbound-call.md
+++ b/_tutorials/add-a-call-whisper-to-an-inbound-call.md
@@ -1,6 +1,6 @@
 ---
 title: Add a Call whisper to an inbound call
-products: voice
+products: voice/voice-api
 description: "Phone numbers are everywhere in advertising: on billboards, in TV ads, on websites, in newspapers. Often these numbers all redirect to the same call center, where an agent needs to inquire why the person is calling, and where they saw the advert. Call Whispers make this so much simpler."
 ---
 

--- a/_tutorials/call-tracking.md
+++ b/_tutorials/call-tracking.md
@@ -1,6 +1,6 @@
 ---
 title: Call tracking
-products: voice
+products: voice/voice-api
 description: We live in a world of data and analytics where we use unique identifiers to measure the impact of past decisions in order to fine tune future ones. You can use phone numbers in this way too. For example, you track the most popular phone numbers used for television radio, magazine, print or online advertising, and the times those phone numbers are used, in order to improve future campaigns.
 ---
 

--- a/_tutorials/interactive-voice-response.md
+++ b/_tutorials/interactive-voice-response.md
@@ -1,6 +1,6 @@
 ---
 title: Interactive Voice Response
-products: voice
+products: voice/voice-api
 description: Make it easy for visitors to navigate an Interactive Voice Response (IVR) application with simple text-to-speech (TTS) prompts.
 ---
 

--- a/_tutorials/mobile-app-invites.md
+++ b/_tutorials/mobile-app-invites.md
@@ -1,6 +1,6 @@
 ---
 title: Mobile app invites
-products: SMS
+products: messaging/sms
 description: Link your customers to your app with SMS
 ---
 

--- a/_tutorials/private-voice-communication.md
+++ b/_tutorials/private-voice-communication.md
@@ -1,6 +1,6 @@
 ---
 title: Private voice communication
-products: voice
+products: voice/voice-api
 description: Protect user's number privacy by connecting users together for private voice communication.
 ---
 

--- a/_tutorials/smart-local-numbers.md
+++ b/_tutorials/smart-local-numbers.md
@@ -1,6 +1,6 @@
 ---
 title: Smart local numbers
-products: voice
+products: voice/voice-api
 description: "Replace your toll-free numbers (e.g. 800, 0800) with easy to use, smart local numbers that allow you to provide a better customer service."
 ---
 

--- a/app/helpers/tutorial_helper.rb
+++ b/app/helpers/tutorial_helper.rb
@@ -11,6 +11,7 @@ module TutorialHelper
 
   def normalise_product_title(product)
     return "SMS" if product == 'messaging/sms'
+    return "Voice" if product == "voice/voice-api"
     return "Number Insight" if product == "number-insight"
     return product.camelcase
   end

--- a/config/redirects.yml
+++ b/config/redirects.yml
@@ -46,3 +46,21 @@
 /sip: /voice/sip
 /voice/guides/sip: /voice/sip
 /voice/overview: /voice/voice-api/overview
+
+/voice/guides/voice-app-components: /voice/voice-api/guides/voice-app-components
+/voice/guides/connect-two-users: /voice/voice-api/guides/connect-two-users
+/voice/guides/connecting-voice-calls-to-amazon-lex-bots: /voice/voice-api/guides/connecting-voice-calls-to-amazon-lex-bots
+/voice/guides/create-conferences: /voice/voice-api/guides/create-conferences
+/voice/guides/handle-call-status: /voice/voice-api/guides/handle-call-status
+/voice/guides/inbound-calls: /voice/voice-api/guides/inbound-calls
+/voice/guides/interactive-voice-response: /voice/voice-api/guides/interactive-voice-response
+/voice/guides/ncco-reference: /voice/voice-api/guides/ncco-reference
+/voice/guides/ncco: /voice/voice-api/guides/ncco
+/voice/guides/outbound-calls: /voice/voice-api/guides/outbound-calls
+/voice/guides/record-calls-and-conversations: /voice/voice-api/guides/record-calls-and-conversations
+/voice/guides/call-a-websocket: /voice/voice-api/guides/call-a-websocket
+/voice/building-blocks/make-a-phone-call: /voice/voice-api/building-blocks/make-a-phone-call
+/voice/building-blocks/connect-a-phone-call: /voice/voice-api/building-blocks/connect-a-phone-call
+/voice/building-blocks/receive-a-phone-call: /voice/voice-api/building-blocks/receive-a-phone-call
+/voice/tutorials: /voice/voice-api/tutorials
+/voice/api-reference: /voice/voice-api/api-reference

--- a/config/redirects.yml
+++ b/config/redirects.yml
@@ -39,6 +39,7 @@
 /write-the-docs: /contribute/write-the-docs
 
 /voice/api-reference: /api/voice
+/voice/voice-api/api-reference: /api/voice
 /messaging/sms/api-reference: /api/sms
 /verify/api-reference: /api/verify
 /number-insight/api-reference: /api/number-insight

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,7 +21,6 @@ Rails.application.routes.draw do
   get '/community', to: 'static#community'
   get '/community/past-events', to: 'static#past_events'
 
-
   match '/search', to: 'search#results', via: [:get, :post]
   match '/quicksearch', to: 'search#quicksearch', via: [:get, :post]
 


### PR DESCRIPTION
## Description

With #201 the root for Voice API moved from `/voice` to `/voice/voice-api` redirects were missed before merging. My fault.

## Deploy Notes

None
