### PR TITLE
Issue 651 - Removed Call API as soon to be switched off.

### DIFF
--- a/app/views/static/legacy.md
+++ b/app/views/static/legacy.md
@@ -19,7 +19,6 @@ Number Insight Advanced Async API | <https://docs.nexmo.com/number-insight/advan
 
 Title | Link
 -- | --
-Call API | <https://docs.nexmo.com/voice/voice-deprecated/call>
 VoiceXML Quickstarts | <https://docs.nexmo.com/voice/voice-deprecated/VoiceXML>
 
 ## Deprecated Verify products


### PR DESCRIPTION
Had no follow up on Slack about this so simply went ahead and removed entry as requested.