### PR TITLE
Add support for language information in feedbacks

### DIFF
--- a/app/admin/feedback_feedback.rb
+++ b/app/admin/feedback_feedback.rb
@@ -22,6 +22,7 @@ ActiveAdmin.register ::Feedback::Feedback, as: 'Feedback' do
     column :owner
     column :ip
     column :comment
+    column :code_language
     actions
   end
 end

--- a/app/admin/feedback_feedback.rb
+++ b/app/admin/feedback_feedback.rb
@@ -23,6 +23,9 @@ ActiveAdmin.register ::Feedback::Feedback, as: 'Feedback' do
     column :ip
     column :comment
     column :code_language
+    column :code_language_selected_whilst_on_page
+    column :code_language_set_by_url
+    column :created_at
     actions
   end
 end

--- a/app/assets/stylesheets/_core.scss
+++ b/app/assets/stylesheets/_core.scss
@@ -139,3 +139,7 @@ hr {
 .flex {
   display: flex;
 }
+
+.hide {
+  display: none;
+}

--- a/app/assets/stylesheets/layout/_feedback.scss
+++ b/app/assets/stylesheets/layout/_feedback.scss
@@ -1,6 +1,0 @@
-#feedback__improve {
-  p {
-    // margin: 7px 0;
-    // font-size: 0.9em;
-  }
-}

--- a/app/assets/stylesheets/nexmo.scss
+++ b/app/assets/stylesheets/nexmo.scss
@@ -92,7 +92,6 @@ $font-family: 'Averta', sans-serif;
 @import "layout/community";
 @import "layout/header";
 @import "layout/hero";
-@import "layout/feedback";
 @import "layout/footer";
 @import "layout/landing";
 @import "layout/search";

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -57,10 +57,9 @@ class ApplicationController < ActionController::Base
   end
 
   def set_canonical_url
-    if params[:code_language]
-      @canonical_url = request.path.gsub("/#{params[:code_language]}", '')
-      @canonical_url.prepend(request.base_url)
-    end
+    @show_canonical_meta = params[:code_language].present?
+    @canonical_url = request.path.chomp("/#{params[:code_language]}")
+    @canonical_url.prepend(request.base_url)
   end
 
   def set_feedback_author

--- a/app/controllers/feedback/feedbacks_controller.rb
+++ b/app/controllers/feedback/feedbacks_controller.rb
@@ -37,7 +37,7 @@ module Feedback
     end
 
     def feedback_params
-      params.require(:feedback_feedback).permit(:sentiment, :comment, :source)
+      params.require(:feedback_feedback).permit(:sentiment, :comment, :source, :code_language)
     end
 
     def should_use_cookied_author?(author)

--- a/app/controllers/feedback/feedbacks_controller.rb
+++ b/app/controllers/feedback/feedbacks_controller.rb
@@ -37,7 +37,14 @@ module Feedback
     end
 
     def feedback_params
-      params.require(:feedback_feedback).permit(:sentiment, :comment, :source, :code_language)
+      params.require(:feedback_feedback).permit(
+        :sentiment,
+        :comment,
+        :source,
+        :code_language,
+        :code_language_set_by_url,
+        :code_language_selected_whilst_on_page,
+      )
     end
 
     def should_use_cookied_author?(author)

--- a/app/javascript/packs/TabbedExamples.js
+++ b/app/javascript/packs/TabbedExamples.js
@@ -24,7 +24,7 @@ export default class TabbedExamples {
   }
 
   initialLanguage() {
-    const initialLanguage = $('#primary-content').data('initial-language')
+    const initialLanguage = $('#primary-content').attr('data-initial-language')
     return initialLanguage === '' ? false : initialLanguage
   }
 
@@ -88,6 +88,8 @@ export default class TabbedExamples {
       this.setLanguage(language)
 
       if (linkable) {
+        $('#feedback_feedback_code_language').val(language)
+
         if (window.history.state.language || this.initialLanguage()) {
           window.history.pushState({ language }, 'language', language)
         } else {

--- a/app/javascript/packs/TabbedExamples.js
+++ b/app/javascript/packs/TabbedExamples.js
@@ -51,6 +51,7 @@ export default class TabbedExamples {
       if (this.shouldRestoreTabs()) {
         if (window.localStorage) {
           var language = window.localStorage.getItem('languagePreference')
+          $('#feedback_feedback_code_language').val(language)
           if (language) { this.setLanguage(language, this.context) }
         }
 
@@ -89,6 +90,7 @@ export default class TabbedExamples {
 
       if (linkable) {
         $('#feedback_feedback_code_language').val(language)
+        $('#feedback_feedback_code_language_selected_whilst_on_page').prop('checked', true)
 
         if (window.history.state.language || this.initialLanguage()) {
           window.history.pushState({ language }, 'language', language)

--- a/app/views/layouts/partials/_feedback.html.erb
+++ b/app/views/layouts/partials/_feedback.html.erb
@@ -6,10 +6,10 @@
   <div class="feedback-container">
     <%= form_for Feedback::Feedback.new, remote: true, format: :js do |f| %>
       <div class="row">
-        <div class="columns small-6">
+        <div class="columns small-8">
           <h2>Was this documentation helpful?</h2>
         </div>
-        <div class="columns small-6 right" id="feedback__improve">
+        <div class="columns small-4 right" id="feedback__improve">
           <% if @document_path %>
             <p>
               <i class="icon icon-github"></i> <%= link_to("Improve this page", "https://github.com/Nexmo/nexmo-developer/blob/master/#{@document_path}", target: "_blank") %>
@@ -20,7 +20,8 @@
 
       <div class="feedback-basic-fields">
         <%= f.hidden_field :id, value: nil %>
-        <%= f.hidden_field :source, value: "#{request.base_url}#{request.fullpath}" %>
+        <%= f.hidden_field :code_language, value: request.parameters['code_language'] %>
+        <%= f.hidden_field :source, value: "#{@canonical_url}" %>
         <%= f.radio_button(:sentiment, 'negative') %>
         <%= f.label(:sentiment_negative, '<i class="icon icon-thumbs-o-down"></i>'.html_safe, class: 'sentiment') %>
         <%= f.radio_button(:sentiment, 'positive') %>

--- a/app/views/layouts/partials/_feedback.html.erb
+++ b/app/views/layouts/partials/_feedback.html.erb
@@ -21,6 +21,8 @@
       <div class="feedback-basic-fields">
         <%= f.hidden_field :id, value: nil %>
         <%= f.hidden_field :code_language, value: request.parameters['code_language'] %>
+        <%= f.check_box :code_language_selected_whilst_on_page, class: 'hide' %>
+        <%= f.check_box :code_language_set_by_url, checked: params[:code_language].present?, class: 'hide' %>
         <%= f.hidden_field :source, value: "#{@canonical_url}" %>
         <%= f.radio_button(:sentiment, 'negative') %>
         <%= f.label(:sentiment_negative, '<i class="icon icon-thumbs-o-down"></i>'.html_safe, class: 'sentiment') %>

--- a/app/views/layouts/partials/_head.html.erb
+++ b/app/views/layouts/partials/_head.html.erb
@@ -37,7 +37,7 @@
     })(window,document,'script','dataLayer','<%= ENV['GOOGLE_TAG_MANAGER_ID'] %>');</script>
   <% end %>
 
-  <% if @canonical_url %>
+  <% if @show_canonical_meta %>
     <link rel="canonical" href="<%= @canonical_url %>">
   <% end %>
 

--- a/db/migrate/20170914145346_add_code_language_to_feedback.rb
+++ b/db/migrate/20170914145346_add_code_language_to_feedback.rb
@@ -1,0 +1,6 @@
+class AddCodeLanguageToFeedback < ActiveRecord::Migration[5.1]
+  def change
+    add_column :feedback_feedbacks, :code_language, :string
+    add_index :feedback_feedbacks, :code_language
+  end
+end

--- a/db/migrate/20170915081222_correct_uri_of_resources.rb
+++ b/db/migrate/20170915081222_correct_uri_of_resources.rb
@@ -1,0 +1,31 @@
+CODE_LANGUAGES = ['curl', 'node', 'java', 'dotnet', 'csharp', 'php', 'python', 'ruby']
+
+class CorrectUriOfResources < ActiveRecord::Migration[5.1]
+  def up
+    Feedback::Resource.all.each do |resource|
+      uri = URI(resource.uri)
+
+      # Get the code_language from the URI. Will return nil if there isn't one
+      code_language = CODE_LANGUAGES.detect { |language| language == uri.path.split('/').last }
+
+      # Get the canonical_uri by removing query parameters and then chomp the code_language off the end if present
+      canonical_uri = "#{uri.scheme}://#{uri.host}#{uri.path}".chomp("/#{code_language}")
+
+      # Check if the current uri of the resource matches our canonical_uri, if so do nothing
+      unless canonical_uri == resource.uri
+        # Lets see if a resource with the canonical_uri already exists
+        canonical_resource = Feedback::Resource.find_by_uri(canonical_uri)
+
+        if canonical_resource
+          # If we do have a canonical_resource update this resources feedbacks to belong to it and destroy this resource
+          # since it will no longer be used.
+          resource.feedbacks.update_all({ resource_id: canonical_resource.id })
+          resource.destroy!
+        else
+          # Otherwise we'll simply correct the uri of this resource
+          resource.update({ uri: canonical_uri })
+        end
+      end
+    end
+  end
+end

--- a/db/migrate/20170919151243_add_langugage_set_filters_to_feedbacks.rb
+++ b/db/migrate/20170919151243_add_langugage_set_filters_to_feedbacks.rb
@@ -1,0 +1,9 @@
+class AddLangugageSetFiltersToFeedbacks < ActiveRecord::Migration[5.1]
+  def change
+    add_column :feedback_feedbacks, :code_language_selected_whilst_on_page, :boolean
+    add_column :feedback_feedbacks, :code_language_set_by_url, :boolean
+
+    add_index :feedback_feedbacks, :code_language_selected_whilst_on_page, name: 'index_feedbacks_on_code_language_selected_whilst_on_page'
+    add_index :feedback_feedbacks, :code_language_set_by_url, name: 'index_feedbacks_on_code_language_set_by_url'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170908153555) do
+ActiveRecord::Schema.define(version: 20170915081222) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -75,6 +75,8 @@ ActiveRecord::Schema.define(version: 20170908153555) do
     t.text "comment"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "code_language"
+    t.index ["code_language"], name: "index_feedback_feedbacks_on_code_language"
     t.index ["ip"], name: "index_feedback_feedbacks_on_ip"
     t.index ["owner_id", "owner_type"], name: "index_feedback_feedbacks_on_owner_id_and_owner_type"
     t.index ["resource_id"], name: "index_feedback_feedbacks_on_resource_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170915081222) do
+ActiveRecord::Schema.define(version: 20170919151243) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -76,7 +76,11 @@ ActiveRecord::Schema.define(version: 20170915081222) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "code_language"
+    t.boolean "code_language_selected_whilst_on_page"
+    t.boolean "code_language_set_by_url"
     t.index ["code_language"], name: "index_feedback_feedbacks_on_code_language"
+    t.index ["code_language_selected_whilst_on_page"], name: "index_feedbacks_on_code_language_selected_whilst_on_page"
+    t.index ["code_language_set_by_url"], name: "index_feedbacks_on_code_language_set_by_url"
     t.index ["ip"], name: "index_feedback_feedbacks_on_ip"
     t.index ["owner_id", "owner_type"], name: "index_feedback_feedbacks_on_owner_id_and_owner_type"
     t.index ["resource_id"], name: "index_feedback_feedbacks_on_resource_id"


### PR DESCRIPTION
## Description

This change will now associate the users selected code language in feedbacks if they have visited a page on a language specific URL or have selected a language in a `TabbedExample` component.

It also goes through the existing data to correct resource URIs that contain the language within the URLs or other artefacts such as URL parameters.

## Deploy Notes

- [ ] `rake db:migrate` 