### PR TITLE
Reset sidebar on page change

### DIFF
--- a/app/javascript/packs/Scrollspy.js
+++ b/app/javascript/packs/Scrollspy.js
@@ -33,15 +33,19 @@ export default () => {
   $(document).ready(function() {
     let onScrollOrResizeThrottled = throttle(onScrollOrResize, 20);
     $(document).scroll(onScrollOrResizeThrottled);
-    return $(document).resize(onScrollOrResizeThrottled);
-  });
+    $(document).resize(onScrollOrResizeThrottled);
 
-  $('.navigation').scrollToFixed({
-    marginTop: 20,
-    minWidth: 575,
-    limit: () => {
-      return $('#footer').offset().top - $('.navigation').outerHeight(true) - 20
-    }
+    // Reset sidenav
+    $('.navigation').siblings('div').remove()
+    $('.navigation').removeAttr('style')
+
+    $('.navigation').scrollToFixed({
+      marginTop: 20,
+      minWidth: 575,
+      limit: () => {
+        return $('#footer').offset().top - $('.navigation').outerHeight(true) - 20
+      }
+    });
   });
 
 }


### PR DESCRIPTION
## Description

Fixes an issue where sidenav is not handled correctly when pageload happens after animation.

## Deploy Notes

- [x] Deploy to review app
- [x] Test on review app
