### PR TITLE
Tweak/not found reporting

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -102,6 +102,9 @@ gem 'devise', '4.3.0'
 # Simple wrapper for the GitHub API
 gem 'octokit'
 
+# Cross-language UserAgent classifier library, ruby implementation
+gem 'woothee'
+
 group :development, :test do
   gem 'awesome_print'
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -387,6 +387,7 @@ GEM
     websocket-driver (0.6.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.2)
+    woothee (1.7.0)
 
 PLATFORMS
   ruby
@@ -440,6 +441,7 @@ DEPENDENCIES
   uglifier (>= 1.3.0)
   web-console (>= 3.3.0)
   webpacker!
+  woothee
 
 RUBY VERSION
    ruby 2.4.1p111

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -17,13 +17,7 @@ class ApplicationController < ActionController::Base
     if redirect
       redirect_to redirect
     else
-      Bugsnag.notify('404 - Not Found') do |notification|
-        notification.add_tab(:request, {
-          params: request.params,
-          path: request.path,
-          base_url: request.base_url,
-        })
-      end
+      NotFoundNotifier.notify(request)
       render 'static/404', status: :not_found, formats: [:html]
     end
   end

--- a/app/services/not_found_notifier.rb
+++ b/app/services/not_found_notifier.rb
@@ -1,0 +1,25 @@
+IGNORED_FORMATS = %w(php action swf)
+
+class NotFoundNotifier
+  def self.notify(request)
+    return if ignored_format?(request.params['format'])
+    return if crawler?(request.user_agent)
+
+    Bugsnag.notify('404 - Not Found') do |notification|
+      notification.add_tab(:request, {
+        params: request.params,
+        path: request.path,
+        base_url: request.base_url,
+      })
+    end
+  end
+
+  def self.ignored_format?(format)
+    return false unless format
+    IGNORED_FORMATS.include? format.downcase
+  end
+
+  def self.crawler?(user_agent)
+    Woothee.parse(user_agent)[:category] == :crawler
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,7 +7,14 @@ Rails.application.routes.draw do
     resources :feedbacks
   end
 
+  get '/robots.txt', to: 'static#robots'
+
   get 'markdown/show'
+
+  get '/signout', to: 'sessions#destroy'
+
+  post '/jobs/code_example_push', to: 'jobs#code_example_push'
+  post '/jobs/open_pull_request', to: 'jobs#open_pull_request'
 
   get '/tutorials', to: 'tutorials#index'
   get '/tutorials/*document(/:code_language)', to: 'tutorials#show', constraints: DocumentationConstraint.code_language
@@ -43,13 +50,6 @@ Rails.application.routes.draw do
   end
 
   get '/:product/*document(/:code_language)', to: 'markdown#show', constraints: DocumentationConstraint.documentation
-
-  get '/robots.txt', to: 'static#robots'
-
-  get '/signout', to: 'sessions#destroy'
-
-  post '/jobs/code_example_push', to: 'jobs#code_example_push'
-  post '/jobs/open_pull_request', to: 'jobs#open_pull_request'
 
   get '*unmatched_route', to: 'application#not_found'
 

--- a/spec/services/not_found_notifier_spec.rb
+++ b/spec/services/not_found_notifier_spec.rb
@@ -1,0 +1,28 @@
+require 'rails_helper'
+
+RSpec.describe NotFoundNotifier do
+  context '#crawler?' do
+    it 'reports if a user agent is a crawler' do
+      crawler = 'Mozilla/5.0 (compatible; YandexBot/3.0; +http://yandex.com/bots)'
+      user = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/62.0.3202.94 Safari/537.36'
+
+      expect(NotFoundNotifier.crawler?(crawler)).to eq(true)
+      expect(NotFoundNotifier.crawler?(user)).to eq(false)
+    end
+  end
+
+  context '#ignored_format?' do
+    it 'returns true for nil' do
+      expect(NotFoundNotifier.ignored_format?(nil)).to eq(false)
+    end
+
+    it 'returns true for php' do
+      expect(NotFoundNotifier.ignored_format?('PHP')).to eq(true)
+      expect(NotFoundNotifier.ignored_format?('php')).to eq(true)
+    end
+
+    it 'returns false for an unmatched value' do
+      expect(NotFoundNotifier.ignored_format?('foobar')).to eq(false)
+    end
+  end
+end


### PR DESCRIPTION
## Description

Implementation to reduce the amount of false positive not found notifications to Bugsnag.

This change prevents known crawlers from triggering reports as well as known bad actors such as when as attempts to access `/wp-login.php` and `swf` vulnerabilities.

## Deploy Notes

None