### PR TITLE
Consistent wording for request methods

### DIFF
--- a/_api/voice.md
+++ b/_api/voice.md
@@ -52,7 +52,7 @@ Parameter | Description | Required
 `to` | The single or mixed collection of endpoint types you connected to. @[Possible values](/_modals/voice/guides/ncco-reference/endpoint.md). | ✅
 `from` | The endpoint you are calling from. Possible value are the same as *to*. | ✅
 `answer_url` | The webhook endpoint where you provide the Nexmo Call Control Object that governs this call. As soon as your user answers a call, Platform requests this NCCO from `answer_url`. Use `answer_method` to manage the HTTP method. | ✅
-`answer_method` | A [GET] request. | ❎
+`answer_method` | The HTTP method used to send event information to `answer_url`. The default value is [GET]. | ❎
 `event_url` | Platform sends event information asynchronously to this endpoint when status changes. For more information about the values sent, see callback. | ❎ 
 `event_method` | 	The HTTP method used to send event information to `event_url`. The default value is [POST]. | ❎
 `machine_detection` | Configure the behavior when Nexmo detects that a destination is an answerphone. @[Possible values](/_modals/voice/api/calls/machine_detection.md). | ❎


### PR DESCRIPTION
## Description

Update the wording of `answer_method` to match the more descriptive `event_method`.

⚠️ I'm not 100% if `answer_method` does default to GET or not.

## Deploy Notes

N/A