### PR TITLE
"Developer APIs" → "Developer API"

### DIFF
--- a/app/views/api/index.html.erb
+++ b/app/views/api/index.html.erb
@@ -123,9 +123,9 @@
     </div>
 
     <div class="card card--with-icon card--invisible card--developer">
-      <h2 id="developer-apis">
+      <h2 id="developer-api">
         <a href="#" class="unstyled spacious">
-          Developer APIs
+          Developer API
         </a>
       </h2>
 

--- a/app/views/layouts/partials/_footer.html.erb
+++ b/app/views/layouts/partials/_footer.html.erb
@@ -15,7 +15,7 @@
       <a href="/api/voice">Voice</a>
       <a href="/api/verify">Verify</a>
       <a href="/api/number-insight">Number Insight</a>
-      <a href="/api#developer-apis">Developer APIs</a>
+      <a href="/api#developer-api">Developer API</a>
       <a href="/api#global-apis">Global APIs</a>
     </div>
 

--- a/app/views/static/_products.html.erb
+++ b/app/views/static/_products.html.erb
@@ -120,7 +120,7 @@
     <div class="landing-filler">
       <div>
 
-        <h3>Developer APIs</h3>
+        <h3>Developer API</h3>
         <a href="/api/developer/account">Account</a> |
         <a href="/api/developer/messages">Messages</a> |
         <a href="/api/developer/numbers">Numbers</a>


### PR DESCRIPTION
Fixes DOCS-297. Company style is not to pluralise "Developer APIs".