### PR TITLE
Removed Call API and added TTS API

### DIFF
--- a/app/views/static/legacy.md
+++ b/app/views/static/legacy.md
@@ -19,8 +19,8 @@ Number Insight Advanced Async API | <https://docs.nexmo.com/number-insight/advan
 
 Title | Link
 -- | --
-Call API | <https://docs.nexmo.com/voice/voice-deprecated/call>
-VoiceXML Quickstarts | <https://docs.nexmo.com/voice/voice-deprecated/VoiceXML>
+Text-to-Speech API | <https://docs.nexmo.com/voice/voice-deprecated/text-to-speech>
+Language, accept and gender | <https://docs.nexmo.com/voice/voice-deprecated/supported-languages>
 
 ## Deprecated Verify products
 


### PR DESCRIPTION
Removed the Call API reference as this is deprecated officially as of 31st March 2018, and is no longer available. Added the TTS API as this is deprecated, but still available.