### PR TITLE
OAS Response Descriptions

### DIFF
--- a/_open_api/definitions/media.yml
+++ b/_open_api/definitions/media.yml
@@ -67,12 +67,12 @@ paths:
                 properties:
                   page_size:
                     type: integer
-                    description: An explanation about the purpose of this instance.
+                    description: The amount of records returned in this response.
                     default: 0
                     example: 20
                   page_index:
                     type: integer
-                    description: An explanation about the purpose of this instance.
+                    description: The `page_index` used in your request.
                     default: 0
                     example: 0
                   _links:
@@ -83,7 +83,6 @@ paths:
                         properties:
                           href:
                             type: string
-                            description: An explanation about the purpose of this instance.
                             default: ''
                             example: "/v3/media?page_size=20&account_id=abcd1234&order=descending"
                       first:
@@ -91,7 +90,6 @@ paths:
                         properties:
                           href:
                             type: string
-                            description: An explanation about the purpose of this instance.
                             default: ''
                             example: "/v3/media?page_size=20&account_id=abcd1234&order=descending"
                       last:
@@ -99,16 +97,19 @@ paths:
                         properties:
                           href:
                             type: string
-                            description: An explanation about the purpose of this instance.
                             default: ''
                             example: "/v3/media?page_size=20&account_id=abcd1234&order=descending"
                   count:
                     type: integer
-                    description: An explanation about the purpose of this instance.
+                    description: The total number of records returned by your request.
                     default: 0
                     example: 1
                   _embedded:
                     type: object
+                    description: >-
+                      A collection of media items.
+                      See [retrieve a media item](#retrieve-a-media-item) for a
+                      description of the returned fields
                     properties:
                       media:
                         type: array

--- a/_open_api/definitions/sms.yml
+++ b/_open_api/definitions/sms.yml
@@ -1,0 +1,482 @@
+openapi: "3.0.0"
+info:
+  version: 1.0.0
+  title: SMS API
+  description: With the Nexmo SMS API you can send SMS from your account and lookup messages both messages that you've sent as well as messages sent to your virtual numbers.
+servers:
+  - url: https://rest.nexmo.com
+paths:
+  /sms/{format}:
+    post:
+      x-group: sms
+      operationId: send-an-sms
+      summary: Send an SMS
+      description: Send an outbound SMS from your Nexmo account
+      x-code-example-path: messaging.sms.send
+      parameters:
+        - name: format
+          description: The format of the response
+          in: path
+          required: true
+          schema:
+            example: json
+            type: string
+            enum:
+              - json
+              - xml
+        - name: api_key
+          description: Your API key
+          required: true
+          in: query
+          example: abcd1234
+          schema:
+            type: string
+            minLength: 8
+            maxLength: 8
+        - name: api_secret
+          description: Your API secret. Required unless `sig` is provided
+          required: false
+          in: query
+          example: abcdef0123456789
+          schema:
+            type: string
+            minLength: 16
+            maxLength: 16
+        - name: sig
+          description: The hash of the request parameters in alphabetical order, a timestamp and the signature secret. See [Signing Requests](/concepts/guides/signing-messages) for more details.
+          required: false
+          in: query
+          schema:
+            type: string
+            minLength: 16
+            maxLength: 16
+      requestBody:
+        required: true
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/NewMessage'
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Message'
+            text/xml:
+              schema:
+                $ref: '#/components/schemas/MessageXmlWrapper'
+
+      callbacks:
+        delivery-receipt:
+          '{$request.body#/callback}':
+            post:
+              summary: Delivery Receipt
+              operationId: delivery-receipt
+              x-example-path: '/webhooks/delivery-receipt'
+              description: The following are parameters sent in as a [delivery receipt](/messaging/sms/guides/delivery-receipts) callback. You can subscribe to [webhooks](/concepts/guides/webhooks) to receive notification when the delivery status of an SMS that you have sent with Nexmo changes.
+              requestBody:
+                required: true
+                content:
+                  application/json:
+                    schema:
+                      $ref: '#/components/schemas/DeliveryReceipt'
+              responses:
+                '200':
+                  description: Your server returns this code if it accepts the callback
+x-webhooks:
+  inbound-sms:
+    '{$request.body#/callback}':
+      post:
+        summary: Inbound SMS
+        operationId: inbound-sms
+        x-example-path: '/webhooks/inbound-sms'
+        description: |
+          If you rent one or more virtual numbers from Nexmo, inbound messages to that number are sent to your [webhook endpoint](/concepts/guides/webhooks).
+
+          When you receive an inbound message, you must send a 2xx response. If you do not send a 2xx response Nexmo will resend the inbound message for the next 24 hours.
+        requestBody:
+          required: true
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InboundMessage'
+        responses:
+          '200':
+            description: Your server returns this code if it accepts the callback
+
+components:
+  schemas:
+    NewMessage:
+      required:
+        - from
+        - to
+      properties:
+        from:
+          description: The name or number the message should be sent from. Alphanumeric senderID's are not supported in all countries, see [Global Messaging](/messaging/sms/guides/global-messaging#country-specific-features) for more details.
+          type: string
+          example: 'Acme Inc'
+        to:
+          description: The number that the message should be sent to
+          type: string
+          minLength: 7
+          maxLength: 15
+          pattern: '\d{7,15}'
+          example: 447700900000
+        text:
+          description: The body of the message being sent. If your message contains characters that can be encoded according to the GSM Standard and Extended tables then you can set the `type` to `text`. If your message contains characters outside this range, then you will need to set the `type` to `unicode`.
+          type: string
+          example: Hello World!
+        ttl:
+          description: '**Advanced**: The duration in milliseconds the delivery of an SMS will be attempted.§§ By default Nexmo attempt delivery for 72 hours, however the maximum effective value depends on the operator and is typically 24 - 48 hours. We recommend this value should be kept at its default or at least 30 minutes.'
+          type: integer
+          example: 900000
+          default: 259200000
+          minimum: 20000
+          maximum: 604800000
+        status-report-req:
+          description: '**Advanced**: Boolean indicating if you like to receive a [Delivery Receipt](/messaging/sms/building-blocks/receive-a-delivery-receipt).'
+          type: boolean
+          example: false
+          default: true
+        callback:
+          description: '**Advanced**: The webhook endpoint the delivery receipt for this sms is sent to. This parameter overrides the webhook endpoint you set in Dashboard.'
+          type: string
+          example: 'https://example.com/sms-dlr'
+        message-class:
+          description: '**Advanced**: The Data Coding Scheme value of the message'
+          type: integer
+          enum:
+            - 0
+            - 1
+            - 2
+            - 3
+        type:
+          description: '**Advanced**: The format of the message body'
+          type: string
+          enum:
+            - text
+            - binary
+            - wappush
+            - unicode
+            - vcal
+            - vcard
+          example: text
+          default: text
+        vcard:
+          description: '**Advanced**: A business card in [vCard format](https://en.wikipedia.org/wiki/VCard). Depends on `type` parameter having the value `vcard`.'
+          type: string
+          format: vcard
+        vcal:
+          description: '**Advanced**: A calendar event in [vCal format](https://en.wikipedia.org/wiki/VCal). Depends on `type` parameter having the value `vcal`.'
+          type: string
+          format: vcal
+        body:
+          description: '**Advanced**: Hex encoded binary data. Depends on `type` parameter having the value `binary`.'
+          type: string
+          example: 0011223344556677
+        udh:
+          description: '**Advanced**: Your custom Hex encoded [User Data Header](https://en.wikipedia.org/wiki/User_Data_Header). Depends on `type` parameter having the value `binary`.'
+          type: string
+          example: 06050415811581
+        protocol-id:
+          description: '**Advanced**: The value of the [protocol identifier](https://en.wikipedia.org/wiki/GSM_03.40#Protocol_Identifier) to use. Ensure that the value is aligned with `udh`.'
+          type: integer
+          example: 127
+        title:
+          description: '**Advanced**: The title for a wappush SMS. Depends on `type` parameter having the value `wappush`.'
+          type: string
+          example: Welcome
+        url:
+          description: '**Advanced**: The URL of your website. Depends on `type` parameter having the value `wappush`.'
+          type: string
+          example: https://example.com
+        validity:
+          description: '**Advanced**: The availability for an SMS in milliseconds. Depends on `type` parameter having the value `wappush`.'
+          type: string
+          example: 300000
+        client-ref:
+          description: '**Advanced**: You can optionally include your own reference of up to 40 characters.'
+          type: string
+          example: my-personal-reference
+    Error:
+      type: object
+      properties:
+        message-count:
+          type: integer
+          description: The amount of messages in the request
+          example: 1
+        messages:
+          type: array
+          items:
+            $ref: '#/components/schemas/ErrorMessage'
+    ErrorMessage:
+      type: object
+      properties:
+        status:
+          type: string
+          description: The error status of the message
+          example: '2'
+        error-text:
+          type: string
+          description: The description of the error
+          example: 'Missing to param'
+    SMS:
+      type: object
+      properties:
+        message-count:
+          type: integer
+          description: The amount of messages in the request
+          example: 1
+        messages:
+          type: array
+          items:
+            $ref: '#/components/schemas/Message'
+    InboundMessage:
+      type: object
+      properties:
+        msisdn:
+          type: string
+          description: The phone number that this inbound message was sent from.
+          example: '447700900001'
+          required: true
+        to:
+          type: string
+          description: The phone number the message was sent to. **This is your virtual number**.
+          example: '447700900000'
+          required: true
+        messageId:
+          type: string
+          description: The ID of the message
+          example: 0A0000000123ABCD1
+          required: true
+        text:
+          type: string
+          description: The message body for this inbound message.
+          example: Hello world
+          required: true
+        type:
+          type: string
+          description: |
+            Possible values are:
+
+              - `text` - standard text.
+              - `unicode` - URLencoded   unicode  . This is valid for standard GSM, Arabic, Chinese, double-encoded characters and so on.
+              - `binary` - a binary message.
+          example: 'text'
+          required: true
+        keyword:
+          type: string
+          description: The first word in the message body. This is typically used with short codes.
+          example: Hello
+          required: true
+        message-timestamp:
+          description: The time when Nexmo started to push this Delivery Receipt to your webhook endpoint.
+          type: string
+          example: 2020-01-01 12:00:00
+          required: true
+        timestamp:
+          description: A unix timestamp representation of message-timestamp.
+          type: string
+          example: "1578787200"
+        nonce:
+          type: string
+          description: A random string that forms part of the signed set of parameters, it adds an extra element of unpredictability into the signature for the request. You use the nonce and timestamp parameters with your shared secret to calculate and validate the signature for inbound messages.
+          example: aaaaaaaa-bbbb-cccc-dddd-0123456789ab
+        concat:
+          type: string
+          description: True - if this is a concatenated message.
+          example: 'true'
+        concat-ref:
+          type: string
+          description: The transaction reference. All parts of this message share this value.
+          example: '1'
+        concat-total:
+          type: string
+          description: The number of parts in this concatenated message.
+          example: '3'
+        concat-part:
+          type: string
+          description: The number of this part in the message. Counting starts at 1.
+          example: '2'
+        data:
+          type: string
+          format: binary
+          description: The content of this message, if type is binary.
+        udh:
+          type: string
+          description: The hex encoded User Data Header, if type is binary
+    Message:
+      type: object
+      properties:
+        to:
+          type: string
+          description: The number the message was sent to
+          example: '447700900000'
+        message-id:
+          type: string
+          description: The ID of the message
+          example: 0A0000000123ABCD1
+          xml:
+            name: messageId
+        status:
+          type: string
+          description: The status of the message
+          example: '0'
+        remaining-balance:
+          type: string
+          description: Your remaining balance
+          example: '3.14159265'
+          xml:
+            name: remainingBalance
+        message-price:
+          type: string
+          description: The cost of the message
+          example: '0.03330000'
+          xml:
+            name: messagePrice
+        network:
+          type: string
+          description: The ID of the network of the recipient
+          example: '12345'
+    MessageXmlWrapper:
+      type: object
+      xml:
+        name: mt-submission-response
+      properties:
+        messages:
+          x-skip-response-description: true
+          type: array
+          items:
+            $ref: '#/components/schemas/Message'
+          properties:
+            count:
+              type: integer
+              example: 1
+              xml:
+                attribute: true
+    DeliveryReceipt:
+      type: object
+      properties:
+        msisdn:
+          type: string
+          description: The number the message was sent to
+          example: '447700900000'
+        to:
+          type: string
+          description: The SenderID you set in from in your request
+          example: Acme Inc
+        network-code:
+          type: string
+          description: The Mobile Country Code Mobile Network Code (MCCMNC) of the carrier this phone number is registered with.
+          example: '12345'
+        messageId:
+          type: string
+          description: The Nexmo ID for this message.
+          example: '0A0000001234567B'
+        price:
+          type: string
+          description: The cost of the message
+          example: '0.03330000'
+        status:
+          type: string
+          description: A code that explains where the message is in the delivery process.
+          example: 'delivered'
+          x-possible-values:
+            - delivered
+            - expired
+            - failed
+            - rejected
+            - accepted
+            - buffered
+            - unknown
+        scts:
+          type: string
+          description: When the DLR was recieved from the carrier in the following format `YYMMDDHHMM`. For example, `2001011400` is at `2020-01-01 14:00`
+          example: '2001011400'
+        err-code:
+          type: string
+          description: The status of the request. Will be a non `0` value if there has been an error. See the [SMS error reference](/api-errors/sms) for more details
+          example: '0'
+        message-timestamp:
+          description: The time when Nexmo started to push this Delivery Receipt to your webhook endpoint.
+          type: string
+          example: 2020-01-01 12:00:00
+x-groups:
+  sms:
+    name: "SMS"
+    order: 1
+    description: The SMS object contains information about the request and details of the message information.
+    schema:
+      application/json:
+        $ref: '#/components/schemas/SMS'
+      text/xml:
+        $ref: '#/components/schemas/MessageXmlWrapper'
+
+x-errors:
+  1:
+    description: An unknown error was received from the carrier who tried to send this this message. Depending on the carrier, that `to` is unknown.
+    resolution: When you see this error, and status is rejected, always check if `to` in your request was valid.
+
+  2:
+    description: This message was not delivered because `to` was temporarily unavailable. For example, the handset used for to was out of coverage or switched off.
+    resolution: This is a temporary failure, retry later for a positive result.
+
+  3:
+    description: The `to` number is no longer active
+    resolution: Remove this phone number from your database.
+
+  4:
+    description: Call barred by user
+    resolution: You should remove this phone number from your database. If the user wants to receive messages from you, they need to contact their carrier directly.
+
+  5:
+    description: Portability error. There is an issue after the user has changed carrier for `to`
+    resolution: If the user wants to receive messages from you, they need to contact their carrier directly.
+
+  6:
+    description: Anti-Spam rejection. Carriers often apply restrictions that block messages following different criteria. For example, on SenderID or message content
+    resolution: If you believe that your message is being blocked incorrectly, either email us at support@nexmo.com or create a helpdesk ticket at https://help.nexmo.com
+
+  7:
+    description: Handset busy. The handset associated with to was not available when this message was sent. 
+    resolution: If status is Failed, this is a temporary failure; retry later for a positive result. If status is Accepted, this message has is in the retry scheme and will be resent until it expires in 24-48 hours.
+
+  8:
+    description: Network error. A network failure occured while sending your message
+    resolution: This is a temporary failure, retry later for a positive result.
+
+  9:
+    description: Insufficent funds. `To`’s pre-paid account does not have enough credit to receive the message.
+    resolution: The `to` number must top up, then you can retry sending the message
+
+  10:
+    description: The message could not be sent because one of the parameters in the message was incorrect. For example, incorrect type or udh.
+    resolution: Check your outbound request and try again
+    link:
+      text: View API reference
+      url: /api/sms#send-an-sms
+
+  11:
+    description: The chosen route to send your message is not available. This is because the phone number is either currently on an unsupported network or on a pre-paid or reseller account that could not receive a message sent by `from`.
+    resolution: Either email us at support@nexmo.com or create a helpdesk ticket at https://help.nexmo.com
+
+  12:
+    description: Desintation unreachable. The message could not be delivered to the phone number.
+    resolution: Check that your `to` number is valid. Make sure to use the country prefix (e.g. `44` for the UK) and not a `0`
+
+  13:
+    description: The carrier blocked this message because the content is not suitable for `to` based on age restrictions.)
+    resolution: N/A
+
+  14:
+    description: The carrier blocked this message. This could be due to several reasons. For example, `to`'s plan does not include SMS or the account is suspended.
+    resolution: N/A
+
+  15:
+    description: You tried to send a message to a blacklisted phone number. That is, the user has already sent a STOP opt-out message and no longer wishes to receive messages from you.
+    resolution: N/A
+
+  99:
+    description: There is a problem with the chosen route to send your message
+    resolution: To resolve this issue either email us at support@nexmo.com or create a helpdesk ticket at https://help.nexmo.com.

--- a/_open_api/definitions/voice.yml
+++ b/_open_api/definitions/voice.yml
@@ -104,24 +104,13 @@ paths:
               schema:
                 properties:
                   uuid:
-                    type: string
-                    format: uuid
-                    example: 63f61863-4a51-4f6b-86e1-46edebcf9356
+                    $ref: '#/components/schemas/fields/uuid'
                   status:
-                    type: string
-                    example: started
-                    enum:
-                    - started
+                    $ref: '#/components/schemas/fields/status'
                   direction:
-                    type: string
-                    example: outbound
-                    enum:
-                    - outbound
-                    - inbound
+                    $ref: '#/components/schemas/fields/direction'
                   conversation_uuid:
-                    type: string
-                    format: uuid
-                    example: CON-f972836a-550f-45fa-956c-12a2ab5b7d22
+                    $ref: '#/components/schemas/fields/conversation_uuid'
     get:
       security:
       - bearerAuth: []
@@ -135,7 +124,7 @@ paths:
         description: Filter by call status
         schema:
           type: string
-          example: completed
+          example: started
           enum:
           - started
           - ringing
@@ -188,9 +177,7 @@ paths:
         in: query
         description: Return all the records associated with a specific conversation.
         schema:
-          type: string
-          format: uuid
-          example: CON-f972836a-550f-45fa-956c-12a2ab5b7d22
+          $ref: '#/components/schemas/fields/conversation_uuid'
       responses:
         '200':
           description: Ok
@@ -201,15 +188,15 @@ paths:
                 properties:
                   count:
                     type: integer
-                    title: The Number of records found
+                    title: The total number of records returned by your request.
                     example: 100
                   page_size:
                     type: integer
-                    title: The Number of records in this response
+                    title: The amount of records returned in this response.
                     example: 10
                   record_index:
                     type: integer
-                    title: The Record Index
+                    title: The `record_index` used in your request.
                     example: 0
                   _links:
                     type: object
@@ -222,6 +209,10 @@ paths:
                             title: Link to the object
                             example: "/calls?page_size=10&record_index=20&order=asc"
                   _embedded:
+                    description: >-
+                        A list of call objects. See the
+                        [get details of a specific call](#getCall)
+                        response fields for a description of the nested objects
                     type: object
                     properties:
                       calls:
@@ -240,73 +231,29 @@ paths:
                                       title: The Link to the Call Object
                                       example: "/calls/63f61863-4a51-4f6b-86e1-46edebcf9356"
                             uuid:
-                              type: string
-                              format: uuid
-                              title: The UUID of the Call
-                              example: 63f61863-4a51-4f6b-86e1-46edebcf9356
+                              $ref: '#/components/schemas/fields/uuid'
                             conversation_uuid:
-                              type: string
-                              format: uuid
-                              title: The UUID of the Conversation
-                              example: CON-f972836a-550f-45fa-956c-12a2ab5b7d22
+                              $ref: '#/components/schemas/fields/conversation_uuid'
                             to:
-                              type: array
-                              items:
-                                type: object
-                                properties:
-                                  type:
-                                    type: string
-                                    title: 'The Type of Endpoint Called '
-                                    example: phone
-                                  number:
-                                    type: string
-                                    title: 'The number Of the endpoint called '
-                                    example: '447700900000'
+                              $ref: '#/components/schemas/fields/to'
                             from:
-                              type: object
-                              properties:
-                                type:
-                                  type: string
-                                  title: 'The Type of Endpoint that made the call '
-                                  example: phone
-                                number:
-                                  type: string
-                                  title: 'The Number that made the call '
-                                  example: '447700900001'
+                              $ref: '#/components/schemas/fields/from'
                             status:
-                              type: string
-                              title: 'The State of the call '
-                              example: completed
+                              $ref: '#/components/schemas/fields/status'
                             direction:
-                              type: string
-                              title: 'The Direction of the Call '
-                              example: outbound
+                              $ref: '#/components/schemas/fields/direction'
                             rate:
-                              type: string
-                              title: The Price per minute of the called destination
-                              example: '0.39'
+                              $ref: '#/components/schemas/fields/rate'
                             price:
-                              type: string
-                              title: 'The total price of the call '
-                              example: '23.40'
+                              $ref: '#/components/schemas/fields/price'
                             duration:
-                              type: string
-                              title: 'The Duration of the call '
-                              example: '60'
+                              $ref: '#/components/schemas/fields/duration'
                             start_time:
-                              type: string
-                              format: timestamp
-                              title: 'The Start Time of the call '
-                              example: '2015-02-04T22:45:00Z'
+                              $ref: '#/components/schemas/fields/start_time'
                             end_time:
-                              type: string
-                              format: timestamp
-                              title: The end time of the call
-                              example: '2015-02-04T23:45:00Z'
+                              $ref: '#/components/schemas/fields/end_time'
                             network:
-                              type: string
-                              title: 'The Network ID of the destination '
-                              example: '65512'
+                              $ref: '#/components/schemas/fields/network'
   "/calls/{uuid}":
     parameters:
     - in: path
@@ -342,73 +289,29 @@ paths:
                             title: Link to the object
                             example: "/calls?page_size=10&record_index=20&order=asc"
                   uuid:
-                    type: string
-                    format: uuid
-                    title: The UUID of the Call
-                    example: 63f61863-4a51-4f6b-86e1-46edebcf9356
+                    $ref: '#/components/schemas/fields/uuid'
                   conversation_uuid:
-                    type: string
-                    format: uuid
-                    title: The UUID of the Conversation
-                    example: CON-f972836a-550f-45fa-956c-12a2ab5b7d22
+                    $ref: '#/components/schemas/fields/conversation_uuid'
                   to:
-                    type: array
-                    items:
-                      type: object
-                      properties:
-                        type:
-                          type: string
-                          title: 'The Type of Endpoint Called '
-                          example: phone
-                        number:
-                          type: string
-                          title: 'The number Of the endpoint called '
-                          example: '447700900000'
+                    $ref: '#/components/schemas/fields/to'
                   from:
-                    type: object
-                    properties:
-                      type:
-                        type: string
-                        title: 'The Type of Endpoint that made the call '
-                        example: phone
-                      number:
-                        type: string
-                        title: 'The Number that made the call '
-                        example: '447700900001'
+                    $ref: '#/components/schemas/fields/from'
                   status:
-                    type: string
-                    title: 'The State of the call '
-                    example: completed
+                    $ref: '#/components/schemas/fields/status'
                   direction:
-                    type: string
-                    title: 'The Direction of the Call '
-                    example: outbound
+                    $ref: '#/components/schemas/fields/direction'
                   rate:
-                    type: string
-                    title: The Price per minute of the called destination
-                    example: '0.39'
+                    $ref: '#/components/schemas/fields/rate'
                   price:
-                    type: string
-                    title: 'The total price of the call '
-                    example: '23.40'
+                    $ref: '#/components/schemas/fields/price'
                   duration:
-                    type: string
-                    title: 'The Duration of the call '
-                    example: '60'
+                    $ref: '#/components/schemas/fields/duration'
                   start_time:
-                    type: string
-                    format: timestamp
-                    title: 'The Start Time of the call '
-                    example: '2015-02-04T22:45:00Z'
+                    $ref: '#/components/schemas/fields/start_time'
                   end_time:
-                    type: string
-                    format: timestamp
-                    title: The end time of the call
-                    example: '2015-02-04T23:45:00Z'
+                    $ref: '#/components/schemas/fields/end_time'
                   network:
-                    type: string
-                    title: 'The Network ID of the destination '
-                    example: '65512'
+                    $ref: '#/components/schemas/fields/network'
     put:
       security:
       - bearerAuth: []
@@ -493,13 +396,11 @@ paths:
                 type: object
                 properties:
                   message:
+                    description: Description of the action taken
                     type: string
                     example: Stream started
                   uuid:
-                    type: string
-                    example: 63f61863-4a51-4f6b-86e1-46edebcf9356
-                    format: uuid
-                    title: The UUID of this request
+                    $ref: '#/components/schemas/fields/uuid'
     delete:
       security:
       - bearerAuth: []
@@ -516,13 +417,11 @@ paths:
                 type: object
                 properties:
                   message:
+                    description: Description of the action taken
                     type: string
                     example: Stream stopped
                   uuid:
-                    type: string
-                    example: 63f61863-4a51-4f6b-86e1-46edebcf9356
-                    format: uuid
-                    title: The UUID of this request
+                    $ref: '#/components/schemas/fields/uuid'
   "/calls/{uuid}/talk":
     parameters:
     - in: path
@@ -567,13 +466,11 @@ paths:
                 type: object
                 properties:
                   message:
+                    description: Description of the action taken
                     type: string
                     example: Talk started
                   uuid:
-                    type: string
-                    example: 63f61863-4a51-4f6b-86e1-46edebcf9356
-                    format: uuid
-                    title: The UUID of this request
+                    $ref: '#/components/schemas/fields/uuid'
     delete:
       security:
       - bearerAuth: []
@@ -590,13 +487,11 @@ paths:
                 type: object
                 properties:
                   message:
+                    description: Description of the action taken
                     type: string
                     example: Talk stopped
                   uuid:
-                    type: string
-                    example: 63f61863-4a51-4f6b-86e1-46edebcf9356
-                    format: uuid
-                    title: The UUID of this request
+                    $ref: '#/components/schemas/fields/uuid'
   "/calls/{uuid}/dtmf":
     parameters:
     - in: path
@@ -633,13 +528,11 @@ paths:
                 type: object
                 properties:
                   message:
+                    description: Description of the action taken
                     type: string
                     example: DTMF sent
                   uuid:
-                    type: string
-                    example: 63f61863-4a51-4f6b-86e1-46edebcf9356
-                    format: uuid
-                    title: The UUID of this request
+                    $ref: '#/components/schemas/fields/uuid'
 components:
   securitySchemes:
     bearerAuth:
@@ -647,6 +540,99 @@ components:
       scheme: bearer
       bearerFormat: JWT
   schemas:
+    fields:
+      network:
+        description: >-
+            The Mobile Country Code Mobile Network Code 
+            ([MCCMNC](https://en.wikipedia.org/wiki/Mobile_country_code)) for
+            the carrier network used to make this call.
+        type: string
+        title: 'The Network ID of the destination '
+        example: '65512'
+      start_time:
+        description: 'The time the call started in the following format: `YYYY-MM-DD HH:MM:SS`. For example, `2020-01-01 12:00:00`.'
+        type: string
+        format: timestamp
+        title: 'The Start Time of the call '
+        example: '2020-01-01 12:00:00'
+      end_time:
+        description: 'The time the call started in the following format: `YYYY-MM-DD HH:MM:SS`. For example, `2020-01-01 12:00:00`. This is only sent if `status` is `completed`.'
+        type: string
+        format: timestamp
+        title: 'The End Time of the call '
+        example: '2020-01-01 12:00:00'
+      duration:
+        description: The time elapsed for the call to take place in seconds. This is only sent if `status` is `completed`.
+        type: string
+        title: 'The Duration of the call '
+        example: '60'
+      price:
+        description: The total price charged for this call. This is only sent if `status` is `completed`.
+        type: string
+        title: 'The total price of the call '
+        example: '23.40'
+      rate:
+        description: The price per minute for this call. This is only sent if `status` is `completed`.
+        type: string
+        title: The Price per minute of the called destination
+        example: '0.39'
+      direction:
+       type: string
+       description: Possible values are `outbound` or `inbound`
+       example: outbound
+       enum:
+       - outbound
+       - inbound
+      uuid:
+        type: string
+        format: uuid
+        title: The UUID of the Call
+        example: 63f61863-4a51-4f6b-86e1-46edebcf9356
+        description: >-
+            The unique identifier for this call leg. The UUID is created when
+            your call request is accepted by Nexmo. You use the UUID in all
+            requests for individual live calls
+      conversation_uuid:
+        type: string
+        format: uuid
+        title: The UUID of the Conversation
+        example: CON-f972836a-550f-45fa-956c-12a2ab5b7d22
+        description: The unique identifier for the conversation this call leg is part of.
+      from:
+        type: array
+        description: The endpoint you called from. Possible values are the same as `to`.
+        title: The number or address that has been called
+        items:
+            type: object
+            properties:
+              type:
+                type: string
+                title: The type of Endpoint that made the call
+                example: phone
+              number:
+                type: string
+                title: The number that made the call
+                example: '447700900001'
+      to:
+        type: array
+        description: The single or mixed collection of endpoint types you connected to
+        title: The number or address to call
+        items:
+            type: object
+            properties:
+              type:
+                type: string
+                title: The Type of Endpoint Called
+                example: phone
+              number:
+                type: string
+                title: The number of the endpoint called
+                example: '447700900000'
+      status:
+        type: string
+        title: The State of the call
+        example: started
+        description: The status of the call. [See possible values](/voice/voice-api/guides/call-flow#events)
     endpoints:
       type: object
       properties:
@@ -740,11 +726,9 @@ components:
           format: uuid
           example: CON-171b3991-49b0-4dfa-badd-2bc6e68b57b4
         to:
-          description: The number or address that has been called
-          type: string
+          $ref: '#/components/schemas/fields/from'
         from:
-          description: The number or address that is calling
-          type: string
+          $ref: '#/components/schemas/fields/from'
         uuid:
           description: The UUID of the call leg that the event relates to
           type: string
@@ -756,6 +740,7 @@ components:
           example: 2018-01-12T15:01:55.315Z
         status:
           type: string
+          example: started
           enum:
           - started
           - ringing

--- a/app/assets/stylesheets/objects/_collapsible.scss
+++ b/app/assets/stylesheets/objects/_collapsible.scss
@@ -27,3 +27,8 @@
   margin-left: 5px;
   margin-bottom: $spacing;
 }
+
+.collapsible-no-indent {
+  padding-left: 0;
+  border-left: 0;
+}

--- a/app/views/open_api/_endpoint.html.erb
+++ b/app/views/open_api/_endpoint.html.erb
@@ -61,6 +61,8 @@
       <% end %>
 
       <%= render 'parameter_groups', endpoint: endpoint %>
+      <%= render 'response_descriptions', endpoint: endpoint %>
+
     </div>
   </div>
 

--- a/app/views/open_api/_response_descriptions.html.erb
+++ b/app/views/open_api/_response_descriptions.html.erb
@@ -22,6 +22,7 @@
                 <% if response.exhibits_one_of_multiple_schemas?(format) %>
                     <% response.split_schemas(format).each_with_index do |schema, index| %>
                         <% schema['properties'].each do |key, value| %>
+                            <% next if key == '_links' %>
                             <li>
                                 <div class="table-list-columns">
                                     <div class="table-list-column" flex="2"><b><%= key %></b></div>
@@ -33,10 +34,16 @@
                 <% else %>
                     <% schema = response.schema(format) %>
                     <% schema['properties'].each do |key, value| %>
+                        <% next if key == '_links' %>
+                        <%
+                            desc = ''
+                            desc = value['title'].render_markdown if value['title']
+                            desc = value['description'].render_markdown if value['description']
+                        %>
                         <li>
                             <div class="table-list-columns">
                                 <div class="table-list-column" flex="2"><b><%= key %></b></div>
-                                <div class="table-list-column" flex="4"><%= value['description'] ? value['description'].render_markdown : '' %></div>
+                                <div class="table-list-column" flex="4"><%= desc %></div>
                             </div>
                         </li>
                     <% end %>

--- a/app/views/open_api/_response_descriptions.html.erb
+++ b/app/views/open_api/_response_descriptions.html.erb
@@ -23,6 +23,7 @@
                     <% response.split_schemas(format).each_with_index do |schema, index| %>
                         <% schema['properties'].each do |key, value| %>
                             <% next if key == '_links' %>
+                            <% next if value['x-skip-response-description'] %>
                             <li>
                                 <div class="table-list-columns">
                                     <div class="table-list-column" flex="2"><b><%= key %></b></div>
@@ -35,6 +36,7 @@
                     <% schema = response.schema(format) %>
                     <% schema['properties'].each do |key, value| %>
                         <% next if key == '_links' %>
+                        <% next if value['x-skip-response-description'] %>
                         <%
                             desc = ''
                             desc = value['title'].render_markdown if value['title']

--- a/app/views/open_api/_response_descriptions.html.erb
+++ b/app/views/open_api/_response_descriptions.html.erb
@@ -1,0 +1,49 @@
+<% endpoint.responses.each do |response| %>
+    <% next unless response.success? %>
+    <% next if response.code.to_i == 204 %>
+    <% id = SecureRandom.hex %>
+    <p class="collapsible">
+    <a class="js-collapsible no-indent" data-collapsible-id="<%= id %>">
+        View response field descriptions
+    </a>
+    </p>
+
+    <div id="<%= id %>" class="collapsible-content collapsible-no-indent" style="display: none;">
+        <h4>Response Fields</h4>
+        <ul class="table-list">
+            <li class="table-list-header">
+                <div class="table-list-columns">
+                    <div class="table-list-column" flex="2">Field</div>
+                    <div class="table-list-column" flex="4">Description</div>
+                </div>
+            </li>
+
+            <% response.formats.each_with_index do |format, index| %>
+                <% if response.exhibits_one_of_multiple_schemas?(format) %>
+                    <% response.split_schemas(format).each_with_index do |schema, index| %>
+                        <% schema['properties'].each do |key, value| %>
+                            <li>
+                                <div class="table-list-columns">
+                                    <div class="table-list-column" flex="2"><b><%= key %></b></div>
+                                    <div class="table-list-column" flex="4"><%= value['description'] ? value['description'].render_markdown : '' %></div>
+                                </div>
+                            </li>
+                        <% end %>
+                    <% end %>
+                <% else %>
+                    <% schema = response.schema(format) %>
+                    <% schema['properties'].each do |key, value| %>
+                        <li>
+                            <div class="table-list-columns">
+                                <div class="table-list-column" flex="2"><b><%= key %></b></div>
+                                <div class="table-list-column" flex="4"><%= value['description'] ? value['description'].render_markdown : '' %></div>
+                            </div>
+                        </li>
+                    <% end %>
+                <% end %>
+
+            <% end %>
+        </ul>
+    </div>
+
+<% end %>

--- a/app/views/open_api/_response_descriptions.html.erb
+++ b/app/views/open_api/_response_descriptions.html.erb
@@ -21,6 +21,7 @@
             <% response.formats.each_with_index do |format, index| %>
                 <% if response.exhibits_one_of_multiple_schemas?(format) %>
                     <% response.split_schemas(format).each_with_index do |schema, index| %>
+                        <% next unless schema['properties'] %>
                         <% schema['properties'].each do |key, value| %>
                             <% next if key == '_links' %>
                             <% next if value['x-skip-response-description'] %>


### PR DESCRIPTION
## Description

This PR adds a collapsible "View response field descriptions" link to all OAS documents that return a `2xx` response. The descriptions were either pre-existing or sourced from the pre-OAS documentation pages.