### PR TITLE
Added ISO8601 Timestamp for WTD

### DIFF
--- a/app/views/static/write-the-docs.md
+++ b/app/views/static/write-the-docs.md
@@ -171,6 +171,7 @@ API Secret | `$API_SECRET` | `API_SECRET`
 From Number | `FROM_NUMBER` | -
 To Number | `TO_NUMBER` | -
 Timestamp | `2020-01-01 12:00:00` | -
+ISO8601 Timestamp | `2020-01-01T12:00:00.000Z` | -
 Epoch | `1577880000` | -
 HTTP Method | ``[GET]`` or ``[POST]`` | [GET] or [POST]
 HTTP Response | `` `200 OK` `` or §§ `` `404 Not Found` `` | `200 OK` or §§ `404 Not Found`


### PR DESCRIPTION
## Description

Currently there is no member for an ISO8601 Timestamp in the WTD, even though JWT process produces a timestamp formatted according to ISO8601.  Accordingly, I propose this PR.
