### PR TITLE
Add dynamic content support

### DIFF
--- a/app/filters/dynamic_content_filter.rb
+++ b/app/filters/dynamic_content_filter.rb
@@ -1,0 +1,22 @@
+class DynamicContentFilter < Banzai::Filter
+  def call(input)
+    input.gsub(/(\s|^)\[\~(.+?)\~\](\s|$)/) do
+      content = environment_value($2) || config_value($2) || "VALUE NOT SET: #{$2}"
+      "#{$1}#{content}#{$3}"
+    end
+  end
+
+  private
+
+  def environment_value(key)
+    return nil unless ENV['DYNAMIC_CONTENT']
+    @environment_dynamic_content ||= YAML.safe_load(ENV['DYNAMIC_CONTENT'])
+    @environment_dynamic_content ||= YAML.safe_load(temp)
+    @environment_dynamic_content[key]
+  end
+
+  def config_value(key)
+    @config_dynamic_content ||= YAML.load_file("#{Rails.root}/config/dynamic_content.yml")
+    @config_dynamic_content[key]
+  end
+end

--- a/app/pipelines/markdown_pipeline.rb
+++ b/app/pipelines/markdown_pipeline.rb
@@ -11,6 +11,7 @@ class MarkdownPipeline < Banzai::Pipeline
       ScreenshotFilter,
       AnchorFilter,
       AudioFilter,
+      DynamicContentFilter,
       TooltipFilter,
       CollapsibleFilter,
       TabFilter.new(options),

--- a/app/views/contribute/guides/styleguide.md
+++ b/app/views/contribute/guides/styleguide.md
@@ -280,3 +280,15 @@ The HTML `<audio>` element can be utilised in Markdown with the following syntax
 This produces the following output:
 
 🔈[https://developer.nexmo.com.s3.amazonaws.com/assets/ssml/06-phonemes.mp3]
+
+## Dynamic content
+
+You can use sytax such as:
+
+````
+Welcome to [~dynamic_content_example~]
+````
+
+This will render as:
+
+Welcome to [~dynamic_content_example~]

--- a/config/dynamic_content.yml
+++ b/config/dynamic_content.yml
@@ -1,0 +1,1 @@
+dynamic_content_example: the future


### PR DESCRIPTION
## Description

Adds support for placeholder varibles in Markdown to be resolved to another value either globally set or on a per environment basis.

See styleguide for example implementation.

## Deploy Notes

None
