### PR TITLE
Add building blocks filter

### DIFF
--- a/app/filters/building_block_filter.rb
+++ b/app/filters/building_block_filter.rb
@@ -1,0 +1,144 @@
+class BuildingBlockFilter < Banzai::Filter
+  def call(input)
+    input.gsub(/```single_building_block(.+?)```/m) do |_s|
+      config = YAML.safe_load($1)
+
+      lexer = language_to_lexer(config['language'])
+
+      # Read the client
+      if config['client']
+          highlighted_client_source = generate_code_block(config['client'], config['unindent'])
+      end
+
+      # Read the code
+      highlighted_code_source = generate_code_block(config['code'], config['unindent'])
+
+      dependency_html = ''
+      if config['dependencies']
+          dependency_html = generate_dependencies(lexer.tag, config['dependencies'])
+      end
+
+      client_html = ""
+      if highlighted_client_source
+      id = SecureRandom.hex
+      client_html = <<~HEREDOC
+        <h3 class="collapsible">
+          <a class="js-collapsible" data-collapsible-id=#{id}>
+            Initialize the library
+          </a>
+        </h3>
+
+        <div id="#{id}" class="collapsible-content" style="display: none;">
+          <p>Create a file named <code>#{config['file_name']}</code> and initialize the client:</p>
+          <pre class="highlight bash"><code>#{highlighted_client_source}</code></pre>
+        </div>
+      HEREDOC
+      end
+
+      code_html = <<~HEREDOC
+        <p>Add the following to <code>#{config['file_name']}</code>:</p>
+        <pre class="highlight #{lexer.tag}"><code>#{highlighted_code_source}</code></pre>
+      HEREDOC
+
+      run_html = ''
+      if config['run_command']
+        id = SecureRandom.hex
+        run_html = <<~HEREDOC
+          <h3 class="collapsible">
+            <a class="js-collapsible" data-collapsible-id=#{id}>
+              Run the code
+            </a>
+          </h3>
+
+          <div id="#{id}" class="collapsible-content" style="display: none;">
+            Save this file to your machine and run it:
+            <pre class="highlight sh"><code>$ #{config['run_command']}</code></pre>
+          </div>
+      HEREDOC
+      end
+
+      dependency_html + client_html + code_html + run_html
+    end
+  end
+
+  private
+
+  def highlight(source, lexer)
+    formatter = Rouge::Formatters::HTML.new
+    formatter.format(lexer.lex(source))
+  end
+
+  def language_to_lexer_name(language)
+    if language_configuration['languages'][language]
+      language_configuration['languages'][language]['lexer']
+    else
+      language
+    end
+  end
+
+  def language_to_lexer(language)
+    language = language_to_lexer_name(language)
+    return Rouge::Lexers::PHP.new({ start_inline: true }) if language == 'php'
+    Rouge::Lexer.find(language.downcase) || Rouge::Lexer.find('text')
+  end
+
+  def language_configuration
+    @language_configuration ||= YAML.load_file("#{Rails.root}/config/code_languages.yml")
+  end
+
+  def generate_code_block(input, unindent)
+      if input
+          code = File.read("#{Rails.root}/#{input['source']}")
+          language = File.extname("#{Rails.root}/#{input['source']}")[1..-1]
+          lexer = language_to_lexer(language)
+
+          total_lines = code.lines.count
+
+          # Minus one since lines are not zero-indexed
+          from_line = (input['from_line'] || 1) - 1
+          to_line = (input['to_line'] || total_lines) - 1
+
+          code = code.lines[from_line..to_line].join
+          code.unindent! if unindent
+
+          highlight(code, lexer)
+      end
+  end
+
+  def generate_dependencies(language, dependencies)
+      dep_managers = {
+          "javascript" => lambda { |deps| "$ npm install #{dependencies.join(' ')}" },
+          "csharp" => lambda { |deps| "$ Install-Package #{dependencies.join(' ')}" },
+          "php" => lambda { |deps| "$ composer require #{dependencies.join(' ')}" },
+          "python" => lambda { |deps| "$ pip install #{dependencies.join(' ')}" },
+          "ruby" => lambda { |deps| "$ gem install #{dependencies.join(' ')}" },
+          "java" => lambda { |deps| 
+              {
+
+                'text' => 'Add the following to <code>build.gradle</code>:',
+                'code' => dependencies.map { |d| "compile '#{d}'" }.join("<br />")
+              }
+          },
+      }
+
+      deps = dep_managers[language].call(dependencies)
+      deps = {'code' => deps} unless deps['code']
+      deps['text'] = '' unless deps['text']
+
+      id = SecureRandom.hex
+
+      dependency_html = <<~HEREDOC
+        <h3 class="collapsible">
+          <a class="js-collapsible" data-collapsible-id=#{id}>
+            Install dependencies
+          </a>
+        </h3>
+
+        <div id="#{id}" class="collapsible-content" style="display: none;">
+          <p>#{deps['text']}</p>
+          <pre class="highlight bash"><code>#{deps['code']}</code></pre>
+        </div>
+      HEREDOC
+
+  end
+end

--- a/app/filters/building_blocks_filter.rb
+++ b/app/filters/building_blocks_filter.rb
@@ -1,0 +1,196 @@
+class BuildingBlocksFilter < Banzai::Filter
+  def call(input)
+    input.gsub(/^(\s*)```building_blocks(.+?)```/m) do |_s|
+      @indentation = $1
+      @config = YAML.safe_load($2)
+      validate_config
+      html
+    end
+  end
+
+  private
+
+  def create_tabs(content)
+    tab = Nokogiri::XML::Element.new 'li', @document
+    tab['class'] = 'tabs-title'
+    tab['class'] += ' is-active' if content[:active]
+
+    if content[:language]
+      tab['data-language'] = content[:language].key
+      tab['data-language-type'] = content[:language].type
+      tab['data-language-linkable'] = content[:language].linkable?
+    end
+
+    if content[:platform]
+      tab['data-language'] = content[:platform].languages.map(&:key).join(',')
+      tab['data-platform'] = content[:platform].key
+      tab['data-platform-type'] = content[:platform].type
+      tab['data-platform-linkable'] = content[:platform].linkable?
+    end
+
+    tab_link = Nokogiri::XML::Element.new 'a', @document
+    tab_link.content = content[:tab_title]
+    tab_link['href'] = "##{content[:id]}"
+
+    tab.add_child(tab_link)
+    @tabs.add_child(tab)
+  end
+
+  def create_content(content)
+    element = Nokogiri::XML::Element.new 'div', @document
+    element['id'] = content[:id]
+    element['class'] = 'tabs-panel'
+    element['class'] += ' is-active' if content[:active]
+    element.inner_html = content[:body]
+
+    @tabs_content.add_child(element)
+  end
+
+  def html
+    id = SecureRandom.hex
+
+    html = <<~HEREDOC
+      <div>
+        <ul class="tabs" data-tabs id="#{id}"></ul>
+        <div class="tabs-content" data-tabs-content="#{id}"></div>
+      </div>
+    HEREDOC
+
+    @document = Nokogiri::HTML::DocumentFragment.parse(html)
+    @tabs = @document.at_css('.tabs')
+    @tabs_content = @document.at_css('.tabs-content')
+
+    contents.each do |content|
+      create_tabs(content)
+      create_content(content)
+    end
+
+    source = @document.to_html
+
+    "#{@indentation}FREEZESTART#{Base64.urlsafe_encode64(source)}FREEZEEND"
+  end
+
+  def contents
+    list = content_from_source
+    list ||= []
+
+    return list unless list.any?
+
+    list = resolve_language(list)
+
+    list = sort_contents(list)
+    resolve_active_tab(list)
+
+    list
+  end
+
+  def validate_config
+    return if @config && @config['source']
+    raise 'A source key must be present in this tabbed_example config'
+  end
+
+  def content_from_source
+    source_path = "#{Rails.root}/#{@config['source']}/*.yml"
+
+    Dir[source_path].map do |content_path|
+      source = File.read(content_path)
+
+      content  = YAML.safe_load(source)
+      content[:id] = SecureRandom.hex
+      content[:source] = source
+      content[:language_key] = content['language']
+      content[:platform_key] = content['platform']
+      content[:tab_title] = content['title']
+
+      source = <<~HEREDOC
+```single_building_block
+#{source}
+```
+      HEREDOC
+
+      if @config['title']
+          source = "<h2>#{@config['title']}</h2>" + source
+      end
+
+      content[:body] = MarkdownPipeline.new(options).call(source)
+
+      content
+    end
+  end
+
+  def resolve_language(contents)
+    contents.map do |content|
+      if content[:language_key]
+        content.merge!({
+          :language => CodeLanguageResolver.find(content[:language_key]),
+        })
+      end
+
+      if content[:platform_key]
+        content.merge!({
+          :platform => CodeLanguageResolver.find(content[:platform_key]),
+        })
+      end
+
+      content
+    end
+  end
+
+  def format_code(contents)
+    contents.each do |content|
+      if content[:from_line] || content[:to_line]
+        lines = content[:source].lines
+        total_lines = lines.count
+        from_line = (content[:from_line] || 1) - 1
+        to_line = (content[:to_line] || total_lines) - 1
+        content[:source] = lines[from_line..to_line].join
+      end
+
+      content[:source].unindent! if content[:unindent]
+    end
+  end
+
+  def resolve_code(contents)
+    contents.map do |content|
+      @formatter ||= Rouge::Formatters::HTML.new
+      lexer = content[:language].lexer
+      highlighted_source = @formatter.format(lexer.lex(content[:source]))
+      body = <<~HEREDOC
+        <pre class="highlight #{content[:language_key]}"><code>#{highlighted_source}</code></pre>
+      HEREDOC
+
+      content.merge!({ :body => body })
+    end
+  end
+
+  def resolve_tab_title(contents)
+    contents.map do |content|
+      content.merge!({ :tab_title => content[:language].label })
+    end
+  end
+
+  def sort_contents(contents)
+    contents.sort_by do |content|
+      next content[:language].weight if content[:language]
+      next content[:frontmatter]['menu_weight'] || 999 if content[:frontmatter]
+      999
+    end
+  end
+
+  def resolve_active_tab(contents)
+    active_index = nil
+
+    if options[:code_language]
+      contents.each_with_index do |content, index|
+        %i{language_key platform_key}.each do |key|
+          active_index = index if content[key] == options[:code_language].key
+        end
+      end
+    end
+
+    @tabs['data-has-initial-tab'] = active_index.present?
+    active_index ||= 0
+
+    contents[active_index][:active] = true
+  end
+end

--- a/app/pipelines/markdown_pipeline.rb
+++ b/app/pipelines/markdown_pipeline.rb
@@ -14,6 +14,8 @@ class MarkdownPipeline < Banzai::Pipeline
       TooltipFilter,
       CollapsibleFilter,
       TabFilter.new(options),
+      BuildingBlocksFilter,
+      BuildingBlockFilter,
       CodeFilter,
       IndentFilter,
       ModalFilter,


### PR DESCRIPTION
This PR adds building blocks as a filter concept. In any markdown file, add the following:

```building_blocks
source: '_examples/redact/redact-a-transaction'
```

This will look for all supported languages in `_examples/redact/redact-a-transaction/*.yml`

Each file contains a definition for a block e.g.:

```yaml
---
title: Node
language: node
dependencies:
  - nexmo
file_name: redact.js
client:
    source: '.repos/nexmo-community/nexmo-node-quickstart/redact/transaction.js'
    from_line: 10
    to_line: 15
code:
    source: '.repos/nexmo-community/nexmo-node-quickstart/redact/transaction.js'
    from_line: 17
    to_line: 22
```

This PR probably needs redactoring/tests adding, but I'd like to merge for now as it's blocking new building blocks. I'll add an issue to refactor at a future date