### PR TITLE
remove back tick typo

### DIFF
--- a/_api/sms.md
+++ b/_api/sms.md
@@ -137,7 +137,7 @@ The response contains the following keys and values:
 
 ```tabbed_content
 source: '/_examples/api/sms/sending/keys-and-values/'
-````
+```
 
 #### Error codes
 


### PR DESCRIPTION
## Description

just removing a rouge back tick 

## Deploy Notes

Notes regarding deployment the contained body of work. These should note any db migrations, etc.
