### PR TITLE
Make Docker build node_modules instead of doing it on the host.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,13 +6,20 @@ RUN apt-get update -qq && apt-get install -y build-essential libpq-dev lsof
 
 # Install modern NodeJS
 run curl -sL https://deb.nodesource.com/setup_8.x | bash -
-run apt-get update && apt-get install -y nodejs
+run curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
+run echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
+run apt-get update && apt-get install -y nodejs yarn
 
 # Set an environment variable where the Rails app is installed to inside of Docker image:
 RUN mkdir -p /app/.git/hooks
+
 WORKDIR /app
 
+# Install Node Dependencies
+ADD package.json yarn.lock /app/
+RUN yarn install --verbose
+
+# Install Ruby Dependencies
 ADD Gemfile /app/Gemfile
 ADD Gemfile.lock /app/Gemfile.lock
 RUN bundle install
-ADD . /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ WORKDIR /app
 
 # Install Node Dependencies
 ADD package.json yarn.lock /app/
-RUN yarn install --verbose
+RUN yarn install
 
 # Install Ruby Dependencies
 ADD Gemfile /app/Gemfile

--- a/README.md
+++ b/README.md
@@ -31,7 +31,6 @@ If you don't want to install Ruby & PostgreSQL then you can use docker to sandbo
 $ git clone git@github.com:Nexmo/nexmo-developer.git
 $ cd nexmo-developer
 $ cp .env.example .env
-$ ./bin/yarn install
 
 # Start the web server
 $ docker-compose up

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,7 @@ services:
     command: bundle exec rails s -p 3000 -b '0.0.0.0'
     volumes:
       - .:/app
+      - /app/node_modules
     ports:
       - "3000:3000"
     depends_on:


### PR DESCRIPTION
## Description

Update the Docker settings to make Docker do the building of `node_modules` instead of having to do it on the host system. I believe that the `ADD . /app` step in the Dockerfile wasn't working correctly as we are mounting the current working directory as `/app` which hides the `/app` directory in the container created in the `build` process.

Docker will now run `yarn install` and create a `node_modules` folder at `/app/node_modules`. When the web service is initialized it will mount both `.:/app` and then `/app/node_modules` which will expose the `node_modules` folder created on the container.