### PR TITLE
Update Python.md

### DIFF
--- a/_examples/voice/guides/call-a-websocket/echo-server/Python.md
+++ b/_examples/voice/guides/call-a-websocket/echo-server/Python.md
@@ -36,7 +36,7 @@ class NCCOHandler(tornado.web.RequestHandler):
         with open("ncco.json", 'r') as f:
             ncco = f.read()
         self.write(ncco)
-        self.set_header("Content-Type", 'text/json')
+        self.set_header("Content-Type", 'application/json')
         self.finish()
 
 application = tornado.web.Application([(r'/socket', WSHandler),


### PR DESCRIPTION
Corrected the content type header when returning the NCCO as `text\json` fails on VAPI

## Description

Please describe what the changes are made in this pull request and why the change was necessary.

## Deploy Notes

Notes regarding deployment the contained body of work. These should note any db migrations, etc.
