### PR TITLE
Removing redundant Tutorial links from overview

### DIFF
--- a/_documentation/messaging/sms/overview.md
+++ b/_documentation/messaging/sms/overview.md
@@ -14,13 +14,13 @@ With low latency and high deliverability, our SMS API is the most reliable way t
 
 ## Contents
 
-In this document you can learn about:
+In this section you can learn about:
 
 * [Nexmo SMS API Concepts](#concepts)
 * [How to Get Started with the SMS API](#getting-started)
 * [SMS API Features](#sms-api-features)
 * [References](#references)
-* [Tutorials](#tutorials)
+* [Tutorials](/messaging/sms/tutorials)
 
 ## Concepts
 
@@ -50,12 +50,3 @@ source: '/_examples/messaging/sending-an-sms/basic'
 ## References
 
 * [SMS API Reference](/api/sms)
-
-## Tutorials
-
-* [Passwordless authentication](/tutorials/passwordless-authentication)
-* [Two-factor authentication](/tutorials/two-factor-authentication)
-* [Private SMS communication](/tutorials/private-sms-communication)
-* [Mobile app invites](/tutorials/mobile-app-invites)
-* [Two-way SMS for customer engagement](/tutorials/two-way-sms-for-customer-engagement)
-* [SMS Customer Support](/tutorials/sms-customer-support)

--- a/_documentation/voice/voice-api/overview.md
+++ b/_documentation/voice/voice-api/overview.md
@@ -15,13 +15,13 @@ The Nexmo Voice API is the easiest way to build high-quality voice applications 
 
 ## Contents
 
-In this document you can learn about:
+In this section you can learn about:
 
 * [Nexmo Voice API Concepts](#concepts)
 * [How to Get Started with the Voice API](#getting-started)
 * [Voice API Features](#voice-api-features)
 * [References](#references)
-* [Tutorials](#tutorials)
+* [Tutorials](/voice/voice-api/tutorials)
 
 ## Concepts
 
@@ -116,9 +116,3 @@ Send Dual-tone multi-frequency (DTMF) to a call | | [`PUT calls/{uuid}/dtmf`](/a
 
 * [Voice API Reference](/api/voice)
 * [NCCO Reference](/voice/guides/ncco-reference)
-
-## Tutorials
-
-* [Private voice communication](/tutorials/private-voice-communication)
-* [Call tracking](/tutorials/call-tracking)
-* [Interactive voice response](/tutorials/interactive-voice-response)


### PR DESCRIPTION
There are Tutorial sections in the overviews for SMS and Voice API but not for Verify or NI. We should have them on all (preferably auto-generated) or none.

Fixes DOCS-298.