### PR TITLE
add /v1/knocking permission to JWT

### DIFF
--- a/_partials/stitch/guides/1-simple-conversation/javascript.md
+++ b/_partials/stitch/guides/1-simple-conversation/javascript.md
@@ -124,7 +124,7 @@ MEM-aaaaaaaa-bbbb-cccc-dddd-0123456789ab | USR-aaaaaaaa-bbbb-cccc-dddd-012345678
 Generate a JWT for the user and take a note of it. Remember to change the `YOUR_APP_ID` value in the command:
 
 ```bash
-$ USER_JWT="$(nexmo jwt:generate ./private.key sub=jamie exp=$(($(date +%s)+86400)) acl='{"paths":{"/v1/users/**":{},"/v1/conversations/**":{},"/v1/sessions/**":{},"/v1/devices/**":{},"/v1/image/**":{},"/v3/media/**":{},"/v1/applications/**":{},"/v1/push/**":{}}}' application_id=YOUR_APP_ID)"
+$ USER_JWT="$(nexmo jwt:generate ./private.key sub=jamie exp=$(($(date +%s)+86400)) acl='{"paths":{"/v1/users/**":{},"/v1/conversations/**":{},"/v1/sessions/**":{},"/v1/devices/**":{},"/v1/image/**":{},"/v3/media/**":{},"/v1/applications/**":{},"/v1/push/**":{},"/v1/knocking/**": {}}}' application_id=YOUR_APP_ID)"
 ```
 
 *Note: The above command saves the generated JWT to a `USER_JWT` constant. It also sets the expiry of the JWT to one day from now.*


### PR DESCRIPTION

without "/v1/knocking" permission in acl PSTN call is not working, it ends with "system:error:permission"

