### PR TITLE
Workaround: Show NCCO reference

### DIFF
--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -37,6 +37,10 @@ class ApiController < ApplicationController
   end
 
   def set_document
-    @document = params[:document]
+    if params[:code_language] == "ncco"
+      @document = "voice/ncco"
+    else
+      @document = params[:document]
+    end
   end
 end


### PR DESCRIPTION
The controller is interpreting the :document as "voice" not "ncco" so
we'll check the :code_language to see if the user is actually looking
for the the ncco reference.