### PR TITLE
Update voice.md

### DIFF
--- a/_api/voice.md
+++ b/_api/voice.md
@@ -646,10 +646,10 @@ Value | Description
 `timeout` | Your user did not answer your call within `ringing_timer` seconds.
 `failed` | The call failed to complete
 `rejected` | The call was rejected
-`unanswered` | The call was not answered
+`cancelled` | The call was not answered
 `busy` | The number being dialled was on another call
 
-When a Call enters a state of `timeout`, `failed`, `rejected`, `unanswered` or `busy` the `event_url` webhook endpoint can optionally return an NCCO to override the current NCCO. See [Connect with fallback NCCO](/voice/guides/ncco-reference#connect_fallback).
+When a Call enters a state of `timeout`, `failed`, `rejected`, `cancelled` or `busy` the `event_url` webhook endpoint can optionally return an NCCO to override the current NCCO. See [Connect with fallback NCCO](/voice/guides/ncco-reference#connect_fallback).
 
 
 ## Errors


### PR DESCRIPTION
correct unanswered status to cancelled

I'm 99% certain that we don't have an event of `unanswered` but we don have an event of `cancelled` when the call is terminated before being answered so the description better fits that anyway
