### PR TITLE
Set RAILS_ENV to development when running via Docker

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,8 @@ services:
     environment:
       - POSTGRES_HOST=db
       - POSTGRES_USERNAME=postgres
+      - RAILS_ENV=development
+      - RACK_ENV=development
   clean:
     image: nexmodeveloper_app
     build: .


### PR DESCRIPTION
## Description

* Set RAILS_ENV=development in docker-compose.yml
* Set RACK_ENV=development in docker-compose.yml

This allows `webpacker` to run when developing NDP via docker. Previously it defaulted to the production environment and was expecting precompiled assets