### PR TITLE
Clarified URLs for answer and events.

### DIFF
--- a/_examples/concepts/guides/applications/commandline.md
+++ b/_examples/concepts/guides/applications/commandline.md
@@ -23,7 +23,7 @@ To create a Voice app and send a text-to-speech message:
 4. Create an Application:
 
     ```sh
-    $ nexmo app:create "VoiceApplication" http://example.com http://example.com  --keyfile private.key
+    $ nexmo app:create "VoiceApplication" http://example.com/webhooks/answer http://example.com/webhooks/event  --keyfile private.key
     ```
 
 5. Associate the application_id with your virtual number.


### PR DESCRIPTION
## Description

Documentation feedback from Richard Chamberlain:

> Step 4 - example.com is confusing and repeated - can it be removed and example.com be defaulted in the CLI? Maybe a warning that it's defaulted to example.com 

I have changed the example so that the answer URL and event URL are more specific. With regards default in the CLI see below.

> Step 5 - can link:app use your default number if you've got only one? Also presumably somewhere in the app it has the UUID in it somewhere. If the user was in the app folder then they could feasibly just do "nexmo link:app"?

Not sure, but maybe best thing would be to raise a GitHub issue for the CLI tool. They could then advise: 

https://github.com/Nexmo/nexmo-cli
