### PR TITLE
Fix notice overlapping with close button

### DIFF
--- a/app/assets/stylesheets/objects/_notices.scss
+++ b/app/assets/stylesheets/objects/_notices.scss
@@ -44,6 +44,7 @@
 
   h2 {
     margin-bottom: 10px;
+    margin-right: 30px;
   }
 }
 


### PR DESCRIPTION
## Description

Minor fix where notice title may overlap with the close button.

## Deploy Notes

None