### PR TITLE
Fix community grid

### DIFF
--- a/app/assets/stylesheets/layout/_community.scss
+++ b/app/assets/stylesheets/layout/_community.scss
@@ -2,3 +2,19 @@
   vertical-align: middle;
   margin-right: 10px;
 }
+
+#community-events {
+  display: flex;
+  flex-wrap: wrap;
+  margin-bottom: $spacing;
+
+  > div {
+    flex: 1;
+    min-width: 350px;
+    padding: $spacing/2;
+
+    @include mobile() {
+      min-width: 280px;
+    }
+  }
+}

--- a/app/views/static/_event.html.erb
+++ b/app/views/static/_event.html.erb
@@ -1,4 +1,4 @@
-<div class="columns small-12 medium-6 large-4 <%= 'end' if last %>">
+<div>
   <br>
   <h2><%= link_to event.title, event.url, target: '_blank' %></h2>
   <p><b><%= event.date_range %></b></p>

--- a/app/views/static/community.html.erb
+++ b/app/views/static/community.html.erb
@@ -29,9 +29,9 @@
 
 <br>
 
-<div class="row">
-  <h2 class="center">You can find us at these upcoming events:</h2>
+<h2 class="center">You can find us at these upcoming events:</h2>
 
+<div id="community-events">
   <% @upcoming_events.each_with_position do |event, first, last| %>
     <%= render 'event', event: event, first: first, last: last %>
   <% end %>


### PR DESCRIPTION
## Description

Improves grid layout for events when the descriptions are different lengths. Floated elements will now be vertically aligned with each other.

## Deploy Notes

None