### PR TITLE
Fix issue with unsanitized search results

### DIFF
--- a/app/views/search/_result.html.erb
+++ b/app/views/search/_result.html.erb
@@ -6,7 +6,7 @@
         <h3><%= hit.title %></h3>
 
         <p class="search-highlighted">
-          <%= hit._snippetResult.body_safe.value.html_safe %>
+          <%= sanitize(hit._snippetResult.body_safe.value, tags: ['em']) %>
         </p>
       </div>
     </a>
@@ -22,7 +22,7 @@
 
 
         <p class="search-highlighted">
-          ...<%= hit._snippetResult.body.value.html_safe %>...
+          ...<%= sanitize(hit._snippetResult.body.value, tags: ['em']) %>...
         </p>
       </div>
     </a>


### PR DESCRIPTION
## Description

Fixes issue where results were trusted to already be HTML safe but weren't. Changed to use `sanitize` to only allow `em` tags.

## Deploy Notes

None
