### PR TITLE
API Sidebar fixed to link to correct IDs

### DIFF
--- a/app/helpers/navigation_helper.rb
+++ b/app/helpers/navigation_helper.rb
@@ -32,7 +32,7 @@ module NavigationHelper
 
       nodes << <<~HEREDOC
         <li>
-          <a href="##{heading.text.parameterize}" data-scrollspy-id="#{heading['data-id']}">
+          <a href="##{heading.attributes['id']}" data-scrollspy-id="#{heading['data-id']}">
             #{heading.text}
           </a>
       HEREDOC


### PR DESCRIPTION
The Rails helper function generates an ID by parameterizing the header's
text. This breaks if there are numerous headers the same (real life
examples: "Request", "Response", "Keys and Values" etc.)

Instead, we can just read the ID that's been generated by the Markdown
parser and use that instead. This should fix lots of broken links on the
site.

Raised originally on JIRA: DOCS-290.