### PR TITLE
Add SSML audio examples

### DIFF
--- a/_documentation/voice/voice-api/guides/ssml.md
+++ b/_documentation/voice/voice-api/guides/ssml.md
@@ -19,6 +19,10 @@ An example of how the SSML strings are stored inside an NCCO is provided below:
 ]
 ```
 
+#### Example
+
+🔈[https://developer.nexmo.com.s3.amazonaws.com/assets/ssml/01-hola.mp3]
+
 ### Language
 
 The `lang` tag allows you to control the language used in the speech. The language tag should contain both the language tag and country code (e.g. `pt-BR` for Brazilian Portuguese, `en-GB` for British English), even for languages with no country variations where a country code might otherwise be redundant (e.g. `it-IT` for Italian).
@@ -27,6 +31,10 @@ The `lang` tag allows you to control the language used in the speech. The langua
 <speak><lang xml:lang='it-IT'>Buongiorno</lang></speak>
 ```
 
+#### Example
+
+🔈[https://developer.nexmo.com.s3.amazonaws.com/assets/ssml/02-langage.mp3]
+
 ### Breaks
 
 The `break` tag allows you to add pauses to text. The duration of the pause can be specified either using a `strength` duration or as a `time` seconds or milliseconds.
@@ -34,7 +42,13 @@ The `break` tag allows you to add pauses to text. The duration of the pause can 
 ```xml
 <speak>My name is <break time='1s' />Slim Shady.</speak>
 ```
+
+#### Example
+
+🔈[https://developer.nexmo.com.s3.amazonaws.com/assets/ssml/03-breaks-1.mp3]
+
 Valid `strength` values include:
+
 * `none` or `x-weak` (which removes a pause which might otherwise exist after a full stop)
 * `weak` or `medium` (equivalent to a comma)
 * `strong` or `x-strong` (equivalent to a paragraph break)
@@ -47,6 +61,8 @@ that is the question.
 </speak>
 ```
 
+🔈[https://developer.nexmo.com.s3.amazonaws.com/assets/ssml/04-breaks-2.mp3]
+
 ### Paragraphs
 
 The `p` tag allows you to specify paragraphs in your speech.
@@ -57,6 +73,10 @@ The `p` tag allows you to specify paragraphs in your speech.
 <p>How are you?</p>
 </speak>
 ```
+
+#### Example
+
+🔈[https://developer.nexmo.com.s3.amazonaws.com/assets/ssml/05-paragraphs.mp3]
 
 ### Phonemes
 
@@ -69,6 +89,10 @@ The `phoneme` tag allows you to send an International Phonetic Alphabet (IPA) re
 Two nations separated by a common language.
 </speak>
 ```
+
+#### Example
+
+🔈[https://developer.nexmo.com.s3.amazonaws.com/assets/ssml/06-phonemes.mp3]
 
 ### Prosody
 
@@ -90,6 +114,10 @@ and can <prosody pitch='x-low'>change my pitch</prosody>.
 </speak>
 ```
 
+#### Example
+
+🔈[https://developer.nexmo.com.s3.amazonaws.com/assets/ssml/07-prosody.mp3]
+
 ### Sentences
 
 You can wrap sentences in the `s` tag. This is equivalent to putting a full stop at the end of the sentence.
@@ -100,6 +128,10 @@ You can wrap sentences in the `s` tag. This is equivalent to putting a full stop
 <s>But our princess is in another castle</s>
 </speak>
 ```
+
+#### Example
+
+🔈[https://developer.nexmo.com.s3.amazonaws.com/assets/ssml/08-sentences.mp3]
 
 ### Say As
 
@@ -129,6 +161,8 @@ come to <say-as interpret-as="address">123 Main Street</say-as>.
 </speak>
 ```
 
+🔈[https://developer.nexmo.com.s3.amazonaws.com/assets/ssml/09-interpret-as.mp3]
+
 #### Date formatting
 
 Dates can be formatted in the following ways:
@@ -153,6 +187,10 @@ Today is <say-as interpret-as="date" format="dm">10/3</say-as>
 </speak>
 ```
 
+#### Example
+
+🔈[https://developer.nexmo.com.s3.amazonaws.com/assets/ssml/09-interpret-as-date.mp3]
+
 ### Substitution
 
 The `sub` tag allows you to provide a substitute pronunciation. The contents of the `alias` attribute will be read instead.
@@ -162,3 +200,7 @@ The `sub` tag allows you to provide a substitute pronunciation. The contents of 
 Welcome to the <sub alias="United States">US</sub>.
 </speak>
 ```
+
+#### Example
+
+🔈[https://developer.nexmo.com.s3.amazonaws.com/assets/ssml/10-alias.mp3]

--- a/_documentation/voice/voice-api/guides/ssml.md
+++ b/_documentation/voice/voice-api/guides/ssml.md
@@ -21,7 +21,7 @@ An example of how the SSML strings are stored inside an NCCO is provided below:
 
 #### Example
 
-🔈[https://developer.nexmo.com.s3.amazonaws.com/assets/ssml/01-hola.mp3]
+🔈[https://nexmo-developer-production.s3.amazonaws.com/assets/ssml/01-hola.mp3]
 
 ### Language
 
@@ -33,7 +33,7 @@ The `lang` tag allows you to control the language used in the speech. The langua
 
 #### Example
 
-🔈[https://developer.nexmo.com.s3.amazonaws.com/assets/ssml/02-langage.mp3]
+🔈[https://nexmo-developer-production.s3.amazonaws.com/assets/ssml/02-langage.mp3]
 
 ### Breaks
 
@@ -45,7 +45,7 @@ The `break` tag allows you to add pauses to text. The duration of the pause can 
 
 #### Example
 
-🔈[https://developer.nexmo.com.s3.amazonaws.com/assets/ssml/03-breaks-1.mp3]
+🔈[https://nexmo-developer-production.s3.amazonaws.com/assets/ssml/03-breaks-1.mp3]
 
 Valid `strength` values include:
 
@@ -61,7 +61,7 @@ that is the question.
 </speak>
 ```
 
-🔈[https://developer.nexmo.com.s3.amazonaws.com/assets/ssml/04-breaks-2.mp3]
+🔈[https://nexmo-developer-production.s3.amazonaws.com/assets/ssml/04-breaks-2.mp3]
 
 ### Paragraphs
 
@@ -76,7 +76,7 @@ The `p` tag allows you to specify paragraphs in your speech.
 
 #### Example
 
-🔈[https://developer.nexmo.com.s3.amazonaws.com/assets/ssml/05-paragraphs.mp3]
+🔈[https://nexmo-developer-production.s3.amazonaws.com/assets/ssml/05-paragraphs.mp3]
 
 ### Phonemes
 
@@ -92,7 +92,7 @@ Two nations separated by a common language.
 
 #### Example
 
-🔈[https://developer.nexmo.com.s3.amazonaws.com/assets/ssml/06-phonemes.mp3]
+🔈[https://nexmo-developer-production.s3.amazonaws.com/assets/ssml/06-phonemes.mp3]
 
 ### Prosody
 
@@ -116,7 +116,7 @@ and can <prosody pitch='x-low'>change my pitch</prosody>.
 
 #### Example
 
-🔈[https://developer.nexmo.com.s3.amazonaws.com/assets/ssml/07-prosody.mp3]
+🔈[https://nexmo-developer-production.s3.amazonaws.com/assets/ssml/07-prosody.mp3]
 
 ### Sentences
 
@@ -131,7 +131,7 @@ You can wrap sentences in the `s` tag. This is equivalent to putting a full stop
 
 #### Example
 
-🔈[https://developer.nexmo.com.s3.amazonaws.com/assets/ssml/08-sentences.mp3]
+🔈[https://nexmo-developer-production.s3.amazonaws.com/assets/ssml/08-sentences.mp3]
 
 ### Say As
 
@@ -161,7 +161,7 @@ come to <say-as interpret-as="address">123 Main Street</say-as>.
 </speak>
 ```
 
-🔈[https://developer.nexmo.com.s3.amazonaws.com/assets/ssml/09-interpret-as.mp3]
+🔈[https://nexmo-developer-production.s3.amazonaws.com/assets/ssml/09-interpret-as.mp3]
 
 #### Date formatting
 
@@ -189,7 +189,7 @@ Today is <say-as interpret-as="date" format="dm">10/3</say-as>
 
 #### Example
 
-🔈[https://developer.nexmo.com.s3.amazonaws.com/assets/ssml/09-interpret-as-date.mp3]
+🔈[https://nexmo-developer-production.s3.amazonaws.com/assets/ssml/09-interpret-as-date.mp3]
 
 ### Substitution
 
@@ -203,4 +203,4 @@ Welcome to the <sub alias="United States">US</sub>.
 
 #### Example
 
-🔈[https://developer.nexmo.com.s3.amazonaws.com/assets/ssml/10-alias.mp3]
+🔈[https://nexmo-developer-production.s3.amazonaws.com/assets/ssml/10-alias.mp3]

--- a/app/filters/audio_filter.rb
+++ b/app/filters/audio_filter.rb
@@ -1,0 +1,13 @@
+class AudioFilter < Banzai::Filter
+  def call(input)
+    input.gsub(/[u{🔈}]\[(.+?)\]/) do
+      audio = <<~HEREDOC
+      <audio controls>
+        <source src="#{$1}" type="audio/mpeg">
+      </audio>
+      HEREDOC
+
+      "FREEZESTART#{Base64.urlsafe_encode64(audio)}FREEZEEND"
+    end
+  end
+end

--- a/app/pipelines/markdown_pipeline.rb
+++ b/app/pipelines/markdown_pipeline.rb
@@ -10,6 +10,7 @@ class MarkdownPipeline < Banzai::Pipeline
       BlockEscapeFilter,
       ScreenshotFilter,
       AnchorFilter,
+      AudioFilter,
       TooltipFilter,
       CollapsibleFilter,
       TabbedExamplesFilter.new(options),

--- a/app/views/contribute/guides/styleguide.md
+++ b/app/views/contribute/guides/styleguide.md
@@ -261,3 +261,15 @@ Here is the example of the final rendered output:
 script: app/screenshots/webhook-url-for-delivery-receipt.js
 image: public/assets/screenshots/da5f952d465355c19eb888fa1049844b31e090c2.png
 ```
+
+## Audio (custom plugin)
+
+The HTML `<audio>` element can be utilised in Markdown with the following syntax:
+
+````
+🔈[https://developer.nexmo.com.s3.amazonaws.com/assets/ssml/06-phonemes.mp3]
+````
+
+This produces the following output:
+
+🔈[https://developer.nexmo.com.s3.amazonaws.com/assets/ssml/06-phonemes.mp3]


### PR DESCRIPTION
## Description

- Adds audio examples for SSML page
- Adds Audio Filter
- Documents Audio Filter in styleguide

![image](https://user-images.githubusercontent.com/1238468/33778992-f996bed0-dc42-11e7-8d05-a6f781428f0e.png)

## Deploy Notes

None