### PR TITLE
fix table of content anchors

### DIFF
--- a/_api/sms/us-short-codes/alerts/sending.md
+++ b/_api/sms/us-short-codes/alerts/sending.md
@@ -36,11 +36,11 @@ https://rest.nexmo.com/sc/us/alert/json?api_key=xxxxxxxx&api_secret=xxxxxxxx&to=
 
 This request contains:
 
-* A [Base URL](#base)
-* [Parameters](#parameters )
-* [Authentication information](#authentic )
-* [Security](#security )
-* [Encoding](#encode)
+* A [Base URL](#base-url)
+* [Parameters](#parameters)
+* Authentication information
+* [Security](#security)
+* [Encoding](#encoding)
 
 ### Base URL
 


### PR DESCRIPTION
## Description

Some anchors had typo errors, leading to un-clickable links.
