### PR TITLE
Add git-hookshot to development

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -97,6 +97,9 @@ group :development do
   gem "better_errors"
   gem "binding_of_caller"
   gem "pry"
+
+  # Share git hooks in Ruby projects among all the collaborators automatically, without them having to do anything
+  gem 'git-hookshot', git: 'https://github.com/brandonweiss/git-hookshot.git'
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,10 @@
 GIT
+  remote: https://github.com/brandonweiss/git-hookshot.git
+  revision: 10f4b35497fd1391b94baa77e4c986d2415f3d29
+  specs:
+    git-hookshot (0.1.0)
+
+GIT
   remote: https://github.com/oscardelben/rawler.git
   revision: f2909b135fce7d35167f98026ac481926c94423e
   specs:
@@ -324,6 +330,7 @@ DEPENDENCIES
   dotenv-rails
   foreman
   foundation-rails (= 6.4.1.2)
+  git-hookshot!
   guard-livereload (~> 2.5)
   jbuilder (~> 2.5)
   jquery-rails
@@ -354,4 +361,4 @@ RUBY VERSION
    ruby 2.4.1p111
 
 BUNDLED WITH
-   1.15.1
+   1.15.3


### PR DESCRIPTION
## Description

Re-adds `git-hookshot`. Changed dependency to be in `development` group only.

More info: https://github.com/brandonweiss/git-hookshot/issues/1

## Deploy Notes

None
