### PR TITLE
Updated Ruby SMS send example to line up with current gem docs

### DIFF
--- a/_examples/messaging/sending-an-sms/basic/Ruby
+++ b/_examples/messaging/sending-an-sms/basic/Ruby
@@ -1,12 +1,12 @@
 require 'nexmo'
 
-client = Nexmo::Client.new({
-  key: 'API_KEY',
-  secret: 'API_SECRET'
-})
+client = Nexmo::Client.new(
+  api_key: 'API_KEY',
+  api_secret: 'API_SECRET'
+)
 
-client.send_message({
+client.sms.send(
   from: 'Nexmo',
   to: 'TO_NUMBER',
   text: 'A text message sent using the Nexmo SMS API',
-})
+)


### PR DESCRIPTION
## Description

Current Ruby example does not use current naming conventions & doesn't line up with the gem docs.

## Deploy Notes

N/A - Documentation update
