### PR TITLE
Copyedits of "you use"

### DIFF
--- a/_api/voice/ncco.md
+++ b/_api/voice/ncco.md
@@ -54,7 +54,7 @@ The record action is asynchronous. Recording starts when the record action is ex
 
 For information about the workflow to follow, see [Recordings](/voice/guides/record-calls-and-conversations).
 
-You use the following options to control a `record` action:
+You can use the following options to control a `record` action:
 
 Option | Description | Required
  -- | -- | --
@@ -97,13 +97,13 @@ You can use the `conversation` action to create standard or moderated Conversati
 
 > **Note**: you can invite up to 50 people to your Conversation.
 
-The following NCCO examples show how to configure different types of Conversation. You use the [*answer_url* webhook GET request parameters](/voice/guides/ncco#controlling) to ensure you deliver one NCCO to participants and another to the moderator.
+The following NCCO examples show how to configure different types of Conversation. You can use the [*answer_url* webhook GET request parameters](/voice/guides/ncco#controlling) to ensure you deliver one NCCO to participants and another to the moderator.
 
 ```tabbed_content
 source: '/_examples/voice/guides/ncco-reference/conversation'
 ```
 
-You use the following options to control a *conversation* action:
+You can use the following options to control a *conversation* action:
 
 Option | Description | Required
 -- | -- | --
@@ -122,7 +122,7 @@ You can use the `connect` action to connect a call to endpoints such as phone nu
 
 This action is synchronous, after a *connect* the next action in the NCCO stack is processed. A connect action ends when the endpoint you are calling is busy or unavailable. You ring endpoints sequentially by nesting connect actions.
 
-You use the following options to control a `connect` action:
+You can use the following options to control a `connect` action:
 
 Option | Description | Required
 -- | -- | --
@@ -283,7 +283,7 @@ The following NCCO examples shows how to send a synthesized speech message to a 
 source: '/_examples/voice/guides/ncco-reference/talk'
 ```
 
-You use the following options to control a *talk* action:
+You can use the following options to control a *talk* action:
 
 <table>
 <thead>
@@ -370,7 +370,7 @@ The following NCCO example shows how to send an audio stream to a Conversation o
 source: '/_examples/voice/guides/ncco-reference/stream'
 ```
 
-You use the following options to control a *stream* action:
+You can use the following options to control a *stream* action:
 
 Option | Description | Required
 -- | -- | --
@@ -400,7 +400,7 @@ WAV:
 
 ## `input`
 
-You use the `input` action to collect digits input by the person you are calling. This action is synchronous, Nexmo processes the input and forwards it in the [parameters](#input_return_parameters) sent to the `eventURL` webhook endpoint you configure in your request. Your webhook endpoint should return another NCCO that replaces the existing NCCO and controls the Call based on the user input. You use this functionality to create an Interactive Voice Response (IVR). For example, if your user presses *4*, you return a [connect](#connect) NCCO that forwards the call to your sales department.
+You can use the `input` action to collect digits input by the person you are calling. This action is synchronous, Nexmo processes the input and forwards it in the [parameters](#input_return_parameters) sent to the `eventURL` webhook endpoint you configure in your request. Your webhook endpoint should return another NCCO that replaces the existing NCCO and controls the Call based on the user input. You could use this functionality to create an Interactive Voice Response (IVR). For example, if your user presses *4*, you return a [connect](#connect) NCCO that forwards the call to your sales department.
 
 The following NCCO example shows how to configure an IVR endpoint:
 
@@ -433,7 +433,7 @@ The following NCCO example shows how to use `bargeIn` to allow a user to interru
 ]
 ```
 
-You use the following options to control an `input` action:
+The following options can be used to control an `input` action:
 
 Option | Description | Required
 -- | -- | --

--- a/_documentation/messaging/us-short-codes/guides/campaign-subscription-management.md
+++ b/_documentation/messaging/us-short-codes/guides/campaign-subscription-management.md
@@ -1,6 +1,6 @@
 ---
 title: Campaign Subscription Management
-description: You use Campaign Subscription Management to create an opt-in and opt-out process for your users.
+description: Create an opt-in and opt-out process for recipients of your campaign.
 ---
 
 # Campaign Subscription Management

--- a/_documentation/voice/voice-api/guides/create-conferences.md
+++ b/_documentation/voice/voice-api/guides/create-conferences.md
@@ -5,7 +5,7 @@ description: Voice API conversations.
 
 #Create conferences
 
-A Conversation is the collection of one or more inbound calls to the virtual number associated to your Voice app. A named Conversation is a conference. You use the *conversation* NCCO to create a standard or moderated conference for the callers. A standard conference starts when the first caller calls in and ends when the last caller hangs up. A moderated conference starts and ends when the moderator calls in and hangs up. Before a moderated conference starts, you can send an audio stream to the waiting participants. When a conference starts, all audio from all inbound calls is mixed into it. You can [record](/voice/guides/record-calls-and-conversations) standard and moderated conferences.
+A Conversation is the collection of one or more inbound calls to the virtual number associated to your Voice app. A named Conversation is a conference. The *conversation* NCCO is used to create a standard or moderated conference for the callers. A standard conference starts when the first caller calls in and ends when the last caller hangs up. A moderated conference starts and ends when the moderator calls in and hangs up. Before a moderated conference starts, you can send an audio stream to the waiting participants. When a conference starts, all audio from all inbound calls is mixed into it. You can [record](/voice/guides/record-calls-and-conversations) standard and moderated conferences.
 
 The workflow for a conference is:
 

--- a/_documentation/voice/voice-api/guides/handle-call-status.md
+++ b/_documentation/voice/voice-api/guides/handle-call-status.md
@@ -24,7 +24,7 @@ A call can be initiated via a request to [`POST /calls`](/api/voice#payload). Th
 }
 ```
 
-Further status changes for the Call are sent to your `event_url` webhook endpoint. Each leg of a Call has a different `uuid`. You use the `uuid` in all [`/calls`](/api/voice#payload) requests that alter or retrieve information about a Call.
+Further status changes for the Call are sent to your `event_url` webhook endpoint. Each leg of a Call has a different `uuid`. The `uuid` is used in all [`/calls`](/api/voice#payload) requests that alter or retrieve information about a Call.
 
 If you [record](/voice/guides/record-calls-and-conversations) your Calls and Conversations, the download URL for the mp3 recording is sent to your event webhook endpoint when `status` is `complete`.
 

--- a/_documentation/voice/voice-api/guides/handle-call-status.md
+++ b/_documentation/voice/voice-api/guides/handle-call-status.md
@@ -11,7 +11,7 @@ The event webhook is defined in the following:
 
 * Application configuration - [`POST /applications`](/api/application#create) - the default event webhook endpoint for all Calls and Conversations that use this application
 * A Call request - [`POST /calls`](/api/voice#payload) - the event webhook endpoint used for a particular Call
-* A [connect](/voice/guides/ncco-reference#connect) NCCO action - when you use the connect NCCO action to connect a voice call to an endpoint
+* A [connect](/voice/guides/ncco-reference#connect) NCCO action - when you use the `connect` NCCO action to connect a voice call to an endpoint
 
 A call can be initiated via a request to [`POST /calls`](/api/voice#payload). The response from this request contains initial information about the call.
 

--- a/_documentation/voice/voice-api/guides/ncco.md
+++ b/_documentation/voice/voice-api/guides/ncco.md
@@ -5,7 +5,7 @@ description: The Nexmo Call Control Objects used to manage your Voice API calls.
 
 # Nexmo Call Control Objects
 
-A Nexmo Call Control Object (NCCO) is a JSON array of actions that you use to control the flow of a Voice API Call.
+A Nexmo Call Control Object (NCCO) is a JSON array of actions that is used to control the flow of a Voice API Call.
 
 This section describes:
 
@@ -72,7 +72,7 @@ Name | Description
 `from` | The endpoint you are calling from.
 `conversation_uuid` | The unique ID for this Conversation.
 
-You use these parameters to customize the NCCO you return to Nexmo. The following code examples show how to provide the NCCO that controls your call or conversation:
+You can use these parameters to customize the NCCO you return to Nexmo. The following code examples show how to provide the NCCO that controls your call or conversation:
 
 ```tabbed_examples
 source: '_examples/voice/ncco/creating-a-custom-call-or-conversation-for-each-user'

--- a/_documentation/voice/voice-api/guides/outbound-calls.md
+++ b/_documentation/voice/voice-api/guides/outbound-calls.md
@@ -44,7 +44,7 @@ To create a Call using the Voice API:
     source: '_examples/voice/guides/outbound-calls/handle-the-call-state-changes'
     ```
 
-5. Write a method to generate the JWT you use to access Nexmo API for your application:
+5. Write a method to generate the JWT used to access Nexmo API for your application:
 
     ```tabbed_examples
     source: '_examples/voice/guides/outbound-calls/jwt'

--- a/_documentation/voice/voice-api/guides/record-calls-and-conversations.md
+++ b/_documentation/voice/voice-api/guides/record-calls-and-conversations.md
@@ -5,14 +5,14 @@ description: Record the audio from a Call or Conversation.
 
 #Record calls and conversations
 
-Recordings are contextual, they are attached to the UUID of each leg in a Call or a Conversation. You use different NCCOs to record:  
+Recordings are contextual, they are attached to the UUID of each leg in a Call or a Conversation. Different NCCOs are used to record in the two different contexts.
 
 * Calls - you set the [record](/voice/guides/ncco-reference#record) action at the start of your NCCO so everything is recorded. Recording starts when the *record* action is executed in the NCCO and finishes when the synchronous condition in the action is met. That is, *endOnSilence*, *timeOut* or *endOnKey*. If you do not set a synchronous condition, the Voice API immediately executes the next NCCO without recording.
 * Conversations - you set the *record* option in the [conversation](/voice/guides/ncco-reference#conversation) action. For standard conversations, recordings start when one or more attendee connects to the conversation and terminate when the last attendee disconnects. For moderated conversations, recordings start when the moderator joins. That is, when an NCCO is executed for the named conversation where ‘startOnEnter’ is set to *true*. When the recording is terminated, the URL you download the recording from is sent to the event URL.
 
 The workflow to create a recording is:
 
-1. You use the *record* NCCO action to record an active Call or Conversation:
+1. Use the *record* NCCO action to record an active Call or Conversation:
 
     ```tabbed_content
     source: '/_examples/voice/guides/record-calls-and-conversations/ncco'

--- a/_examples/concepts/guides/applications/api.md
+++ b/_examples/concepts/guides/applications/api.md
@@ -13,8 +13,8 @@ menu_weight: 2
 
     Key | Description
     -- | --
-    `application id` | You use this id to perform all actions on your application.
-    `private_key` | The JWTs you use to authenticate your requests to Nexmo API are based on this private key. You should keep this key in a file that is not accessible from the Internet.
+    `application id` | This ID is used to perform all actions on your application.
+    `private_key` | The JWTs used to authenticate your requests to Nexmo API are based on this private key. You should keep this key in a file that is not accessible from the Internet.
 
 3. If you do not have one, rent a virtual number.
 

--- a/_tutorials/fraud-scoring-and-phone-number-verification.md
+++ b/_tutorials/fraud-scoring-and-phone-number-verification.md
@@ -1,16 +1,16 @@
 ---
 title: Fraud scoring and phone number verification
 products: number-insight
-description: While it would be easy to confirm a phone number with Nexmo Verify every time a user provides you with their number this is hardly always necessary. By combining Nexmo Verify with Nexmo Number Insight, and applying your own fraud scoring logic, it is extremely easy to build your own fraud detection system.
+description: While it would be easy to confirm a phone number with Nexmo Verify every time a user provides you with their number this is hardly always necessary. By combining Nexmo Verify with Nexmo Number Insight, and applying your own fraud scoring logic, it is easy to build your own fraud detection system.
 ---
 
 # Fraud scoring and phone number verification
 
-While it would be easy to confirm a phone number with Nexmo Verify every time a user provides you with their number this is hardly always necessary. By combining Nexmo Verify with Nexmo Number Insight, and applying your own fraud scoring logic, it is extremely easy to build your own fraud detection system.
+While it would be easy to confirm a phone number with Nexmo Verify every time a user provides you with their number this is not always necessary. By combining Nexmo Verify with Nexmo Number Insight, and applying your own fraud scoring logic, it is easy to build your own fraud detection system.
 
 ## In this tutorial
 
-You see how to build a number verification system using Nexmo APIs and libraries. For this tutorial the fraud rating logic extracts the user's current country from their IP and request their phone's current (roaming) country. The number is flagged as potentially fraudulent if the user's phone number location and IP location don't match.  
+By following this tutorial, you can see how to build a number verification system using Nexmo APIs and libraries. For this tutorial, the fraud rating logic extracts the user's current country from their IP and request their phone's current (roaming) country. The number is flagged as potentially fraudulent if the user's phone number location and IP location don't match.
 
 To do this:
 

--- a/_tutorials/interactive-voice-response.md
+++ b/_tutorials/interactive-voice-response.md
@@ -213,7 +213,7 @@ protected function promptSearch()
 }
 ```
 
-You use the `eventUrl` option in your NCCO to send the input to a particular `Action`. This is essentially the same thing you do with the `action` property of a HTML `<form>`. This is where the `$config` array and the base URL are used.
+The `eventUrl` option in your NCCO is used to send the input to a particular `Action`. This is essentially the same thing you do with the `action` property of a HTML `<form>`. This is where the `$config` array and the base URL are used.
 
 A few other `input` specific properties are used. `timeOut` gives the user more time to enter the order number and `submitOnHash` lets them avoid waiting by ending their order ID with the pound sign.
 

--- a/_tutorials/interactive-voice-response.md
+++ b/_tutorials/interactive-voice-response.md
@@ -15,8 +15,8 @@ This tutorial is based on the [Simple IVR](https://www.nexmo.com/use-cases/inter
 In this tutorial you build an interactive phone menu with different paths based on the user's responses and identity:
 
 - [Create a voice application](#create-a-voice-application) - create and configure an application using [Nexmo CLI](https://github.com/nexmo/nexmo-cli), then configure the webhook endpoints to provide NCCOs and handle changes in Call status
-- [Buy a phone number](#buy-a-phone-number) - buy voice enabled numbers you use
-* [Link the phone numbers to the Nexmo Application](#link-numbers) - configure the voice enabled phone numbers you use to mask user numbers
+- [Buy a phone number](#buy-a-phone-number) - buy voice enabled numbers for use in the application
+* [Link the phone numbers to the Nexmo Application](#link-numbers) - configure the voice enabled phone numbers to mask user numbers
 - [Route an inbound call](#route-an-inbound-call) - configure your webhook endpoint to handle incoming voice calls, find the phone number it is associated with and handle the call
 - [Send text-to-speech greeting](#text-to-speech) - Greet the user with text-to-speech upon answer
 - [Request user input via IVR](#request-user-input) - Create a text-to-speech prompt followed by requesting user input via IVR
@@ -37,7 +37,7 @@ If you're developing behind a firewall or a NAT, use [ngrok](https://ngrok.com/)
 
 A Nexmo application contains the security and configuration information you need to connect to Nexmo endpoints and easily use our products. You make calls to a Nexmo product using the security information in the application. When you make a Call, Nexmo communicates with your webhook endpoints so you can manage your call.
 
-You use Nexmo CLI to create an application for Voice API:
+You can use Nexmo CLI to create an application for Voice API:
 
 ```bash
 nexmo app:create phone-menu https://example.com/answer https://example.com/event
@@ -54,7 +54,7 @@ The parameters are:
 
 ## Buy a phone number
 
-You use Nexmo numbers to handle inbound calls to the IVR.
+To handle inbound calls to the IVR, you need to buy a number from Nexmo.
 
 Use the [Nexmo CLI](https://github.com/nexmo/nexmo-cli) to buy the phone numbers:
 
@@ -133,7 +133,7 @@ public function __construct($config)
 
 ## Generate NCCOs
 
-A Nexmo Call Control Object (NCCO) is a JSON array that you use to control the flow of a Voice API call. Nexmo expects your webhook to return an NCCO to control the Call.
+A Nexmo Call Control Object (NCCO) is a JSON array that is used to control the flow of a Voice API call. Nexmo expects your webhook to return an NCCO to control the Call.
 
 To manage NCCOs this tutorial uses array manipulation and a few simple methods.
 

--- a/_tutorials/private-sms-communication.md
+++ b/_tutorials/private-sms-communication.md
@@ -18,7 +18,7 @@ This tutorial is based on the [Private SMS Communication](https://www.nexmo.com/
 
 In this tutorial you see how to build an SMS proxy for private communication system using Nexmo APIs and libraries:
 
-* [Provision virtual numbers](#provision-virtual-numbers) - rent and configure the virtual numbers you use to mask real numbers
+* [Provision virtual numbers](#provision-virtual-numbers) - rent and configure the virtual numbers used to mask real numbers
 * [Initiate private SMS communication](#initiate-private-sms-communication) - setup the conversation between two numbers
 * [Validate numbers](#validate-numbers) - validate the numbers for two users and determine their country using Number Insight
 * [Send a confirmation SMS](#send-a-confirmation-sms) - send an SMS to each user so they can interact securely using the provisioned virtual numbers
@@ -46,9 +46,9 @@ Now the basic server is in place you can focus on the SMS Proxy logic.
 
 ## Provision Virtual Numbers
 
-You use virtual numbers to hide real phone numbers from your application users.
+Virtual numbers are used to hide real phone numbers from your application users.
 
-The workflow to provision and configure a virtual number is:
+The workflow diagram below shows the process for provisioning and configuring a virtual number.
 
 ```js_sequence_diagram
 Participant App

--- a/_tutorials/private-voice-communication.md
+++ b/_tutorials/private-voice-communication.md
@@ -17,7 +17,7 @@ This tutorial is based on the [Private Voice Communication](https://www.nexmo.co
 You see how to build an Voice proxy for private communication system using [Nexmo CLI](https://github.com/nexmo/nexmo-cli) and [Nexmo Node.JS](https://github.com/Nexmo/nexmo-node)
 
 * [Create a Voice application](#create-a-voice-application) - create and configure an application using [Nexmo CLI](https://github.com/nexmo/nexmo-cli), then configure the webhook endpoints to provide NCCOs and handle changes in Call status
-* [Provision virtual numbers](#provision-virtual-voice-numbers) - rent and configure the voice enabled virtual numbers you use to mask real numbers
+* [Provision virtual numbers](#provision-virtual-voice-numbers) - rent and configure the voice enabled virtual numbers to mask real numbers
 * [Create a Call](#create-a-call) - create a Call between two users, validate their phone numbers and determine the country the phone number is registered in using Number Insight
 * [Handle inbound calls](#handle-inbound-calls) - configure your webhook endpoint to handle incoming voice calls, find the phone number it is associated with and return the NCCO to control the Call
 * [Proxy the Call](#proxy-the-call) - instruct Nexmo to make a private Call to a phone number
@@ -71,9 +71,9 @@ If you're developing behind a firewall or a NAT, use [ngrok](https://ngrok.com/)
 
 ## Provision virtual numbers
 
-You use virtual numbers to hide real phone numbers from your application users.
+Virtual numbers are used to hide real phone numbers from your application users.
 
-The workflow to provision and configure a virtual number is:
+The workflow diagram below shows the process for provisioning and configuring a virtual number.
 
 ```js_sequence_diagram
 Participant App

--- a/_tutorials/validate-a-number.md
+++ b/_tutorials/validate-a-number.md
@@ -112,7 +112,7 @@ Requests to the Number Insight Basic API are free. See the [API reference](/api/
 
 ## Calculate the cost
 
-You use a phone number in international format to find out more about the products supplied by Nexmo for that phone number.
+Using a phone number in international format, you can use the [Number Insight](/api/number-insight) and [Pricing](/api/developer/pricing) APIs find out what you can do with the number.
 
 To make a request to the Developer API and retrieve the cost of making a voice call or sending an SMS:
 


### PR DESCRIPTION
Herein: a flotilla of little copyedits and improvements to the documentation to reduce our reliance on the uncomfortably emphatic and overbearing phrase "You use". There are a few occasions where it is okay, but mostly it detracts from the reading experience.

This PR reduces the number of instances of "you use" from about 147 to 118. Still plenty more to clean up.