### PR TITLE
voiceCallbackValue description include SIP and tel number

### DIFF
--- a/_api/developer/numbers.md
+++ b/_api/developer/numbers.md
@@ -182,7 +182,7 @@ Parameter | Description | Required
 `moHttpUrl` | An URL encoded URI to the webhook endpoint that handles inbound messages. Your webhook endpoint must be active before you make this request, Nexmo makes a [GET] request to your endpoint and checks that it returns a `200 OK` response. Set to empty string to clear. | No
 `moSmppSysType` | The associated system type for your SMPP client. For example `inbound`. | No
 `voiceCallbackType` | The voice webhook type. Possible values are `sip`, `tel`, `vxml` (VoiceXML) or `app` | No
-`voiceCallbackValue` | A URI for your `voiceCallbackType` or an Application ID
+`voiceCallbackValue` | A SIP URI, telephone number or Application ID  | No
 `voiceStatusCallback` | A webhook URI for Nexmo to send a request to when a call ends. | No
 
 Please note, that `voiceCallbackValue` has to be used together with `voiceCallbackType` parameter.


### PR DESCRIPTION
Explicitly specify *SIP* URI (since VoiceXML is no longer supported this is now the only URI type) and add telephone number

## Description

parameter description was missing possible values


