### PR TITLE
Python code samples: switch to use requests

### DIFF
--- a/_examples/api/application/create-an-application/Python
+++ b/_examples/api/application/create-an-application/Python
@@ -1,13 +1,7 @@
-import urllib
-import urllib2
-import json
+import requests
 
-base_url = 'https://api.nexmo.com'
-version = '/v1'
-action = '/applications/?'
-
-#Create an Application for Voice API.
-params = {
+url = 'https://api.nexmo.com/v1/applications'
+data = {
         'api_key': 'API_KEY',
         'api_secret': 'API_SECRET',
         'name' : 'MyFirstApplication',
@@ -17,25 +11,19 @@ params = {
 }
 #In this example, answer_url points to a static NCCO that creates a Conference.
 
-url =  base_url + version + action
-data =  urllib.urlencode(params)
-
-request = urllib2.Request(url, data)
-request.add_header('Accept', 'application/json')
+resp = requests.post(url, params=data)
 
 try:
-    response = urllib2.urlopen(request)
-    data = response.read()
-    if response.code == 201:
-        application = json.loads(data.decode('utf-8'))
-        print "Application " + application['name'] + " has an ID of:" + application['id']
-        for webhook in application['voice']['webhooks'] :
+    if resp.status_code == 201:
+        application = resp.json()
+        print "Application " + application['name'] + " has an ID of: " + application['id']
+        for webhook in application['voice']['webhooks']:
                 print "  " + webhook['endpoint_type'] + " is " + webhook['endpoint']
         print "  You use your private key to connect to Nexmo endpoints:"
         print "  " + application['keys']['private_key']
     else:
-        print "HTTP Response: " + response.code
-        print data
+        print "HTTP Response: " + resp.status_code
+        print resp.json()
 
-except urllib2.HTTPError as e:
+except requests.exceptions.HTTPError as e:
     print e

--- a/_examples/api/application/destroy-an-application/Python
+++ b/_examples/api/application/destroy-an-application/Python
@@ -1,27 +1,14 @@
-import urllib
-import urllib2
-import json
+import requests
 
-base_url = 'https://api.nexmo.com'
-version = '/v1'
-action = '/applications '
-params = {
-    'api_key': ‘'API_KEY'’,
-    'api_secret': ‘'API_SECRET'’,
+url = 'https://api.nexmo.com/v1/applications/APPLICATION_ID'
+data = {
+    'api_key': 'API_KEY',
+    'api_secret': 'API_SECRET',
 }
-url =  base_url + version + action + "/APPLICATION_ID?"
 
-data =  urllib.urlencode(params)
-
-request = urllib2.Request(url, data)
-request.add_header('Accept', 'application/json')
-response = urllib2.urlopen(request)
-data = response.read()
-
-if response.code == 200 :
-    print "APPLICATION_ID Deleted"
-
+resp = requests.delete(url, params=data)
+if resp.status_code == 204:
+    print "Your applicaiton was deleted"
 else :
-    error = json.loads(data.decode('utf-8'))
     print "Your request failed because:"
-    print "  " + error['type'] + "  " + error['error_title']
+    print resp.json()

--- a/_examples/api/application/retrieve-an-application/Python
+++ b/_examples/api/application/retrieve-an-application/Python
@@ -1,34 +1,21 @@
-import urllib
-import urllib2
-import json
+import requests
 
-base_url = 'https://api.nexmo.com'
-version = '/v1'
-action = '/applications '
-app_id = '/APPLICATION_ID?'
-
-params = {
+url = 'https://api.nexmo.com/v1/applications/APPLICATION_ID'
+data = {
     'api_key': 'API_KEY',
     'api_secret': 'API_SECRET'
 }
 
-url =  base_url + version + action + app_id + urllib.urlencode(params)
-
-request = urllib2.Request(url)
-request.add_header('Accept', 'application/json')
+resp = requests.get(url, params=data)
 
 try:
-    response = urllib2.urlopen(request)
-    data = response.read()
-    if response.code == 200:
-        application = json.loads(data.decode('utf-8'))
+    if resp.status_code == 200:
+        application = resp.json()
         print "Application " + application['name'] + " has an ID of:" + application['id']
         for webhook in application['voice']['webhooks'] :
             print "  " + webhook['endpoint_type'] + " is " + webhook['endpoint']
     else:
-        error = json.loads(data.decode('utf-8'))
         print "Your request failed because:"
-        print error
-
-except urllib2.HTTPError as e:
+        print resp.json()
+except requests.exceptions.HTTPError as e:
     print e

--- a/_examples/api/application/retrieve-your-applications/Python
+++ b/_examples/api/application/retrieve-your-applications/Python
@@ -1,40 +1,27 @@
-import urllib
-import urllib2
-import json
+import requests
 
-base_url = 'https://api.nexmo.com'
-version = '/v1'
-action = '/applications/?'
-
-params = {
+url = 'https://api.nexmo.com/v1/applications'
+data = {
     'api_key': 'API_KEY',
     'api_secret': 'API_SECRET'
 }
 
-url =  base_url + version + action + urllib.urlencode(params)
-
-request = urllib2.Request(url)
-request.add_header('Accept', 'application/json')
-
+resp = requests.get(url, params=data)
 try:
-    response = urllib2.urlopen(request)
-    data = response.read()
-    if response.code == 200:
-        decoded_response = json.loads(data.decode('utf-8'))
-        print "You have " + str(decoded_response['count']) + " applications"
-        print "Page " + str(decoded_response['page_index']) + \
-            " lists " + str(decoded_response['page_size']) + " applications"
-        print "Use the links to navigate. For example: " + base_url \
-            +  decoded_response['_links']['last']['href']
-        for application in decoded_response['_embedded']['applications'] :
+    if resp.status_code == 200:
+        resp_data = resp.json()
+        print "You have " + str(resp_data['count']) + " applications"
+        print "Page " + str(resp_data['page_index']) + \
+            " lists " + str(resp_data['page_size']) + " applications"
+        print "Use the links to navigate. For example: https://api.nexmo.com" \
+            +  resp_data['_links']['last']['href']
+        for application in resp_data['_embedded']['applications'] :
             print "Application " + application['name'] + \
-                " has an ID of:" + application['id']
+                " has an ID of: " + application['id']
             for webhook in application['voice']['webhooks'] :
                 print "  " + webhook['endpoint_type'] + " is " + webhook['endpoint']
     else:
-        error = json.loads(data.decode('utf-8'))
         print "Your request failed because:"
-        print error
-
-except urllib2.HTTPError as e:
+        print resp.json()
+except requests.exceptions.HTTPError as e:
     print e

--- a/_examples/api/application/update-an-application/Python
+++ b/_examples/api/application/update-an-application/Python
@@ -1,13 +1,9 @@
-import urllib
-import urllib2
-import json
+import requests
 
-base_url = 'https://api.nexmo.com'
-version = '/v1'
-action = '/applications '
-app_id = '/APPLICATION_ID?'
+application_id = 'APPLICATION_ID'
+url = 'https://api.nexmo.com/v1/applications/' + application_id
 
-params = {
+data = {
         'api_key': 'API_KEY',
         'api_secret': 'API_SECRET',
         'name' : 'MyFirstApplication',
@@ -16,23 +12,16 @@ params = {
         'event_url' : 'https://example.com/call_status'
 }
 
-url =  base_url + version + action + app_id + urllib.urlencode(params)
-request = urllib2.Request(url)
-request.add_header('Accept', 'application/json')
-request.get_method = lambda: 'PUT'
-
+resp = requests.put(url, params=data)
 try:
-    response = urllib2.urlopen(request)
-    data = response.read()
-    if response.code == 200:
-        application = json.loads(data.decode('utf-8'))
+    if resp.status_code == 200:
+        application = resp.json()
         print "Application " + application['name'] + " has an ID of:" + application['id']
-        for webhook in application['voice']['webhooks'] :
+        for webhook in application['voice']['webhooks']:
                 print "  " + webhook['endpoint_type'] + " is " + webhook['endpoint']
     else:
-        error = json.loads(data.decode('utf-8'))
         print "Your request failed because:"
-        print error
+        print resp.json()
 
-except urllib2.HTTPError as e:
+except requests.exceptions.HTTPError as e:
     print e

--- a/_examples/concepts/guides/applications/code1/Python
+++ b/_examples/concepts/guides/applications/code1/Python
@@ -1,13 +1,7 @@
-import urllib
-import urllib2
-import json
+import requests
 
-base_url = 'https://api.nexmo.com'
-version = '/v1'
-action = '/applications/?'
-
-#Create an Application for Voice API.
-params = {
+url = 'https://api.nexmo.com/v1/applications'
+data = {
         'api_key': 'API_KEY',
         'api_secret': 'API_SECRET',
         'name' : 'MyFirstApplication',
@@ -17,25 +11,19 @@ params = {
 }
 #In this example, answer_url points to a static NCCO that creates a Conference.
 
-url =  base_url + version + action
-data =  urllib.urlencode(params)
-
-request = urllib2.Request(url, data)
-request.add_header('Accept', 'application/json')
+resp = requests.post(url, params=data)
 
 try:
-    response = urllib2.urlopen(request)
-    data = response.read()
-    if response.code == 201:
-        application = json.loads(data.decode('utf-8'))
-        print "Application " + application['name'] + " has an ID of:" + application['id']
-        for webhook in application['voice']['webhooks'] :
+    if resp.status_code == 201:
+        application = resp.json()
+        print "Application " + application['name'] + " has an ID of: " + application['id']
+        for webhook in application['voice']['webhooks']:
                 print "  " + webhook['endpoint_type'] + " is " + webhook['endpoint']
         print "  You use your private key to connect to Nexmo endpoints:"
         print "  " + application['keys']['private_key']
     else:
-        print "HTTP Response: " + response.code
-        print data
+        print "HTTP Response: " + resp.status_code
+        print resp.json()
 
-except urllib2.HTTPError as e:
+except requests.exceptions.HTTPError as e:
     print e

--- a/_examples/concepts/guides/applications/code2/Python
+++ b/_examples/concepts/guides/applications/code2/Python
@@ -1,15 +1,12 @@
-import urllib
-import urllib2
-import json
+import requests
 
-base_url = 'https://rest.nexmo.com'
-action = '/number/update'
+url = 'https://rest.nexmo.com/number/update'
 
 #Change msisdn and country to match your virtual number
 msisdn = '447700900000'
 country = 'GB'
 
-params = {
+data = {
     'api_key': 'API_KEY',
     'api_secret': 'API_SECRET',
     'country' : country,
@@ -18,21 +15,14 @@ params = {
     'voiceCallbackValue': 'APPLICATION_ID'
 }
 
-url =  base_url + action
-data =  urllib.urlencode(params)
-
-request = urllib2.Request(url, urllib.urlencode(params))
-request.add_header('Accept', 'application/json')
+resp = requests.post(url, params=data)
 
 try:
-    response = urllib2.urlopen(request)
-    data = response.read()
-    if response.code == 200:
+    if resp.status_code == 200:
         print "SUCESSS!"
-        app = json.loads(data.decode('utf-8'))
-        print json.dumps(app, indent=4)
+        print resp.json()
     else:
-        print "HTTP Response: " + response.code
-        print data
-except urllib2.HTTPError as e:
+        print "HTTP Response: " + resp.status_code
+        print resp.json()
+except requests.exceptions.HTTPError as e:
     print e


### PR DESCRIPTION
All code examples using urllib2 have been switched over to use requests except one.

The remaining one uses request signing for SMS and would potentially be too complex to move to requests.

Partly fixes #48.