### PR TITLE
Changes collapsible to include icon

### DIFF
--- a/app/assets/stylesheets/objects/_collapsible.scss
+++ b/app/assets/stylesheets/objects/_collapsible.scss
@@ -1,5 +1,6 @@
 .collapsible {
   user-select: none;
+  cursor: pointer;
 
   #primary-content & {
     margin: $spacing 0;

--- a/app/javascript/packs/Collapsible.js
+++ b/app/javascript/packs/Collapsible.js
@@ -1,7 +1,14 @@
 export default () => {
   $(document).on('click', '.js-collapsible', function() {
-    const id = $(this).data('collapsible-id')
-    $(this).parent('.collapsible').toggleClass('collapsible--active')
+    const $element = $(this)
+    const id = $element.data('collapsible-id')
+    
+    if ($element.hasClass('collapsible')) {
+      $element.toggleClass('collapsible--active')
+    } else {
+      $element.parent('.collapsible').toggleClass('collapsible--active')
+    }
+
     $(`#${id}`).toggle()
   })
 }

--- a/app/views/open_api/_endpoint.html.erb
+++ b/app/views/open_api/_endpoint.html.erb
@@ -59,11 +59,10 @@
       <% endpoint.responses.each do |response| %>
         <% id = SecureRandom.hex %>
 
-        <h4 class="collapsible <%= response.success? ? 'collapsible--active' : '' %>">
-          <a class="js-collapsible" data-collapsible-id="<%= id %>">
-            <span class="label label--status--<%= response.code[0] %>xx"><%= response.code %></span> HTTP response
-          </a>
+        <h4 class="js-collapsible collapsible <%= response.success? ? 'collapsible--active' : '' %>" data-collapsible-id="<%= id %>">
+          <span class="label label--status--<%= response.code[0] %>xx"><%= response.code %></span> HTTP response
         </h4>
+        
         <div id="<%= id %>" style="display: <%= response.success? ? 'block' : 'none' %>;">
           <div class="tabs-content" data-tabs-content="<%= id %>">
             <% response.formats.each_with_index do |format, index| %>


### PR DESCRIPTION
## Description

Fixes #544. Previously collapsible items could not be collapsed with the triangle item but rather only by clicking the title. This PR changes this behaviour to be inclusive of the icon.

## Deploy Notes

None