### PR TITLE
Clarified that invalid_parameters is optional

### DIFF
--- a/_api/voice.md
+++ b/_api/voice.md
@@ -632,3 +632,5 @@ The error format is standardized to the `4xx`/`5xx` range with a code and a huma
   }
 }
 ```
+
+The `invalid_parameters` property is optional and will not be returned for `401 Unauthorized` errors.


### PR DESCRIPTION
Fixes DOCS-263 until we move VAPI to OAS3.