### PR TITLE
Add git-hookshot & pre-push hook

### DIFF
--- a/.hooks/pre-push
+++ b/.hooks/pre-push
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+remote_url="$2"
+current_branch=$(git rev-parse --abbrev-ref HEAD)
+
+if [ "$remote_url" == 'git@github.com:Nexmo/nexmo-developer.git' ]
+then
+  if echo $current_branch | grep -E '^private' > /dev/null
+  then
+    echo "You're about to push a private branch to a public repository, is that what you intended? [y|n]"
+    read -n 1 -r < /dev/tty
+
+    echo
+    if echo $REPLY | grep -E '^[Yy]$' > /dev/null
+    then
+      exit 0 # push will execute
+    else
+      exit 1 # push will not execute
+    fi
+  fi
+fi
+
+exit 0

--- a/Gemfile
+++ b/Gemfile
@@ -79,7 +79,7 @@ gem 'rest-client'
 gem 'recaptcha', require: "recaptcha/rails"
 
 # Share git hooks in Ruby projects among all the collaborators automatically, without them having to do anything
-gem 'git-hookshot'
+gem 'git-hookshot', git: 'git://github.com/brandonweiss/git-hookshot.git'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile
+++ b/Gemfile
@@ -78,6 +78,9 @@ gem 'rest-client'
 # Helpers for the reCAPTCHA API
 gem 'recaptcha', require: "recaptcha/rails"
 
+# Share git hooks in Ruby projects among all the collaborators automatically, without them having to do anything
+gem 'git-hookshot'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platform: :mri

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,10 @@
 GIT
+  remote: git://github.com/brandonweiss/git-hookshot.git
+  revision: ba31e703d1fb5088d0aee0afcd3e4ffeece55564
+  specs:
+    git-hookshot (0.1.0)
+
+GIT
   remote: git://github.com/oscardelben/rawler.git
   revision: f2909b135fce7d35167f98026ac481926c94423e
   specs:
@@ -125,7 +131,6 @@ GEM
       railties (>= 3.1.0)
       sass (>= 3.3.0, < 3.5)
       sprockets-es6 (>= 0.9.0)
-    git-hookshot (0.1.0)
     globalid (0.3.7)
       activesupport (>= 4.1.0)
     guard (2.14.1)
@@ -325,7 +330,7 @@ DEPENDENCIES
   dotenv-rails
   foreman
   foundation-rails (= 6.3.0.0)
-  git-hookshot
+  git-hookshot!
   guard-livereload (~> 2.5)
   jbuilder (~> 2.5)
   jquery-rails

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -125,6 +125,7 @@ GEM
       railties (>= 3.1.0)
       sass (>= 3.3.0, < 3.5)
       sprockets-es6 (>= 0.9.0)
+    git-hookshot (0.1.0)
     globalid (0.3.7)
       activesupport (>= 4.1.0)
     guard (2.14.1)
@@ -324,6 +325,7 @@ DEPENDENCIES
   dotenv-rails
   foreman
   foundation-rails (= 6.3.0.0)
+  git-hookshot
   guard-livereload (~> 2.5)
   jbuilder (~> 2.5)
   jquery-rails


### PR DESCRIPTION
## Description

~⚠️  Work in progress~

Adding `pre-push` hook to warn when you try to push private branches to our public repo.

Private branches are any branch which starts with the word `private`. For example `private/content/secret-new-thing`.

![2017-07-27 11 09 58](https://user-images.githubusercontent.com/1238468/28665641-36c98d50-72bc-11e7-8253-0291431bd932.gif)

## Deploy Notes

None