### PR TITLE
update e.164 link to a valid website.

### DIFF
--- a/_api/number-insight.md
+++ b/_api/number-insight.md
@@ -34,7 +34,7 @@ The following table shows extra parameters you can use in the request:
 
 Parameter | Description | Required
 -- | -- | --
-`country` | If a number does not have a country code or is uncertain, set the two-character country code. This code must be in ISO 3166-1 alpha-2 format and in upper case. For example, GB or US. If you set country and number is already in E.164 format, country must match the country code in number.| ❎
+`country` | If a number does not have a country code or is uncertain, set the two-character country code. This code must be in ISO 3166-1 alpha-2 format and in upper case. For example, GB or US. If you set country and number is already in [E.164](https://en.wikipedia.org/wiki/E.164) format, country must match the country code in number.| ❎
 `cnam` | Indicates if the name of the person who owns the phone number should be looked up and returned in the response. Set to true to receive phone number owner name in the response. This features is available for US numbers only and incurs an additional charge. Default value is false. | ❎
 `ip` | The IP address of the user. If supplied, we will compare this to the country the user's phone is located in and return an error if it does not match. | ❎
 

--- a/_api/verify.md
+++ b/_api/verify.md
@@ -35,7 +35,7 @@ The following table shows the parameters you use in the request:
 Parameter | Description | Required
 -- | -- | --
 `format` | The response format. Either `json` or `xml` | Yes
-`number` | The mobile or landline phone number to verify. Unless you are setting `country` explicitly, this number must be in [E.164](https://www.itu.int/rec/T-REC-E.164/en) format. For example, `447700900000`. | Yes
+`number` | The mobile or landline phone number to verify. Unless you are setting `country` explicitly, this number must be in [E.164](https://en.wikipedia.org/wiki/E.164) format. For example, `447700900000`. | Yes
 `country` | If do not set *number* in international format or you are not sure if *number* is correctly formatted, set `country` with the two-character country code. For example, *GB*, *US*. Verify works out the international phone number for you. | No
 `brand` | The name of the company or App you are using Verify for.  This 18 character alphanumeric string is used in the body of Verify message. For example: "Your *brand* PIN is ..". |  Yes
 `sender_id` | An 11 character alphanumeric string to specify the SenderID for SMS sent by Verify. Depending on the destination of the phone number you are applying, restrictions may apply. By default, `sender_id` is VERIFY.   |  No

--- a/_api/verify.md
+++ b/_api/verify.md
@@ -35,7 +35,7 @@ The following table shows the parameters you use in the request:
 Parameter | Description | Required
 -- | -- | --
 `format` | The response format. Either `json` or `xml` | Yes
-`number` | The mobile or landline phone number to verify. Unless you are setting `country` explicitly, this number must be in [E.164](http://www.e164.org/) format. For example, `447700900000`. | Yes
+`number` | The mobile or landline phone number to verify. Unless you are setting `country` explicitly, this number must be in [E.164](https://www.itu.int/rec/T-REC-E.164/en) format. For example, `447700900000`. | Yes
 `country` | If do not set *number* in international format or you are not sure if *number* is correctly formatted, set `country` with the two-character country code. For example, *GB*, *US*. Verify works out the international phone number for you. | No
 `brand` | The name of the company or App you are using Verify for.  This 18 character alphanumeric string is used in the body of Verify message. For example: "Your *brand* PIN is ..". |  Yes
 `sender_id` | An 11 character alphanumeric string to specify the SenderID for SMS sent by Verify. Depending on the destination of the phone number you are applying, restrictions may apply. By default, `sender_id` is VERIFY.   |  No

--- a/_api/voice/ncco.md
+++ b/_api/voice/ncco.md
@@ -127,7 +127,7 @@ You can use the following options to control a `connect` action:
 Option | Description | Required
 -- | -- | --
 `endpoint` | Connect to a single endpoint. @[Possible Types](/_modals/voice/guides/ncco-reference/endpoint.md) | Yes
-`from` | A number in e.164 format that identifies the caller.§§ This must be one of your Nexmo virtual numbers, another value will result in the caller ID being unknown. | No
+`from` | A number in [E.164](https://en.wikipedia.org/wiki/E.164) format that identifies the caller.§§ This must be one of your Nexmo virtual numbers, another value will result in the caller ID being unknown. | No
 `eventType` | Set to `synchronous` to: <ul markdown="1"><li>make the `connect` action synchronous</li><li>enable `eventUrl` to return an NCCO that overrides the current NCCO when a call moves to specific states. See the [Connect with fallback NCCO example](#connect_fallback).</li></ul> | No
 `timeout` |  If the call is unanswered, set the number in seconds before Nexmo stops ringing `endpoint`. The default value is `60`.
 `limit` | Maximum length of the call in seconds. The default and maximum value is `7200` seconds (2 hours). | No

--- a/_documentation/voice/sip/overview.md
+++ b/_documentation/voice/sip/overview.md
@@ -44,7 +44,7 @@ For example, the phone number 331908817135 is made up of:
 
 **Caller ID**
 
-Set the Caller Line Identity (CLI) in the *From* header using E.164. For example: `From: <sip:447937947990@sip.nexmo.com>`.
+Set the Caller Line Identity (CLI) in the *From* header using [E.164](https://en.wikipedia.org/wiki/E.164). For example: `From: <sip:447937947990@sip.nexmo.com>`.
 
 **Codecs**
 

--- a/_modals/api/number-insight/response/carrier.md
+++ b/_modals/api/number-insight/response/carrier.md
@@ -1,6 +1,6 @@
 Key | Value
 -- | --
-network_code | The [https://en.wikipedia.org/wiki/Mobile_country_code](https://en.wikipedia.org/wiki/Mobile_country_code) for the carrier`number` is associated with. Unreal numbers are marked as`unknown` and the request is rejected altogether if the number is impossible according to the E.164 guidelines.
+network_code | The [https://en.wikipedia.org/wiki/Mobile_country_code](https://en.wikipedia.org/wiki/Mobile_country_code) for the carrier`number` is associated with. Unreal numbers are marked as`unknown` and the request is rejected altogether if the number is impossible according to the [E.164](https://en.wikipedia.org/wiki/E.164) guidelines.
 name | The full name of the carrier that `number` is associated with.
 country | The country that `number` is associated with. This is in ISO 3166-1 alpha-2 format.
 network_type | The type of network that `number` is associated with. Possible values are: `mobile`, `landline`, `landline_premium`, `landline_tollfree`, `virtual`, `unknown` & `pager`

--- a/_modals/voice/api/calls/machine_detection.md
+++ b/_modals/voice/api/calls/machine_detection.md
@@ -1,6 +1,6 @@
 # `machine_detection` values
 
-## Phone - phone numbers in e.164 format
+## Phone - phone numbers in E.164 format
 
 Value | Description
 -- | --

--- a/_modals/voice/guides/handle-call-status/to.md
+++ b/_modals/voice/guides/handle-call-status/to.md
@@ -1,8 +1,8 @@
 # `to` Values
 
-`phone` - phone numbers in e.164 format. Options are:
+`phone` - phone numbers in [E.164](https://en.wikipedia.org/wiki/E.164) format. Options are:
 
 Value | Description
 -- | --
-`number` | The phone number to connect to in [E.164 format](https://en.wikipedia.org/wiki/E.164).
+`number` | The phone number to connect to in [E.164](https://en.wikipedia.org/wiki/E.164) format.
 `dtmfAnswer` | Set the digits that are sent to the user as soon as the call is answered. The ``&#42;`` and ``&#35;` digits are respected. You create pauses using p. Each pause is 500ms.

--- a/_modals/voice/guides/ncco-reference/endpoint.md
+++ b/_modals/voice/guides/ncco-reference/endpoint.md
@@ -4,7 +4,7 @@
 
 Value | Description
 -- | --
-`number` | the phone number to connect to in E.164 format.
+`number` | the phone number to connect to in [E.164](https://en.wikipedia.org/wiki/E.164) format.
 `dtmfAnswer` | Set the digits that are sent to the user as soon as the Call is answered. The * and # digits are respected. You create pauses using p. Each pause is 500ms.
 
 ### Websocket - the websocket to connect to

--- a/_tutorials/mobile-app-invites.md
+++ b/_tutorials/mobile-app-invites.md
@@ -163,7 +163,7 @@ get '/download' do
 end
 ```
 
-The form captures the phone number in the <https://en.wikipedia.org/wiki/E.164> format expected by SMS API:
+The form captures the phone number in the [E.164](https://en.wikipedia.org/wiki/E.164) format expected by SMS API:
 
 **views/download.erb**
 

--- a/_tutorials/passwordless-authentication.md
+++ b/_tutorials/passwordless-authentication.md
@@ -94,7 +94,7 @@ get '/login' do
 end
 ```
 
-The form accepts the user's phone number in E.164 format.
+The form accepts the user's phone number in [E.164](https://en.wikipedia.org/wiki/E.164) format.
 
 ```html
 <form action="/start_login" method="post">

--- a/_tutorials/two-factor-authentication.md
+++ b/_tutorials/two-factor-authentication.md
@@ -102,7 +102,7 @@ end
   </div>
 ```
 
-This form captures the phone number in E.164 format expected by Voice API. For example, *447700900000*.
+This form captures the phone number in [E.164](https://en.wikipedia.org/wiki/E.164) format expected by Voice API. For example, *447700900000*.
 
 Let a user log in and out with their details:
 

--- a/_tutorials/two-way-sms-for-customer-engagement.md
+++ b/_tutorials/two-way-sms-for-customer-engagement.md
@@ -118,7 +118,7 @@ Add an HTML form to collect the phone number you will send a notification SMS to
 </form>
 ```
 
-The form captures the phone number in the https://en.wikipedia.org/wiki/E.164 format expected by SMS API:
+The form captures the phone number in the [E.164](https://en.wikipedia.org/wiki/E.164) format expected by SMS API:
 
 ## Send an SMS notification
 


### PR DESCRIPTION
e164.org is not a valid website that provides any information on the e.164 number plan. The website I have linked to provides extensive technical documentation on the standard. However, it may be a better choice to just link to wikipedia on e.164.
