### PR TITLE
developer-messages API; fix client-ref links

### DIFF
--- a/_api/developer/messages.md
+++ b/_api/developer/messages.md
@@ -66,7 +66,7 @@ Key | Value
 `price` | Price in Euros for a MT message
 `date-closed` | The date and time at UTC+0 when Platform received the delivery receipt from the carrier who delivered the MT message. This parameter is in the following format YYYY-MM-DD HH:MM:SS
 `latency` | The overall latency between `date-received` and `date-closed` in milliseconds.
-`client-ref` | The [internal reference](/api/sms#keys-and-values) you set in the request.
+`client-ref` | The [internal reference](/api/sms#send-an-sms) you set in the request.
 `final-status` | The status of `message-id` at `date-closed`. @[Possible values](/_modals/api/developer/message/search/response/final-status.md).
 `error-code-label` | A text label to explain `error-code`
 `status` | A code that explains where the message is in the delivery process. If status is not `delivered` check `error-code` for more information. If status is `accepted` ignore the value of `error-code`. @[Possible values](/_modals/api/developer/message/search/response/status.md).
@@ -129,7 +129,7 @@ Key | Value
 `price` | Price in Euros for a MT message
 `date-closed` | The date and time at UTC+0 when Platform received the delivery receipt from the carrier who delivered the MT message. This parameter is in the following format YYYY-MM-DD HH:MM:SS
 `latency` | The overall latency between `date-received` and `date-closed` in milliseconds.
-`client-ref` | The [internal reference](/api/sms#keys-and-values) you set in the request.
+`client-ref` | The [internal reference](/api/sms#send-an-sms) you set in the request.
 `final-status` | The status of `message-id` at `date-closed`. @[Possible values](/_modals/api/developer/message/search/response/final-status.md).
 `error-code-label` | A text label to explain `error-code`
 `status` | A code that explains where the message is in the delivery process. If status is not `delivered` check `error-code` for more information. If status is `accepted` ignore the value of `error-code`. @[Possible values](/_modals/api/developer/message/search/response/status.md).


### PR DESCRIPTION
## Description

Fix links from `client-ref` to SMS API reference. The original fragment (`#keys-and-values`) was not found.

## Deploy Notes

n/a