### PR TITLE
Admin API > Feedback

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,7 +28,7 @@ gem 'jquery-rails'
 # Turbolinks makes navigating your web application faster. Read more: https://github.com/turbolinks/turbolinks
 gem 'turbolinks', '~> 5'
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
-gem 'jbuilder', '~> 2.5'
+gem 'jbuilder', '~> 2.7.0'
 # Use Redis adapter to run Action Cable in production
 # gem 'redis', '~> 3.0'
 # Use ActiveModel has_secure_password

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -410,7 +410,7 @@ DEPENDENCIES
   guard-livereload (~> 2.5)
   guard-rspec
   icalendar
-  jbuilder (~> 2.5)
+  jbuilder (~> 2.7.0)
   jquery-rails
   listen (~> 3.0.5)
   neatjson

--- a/app/admin/user.rb
+++ b/app/admin/user.rb
@@ -9,6 +9,7 @@ ActiveAdmin.register User do
     column :sign_in_count
     column :created_at
     column :admin
+    column :nexmo_developer_api_secret
     actions
   end
 

--- a/app/controllers/admin_api/feedback_controller.rb
+++ b/app/controllers/admin_api/feedback_controller.rb
@@ -1,0 +1,22 @@
+module AdminApi
+  class FeedbackController < AdminApiController
+    respond_to :json
+
+    def index
+      return unless authenticate
+      @feedbacks = Feedback::Feedback.all
+
+      if params[:created_after] || params[:created_before]
+        if params[:created_after] && params[:created_before]
+          @feedbacks = @feedbacks.created_between(params[:created_after], params[:created_before])
+        elsif params[:created_after]
+          @feedbacks = @feedbacks.created_after(params[:created_after])
+        elsif params[:created_before]
+          @feedbacks = @feedbacks.created_before(params[:created_before])
+        end
+      end
+
+      render :index
+    end
+  end
+end

--- a/app/controllers/admin_api_controller.rb
+++ b/app/controllers/admin_api_controller.rb
@@ -1,0 +1,22 @@
+class AdminApiController < ApplicationController
+  skip_before_action :verify_authenticity_token
+
+  def authenticated?
+    false unless bearer_token
+    User.where(admin: true, nexmo_developer_api_secret: bearer_token).exists?
+  end
+
+  def authenticate
+    return true if authenticated?
+    render plain: 'Unauthorized', status: :unauthorized
+    false
+  end
+
+  private
+
+  def bearer_token
+    pattern = /^Bearer /
+    header  = request.headers['Authorization']
+    header.gsub(pattern, '') if header && header.match(pattern)
+  end
+end

--- a/app/models/feedback/feedback.rb
+++ b/app/models/feedback/feedback.rb
@@ -1,5 +1,8 @@
 module Feedback
   class Feedback < ApplicationRecord
+    scope :created_after, -> (date) { where('created_at >= ?', date )}
+    scope :created_before, -> (date) { where('created_at <= ?', date )}
+    scope :created_between, -> (start_date, end_date) { where('created_at >= ? AND created_at <= ?', start_date, end_date )}
 
     belongs_to :resource, class_name: '::Feedback::Resource'
     belongs_to :owner, polymorphic: true

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,4 +2,13 @@ class User < ApplicationRecord
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable and :omniauthable
   devise :database_authenticatable, :rememberable, :trackable
+
+  before_create :generate_nexmo_developer_api_secret
+
+  def generate_nexmo_developer_api_secret
+    loop do
+      self.nexmo_developer_api_secret = SecureRandom.hex
+      break unless User.exists?(nexmo_developer_api_secret: nexmo_developer_api_secret)
+    end
+  end
 end

--- a/app/views/admin_api/feedback/index.json.jbuilder
+++ b/app/views/admin_api/feedback/index.json.jbuilder
@@ -1,0 +1,3 @@
+json.feedbacks @feedbacks do |feedback|
+  json.(feedback, :id, :sentiment, :resource, :owner, :ip, :comment, :code_language, :code_language_selected_whilst_on_page, :code_language_set_by_url, :created_at, :resolved)
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,10 @@ Rails.application.routes.draw do
     resources :feedbacks
   end
 
+  namespace :admin_api, defaults: {format: 'json'} do
+    resources :feedback, only: [:index]
+  end
+
   get '/robots.txt', to: 'static#robots'
 
   get 'markdown/show'

--- a/db/migrate/20180125163023_add_api_secret_to_users.rb
+++ b/db/migrate/20180125163023_add_api_secret_to_users.rb
@@ -1,0 +1,18 @@
+class AddApiSecretToUsers < ActiveRecord::Migration[5.1]
+  def up
+    add_column :users, :nexmo_developer_api_secret, :string
+
+    User.reset_column_information
+
+    User.all.each do |user|
+      user.generate_nexmo_developer_api_secret
+      user.save!
+    end
+
+    change_column :users, :nexmo_developer_api_secret, :string, null: false
+  end
+
+  def down
+    remove_column :users, :nexmo_developer_api_secret
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171030115603) do
+ActiveRecord::Schema.define(version: 20180125163023) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -21,14 +21,12 @@ ActiveRecord::Schema.define(version: 20171030115603) do
     t.string "namespace"
     t.text "body"
     t.string "resource_type"
-    t.bigint "resource_id"
+    t.uuid "resource_id"
     t.string "author_type"
-    t.bigint "author_id"
+    t.uuid "author_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["author_type", "author_id"], name: "index_active_admin_comments_on_author_type_and_author_id"
     t.index ["namespace"], name: "index_active_admin_comments_on_namespace"
-    t.index ["resource_type", "resource_id"], name: "index_active_admin_comments_on_resource_type_and_resource_id"
   end
 
   create_table "events", id: :uuid, default: -> { "uuid_generate_v4()" }, force: :cascade do |t|
@@ -106,6 +104,7 @@ ActiveRecord::Schema.define(version: 20171030115603) do
     t.datetime "updated_at", null: false
     t.string "api_key"
     t.string "api_secret"
+    t.string "nexmo_developer_api_secret", null: false
     t.index ["admin"], name: "index_users_on_admin"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true


### PR DESCRIPTION
## Description

Adds an Admin API to retrieve feedback.

| Parameter | Description | Example |
| --- | --- | --- |
| `created_after` | Only returns records created on or after the specified timestamp | `2020-01-10T14:00:00` |
| `created_before` | Only returns records created on or before the specified timestamp | `2020-01-10T14:00:00` |

These two parameters can be used together to get records between a datetime range.

Usage example:

```
curl https://developer.nexmo.com/admin_api/feedback \
-H "Authorization: Bearer YOUR_PERSONAL_NEXMO_DEVELOPER_API_SECRET"
```

> Note: API Secret can be retrieved from `/admin`

## Deploy Notes

- [x] Check on staging
- [ ] Migration required
