### PR TITLE
Fix compatibility issue with Ruby 1.5.0 and Rubygems 2.7.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ before_script:
              "  IdentityFile $SSH_FILE" \
              "  LogLevel ERROR" >> ~/.ssh/config
     fi
+  - gem update --system
   - bundle exec rake db:setup
 script:
   - bundle exec rake spec


### PR DESCRIPTION
From https://github.com/travis-ci/travis-ci/issues/8978

> This occurs with the combination of Bundler 1.16.1 and rubygems 2.7.3.
> Since this problem has been addressed in rubygems 2.7.4, execute gem update --system in before_install should fix an error.