### PR TITLE
Improved Python code style for message signing examples

### DIFF
--- a/_examples/messaging/signing-messages/check-response/Python
+++ b/_examples/messaging/signing-messages/check-response/Python
@@ -1,11 +1,11 @@
 
 import json
 
-#Using the response object from the request
+# Using the response object from the request
 
 if response.code == 200 :
     data = response.read()
-    #Decode JSON response from UTF-8
+    # Decode JSON response from UTF-8
     decoded_response = json.loads(data.decode('utf-8'))
     # Check if your messages are succesful
     messages = decoded_response["messages"]
@@ -13,5 +13,5 @@ if response.code == 200 :
         if message["status"] == "0":
             print "success"
 else :
-    #Check the errors
-    print "unexpected http {code} response from nexmo api". response.code
+    # Check the errors
+    print "Unexpected HTTP {code} response from nexmo api". response.code

--- a/_examples/messaging/signing-messages/create-request/Python
+++ b/_examples/messaging/signing-messages/create-request/Python
@@ -9,7 +9,8 @@ import calendar
 
 base_url = 'https://rest.nexmo.com/sms/json?'
 security_secret = 'SECURITY_SECRET'
-#The timestamps used in the signature are in UTC
+
+# The timestamps used in the signature are in UTC
 d = datetime.utcnow()
 
 params = {
@@ -20,19 +21,20 @@ params = {
     'type': 'text',
     'timestamp': calendar.timegm(d.utctimetuple())
 }
+
 # Sort your parameters
 sortedparams = collections.OrderedDict(sorted(params.items()))
 signing_url = '&' + urllib.unquote_plus(urllib.urlencode(sortedparams)) + security_secret
 
-#Add your md5 hash of your parameters to your parameters
+# Add your md5 hash of your parameters to your parameters
 m = md5.new()
 m.update(signing_url)
 params['sig'] = m.hexdigest()
 
-#Create the request
+# Create the request
 url = base_url + urllib.urlencode(params)
 request = urllib2.Request(url)
 request.add_header('Accept', 'application/json')
 
-#Make the request to Nexmo
+# Make the request to Nexmo
 response = urllib2.urlopen(request)

--- a/_examples/messaging/signing-messages/validate-signature/Python
+++ b/_examples/messaging/signing-messages/validate-signature/Python
@@ -1,5 +1,5 @@
-#To run this code, replace the MyHandler in
-#https://wiki.python.org/moin/BaseHttpServer With the following code,
+# To run this code, replace the MyHandler in
+# https://wiki.python.org/moin/BaseHttpServer With the following code,
 import urllib
 import time
 import BaseHTTPServer
@@ -28,11 +28,11 @@ class MyHandler(BaseHTTPServer.BaseHTTPRequestHandler):
         except:
                 callback = {}
 
-        #Check if the callback is signed
+        # Check if the callback is signed
         if 'sig' in callback:
-            #Message cannot be more than 5 minutes old
-            #The timestamps used in the signature are in UTC
-            #Create a UTC timestamp for now and compare
+            # Message cannot be more than 5 minutes old
+            # The timestamps used in the signature are in UTC
+            # Create a UTC timestamp for now and compare
             d = datetime.utcnow()
             now = calendar.timegm(d.utctimetuple())
             message_timestamp = int( callback['timestamp'])
@@ -41,7 +41,7 @@ class MyHandler(BaseHTTPServer.BaseHTTPRequestHandler):
             if (difference >  max_delta ):
                 print("Timestamp difference greater than 5 minutes")
             else:
-                #Remove the signature from the request parameters
+                # Remove the signature from the request parameters
                 message_signature = callback['sig']
                 del callback['sig']
                 # Sort the parameters into alphabetic order
@@ -50,7 +50,7 @@ class MyHandler(BaseHTTPServer.BaseHTTPRequestHandler):
                 tempstamp = sortedparams['message-timestamp']
                 tempstamp = urllib.unquote_plus(tempstamp).decode('utf8')
                 sortedparams['message-timestamp'] = tempstamp
-                #Generate a signature from the parameters and your security secret
+                # Generate a signature from the parameters and your security secret
                 encoded_params = urllib.urlencode(sortedparams)
                 signing_url = '&' + urllib.unquote_plus(encoded_params).decode('utf8')
                 signing_url += security_secret


### PR DESCRIPTION
## Description

Comment format was not PEP-8 compliant. Improved a few other strings and spacing to make the Python examples more readable.
