### PR TITLE
Dates on the events page shouldn't be zero-padded.

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -12,8 +12,8 @@ class Event < ApplicationRecord
   validates :url, presence: true
 
   def date_range
-    starts = starts_at.strftime('%d %B %Y')
-    ends = ends_at.strftime('%d %B %Y')
+    starts = starts_at.strftime('%-d %B %Y')
+    ends = ends_at.strftime('%-d %B %Y')
     return starts if starts_at == ends_at
     "#{starts} - #{ends}"
   end


### PR DESCRIPTION
"04 December 2017" reads very strangely compared to "4 December 2017"