### PR TITLE
Remove VXML reference.

### DIFF
--- a/_api/developer/numbers.md
+++ b/_api/developer/numbers.md
@@ -181,7 +181,7 @@ Parameter | Description | Required
 `msisdn` | An available inbound virtual number. For example, `447700900000`. | Yes
 `moHttpUrl` | An URL encoded URI to the webhook endpoint that handles inbound messages. Your webhook endpoint must be active before you make this request, Nexmo makes a [GET] request to your endpoint and checks that it returns a `200 OK` response. Set to empty string to clear. | No
 `moSmppSysType` | The associated system type for your SMPP client. For example `inbound`. | No
-`voiceCallbackType` | The voice webhook type. Possible values are `sip`, `tel`, `vxml` (VoiceXML) or `app` | No
+`voiceCallbackType` | The voice webhook type. Possible values are `sip`, `tel`, or `app` | No
 `voiceCallbackValue` | A URI for your `voiceCallbackType` or an Application ID
 `voiceStatusCallback` | A webhook URI for Nexmo to send a request to when a call ends. | No
 


### PR DESCRIPTION
As the Call API and Forward to VXML products have been deprecated as of 31st March 2018, the reference should be removed in preparation for full switch off.

## Description

Please describe what the changes are made in this pull request and why the change was necessary.

## Deploy Notes

Notes regarding deployment the contained body of work. These should note any db migrations, etc.
