### PR TITLE
Add UI tweaks

### DIFF
--- a/app/admin/career.rb
+++ b/app/admin/career.rb
@@ -8,7 +8,7 @@ ActiveAdmin.register Career do
   # See permitted parameters documentation:
   # https://github.com/activeadmin/activeadmin/blob/master/docs/2-resource-customization.md#setting-up-strong-parameters
   #
-  permit_params :title, :summary, :published, :location, :description, :description_short, :url, :icon
+  permit_params :title, :summary, :published, :location, :description, :description_short, :url, :icon, :role_group
   #
   # or
   #
@@ -27,6 +27,7 @@ ActiveAdmin.register Career do
     column :description_short
     column :url
     column :icon
+    column :role_group
     actions
   end
 
@@ -40,6 +41,7 @@ ActiveAdmin.register Career do
       input :description_short
       input :url
       input :icon
+      input :role_group
     end
     actions
   end

--- a/app/assets/stylesheets/layout/_jobs.scss
+++ b/app/assets/stylesheets/layout/_jobs.scss
@@ -1,13 +1,14 @@
 .jobs {
   column-count: 2;
-  column-gap: $spacing;
+  column-gap: 0;
 
   @include tablet {
     column-count: 1;
   }
 
   &__job {
-    display: inline-block;
-    margin: 0 0 $spacing;
+    break-inside: avoid;
+    padding-left: $spacing / 2;
+    padding-right: $spacing / 2;
   }
 }

--- a/app/views/careers/show.html.erb
+++ b/app/views/careers/show.html.erb
@@ -8,7 +8,7 @@
 </div>
 
 <div class="row">
-  <div class="columns small-12 medium-10 large-8 medium-centered">
+  <div id="primary-content" class="columns small-12 medium-10 large-8 medium-centered">
     <hr><br><br>
     <% if @career.description %>
       <%= @career.description.render_markdown %>

--- a/app/views/static/team.html.erb
+++ b/app/views/static/team.html.erb
@@ -33,19 +33,24 @@
 
   <br>
 
-  <div class="jobs">
-    <% @careers.each do |career| %>
-      <div class="jobs__job box">
-        <h2>
-          <i class="icon icon--large icon-<%= career.icon %>"></i><br><br>
-          <%= career.title %>
-          <br><br><i><small class="subtle"><%= career.location %></small></i>
-        </h2>
-        <div class="left spacious">
-          <%= career.description_short.render_markdown %>
+  <% @careers.group_by(&:role_group).each do |group_name, careers| %>
+    <h2 class="spacious"><%= group_name %></h2>
+    <div class="jobs">
+      <% careers.each do |career| %>
+        <div class="jobs__job">
+          <div class="box box--white">
+            <h2>
+              <i class="icon icon--large icon-<%= career.icon %>"></i><br><br>
+              <%= career.title %>
+              <br><br><i><small class="subtle"><%= career.location %></small></i>
+            </h2>
+            <div class="left spacious">
+              <%= career.description_short.render_markdown %>
+            </div>
+            <%= link_to "Find out more", career, class: 'button' %>
+          </div>
         </div>
-        <%= link_to "Find out more", career, class: 'button' %>
-      </div>
-    <% end %>
-  </div>
+      <% end %>
+    </div>
+  <% end %>
 </div>

--- a/db/migrate/20180308101927_add_role_group_to_careers.rb
+++ b/db/migrate/20180308101927_add_role_group_to_careers.rb
@@ -1,0 +1,6 @@
+class AddRoleGroupToCareers < ActiveRecord::Migration[5.1]
+  def change
+    add_column :careers, :role_group, :string
+    add_index :careers, :role_group
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180306185340) do
+ActiveRecord::Schema.define(version: 20180308101927) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -41,7 +41,9 @@ ActiveRecord::Schema.define(version: 20180306185340) do
     t.string "icon"
     t.string "slug"
     t.text "description_short"
+    t.string "role_group"
     t.index ["published"], name: "index_careers_on_published"
+    t.index ["role_group"], name: "index_careers_on_role_group"
     t.index ["slug"], name: "index_careers_on_slug"
   end
 


### PR DESCRIPTION
## Description

Tweaks to the career listings:

- Group careers by `role_group`.
- Changes `careers#show` page to use body content styling.
- Fixes minor layout issue with masonry cards

![screen shot 2018-03-08 at 10 39 58](https://user-images.githubusercontent.com/1238468/37146971-55a11b4c-22bd-11e8-9090-30e44b511abd.png)

![screen shot 2018-03-08 at 10 38 58](https://user-images.githubusercontent.com/1238468/37146983-5ed211a8-22bd-11e8-8f5a-180032d92d9c.png)

## Deploy Notes

- [ ] Migration (auto-run)