### PR TITLE
Add Link to Source for Code Example in Building Blocks

### DIFF
--- a/app/filters/building_block_filter.rb
+++ b/app/filters/building_block_filter.rb
@@ -20,7 +20,8 @@ class BuildingBlockFilter < Banzai::Filter
           dependency_html = generate_dependencies(lexer.tag, config['dependencies'])
       end
 
-      source_url = generate_source_url(config['code']['source'])
+      source_url = generate_source_url(config['code'])
+
       client_html = ""
       if highlighted_client_source
       id = SecureRandom.hex
@@ -219,10 +220,25 @@ HEREDOC
         HEREDOC
     end
 
-  def generate_source_url(source)
+  def generate_source_url(code)
     # Source example: .repos/nexmo-community/java-quickstart/ExampleClass.java
     # Direct link on GitHub is in form https://github.com/nexmo-community/java-quickstart/blob/master/ExampleClass.java
+    start_section = 'https://github.com'
+
     # Insert "blob/master" and strip ".repos"
-    "https://github.com/" + source.sub(".repos", "").sub(/-quickstart\//, "\\0blob/master/")
+    file_section = code['source'].sub('.repos', '').sub(/-quickstart\//, '\\0blob/master/')
+
+    # Line highlighting
+    line_section = ''
+    if code['from_line']
+      line_section += "#L#{code['from_line']}"
+      if code['to_line']
+        line_section += "-L#{code['to_line']}"
+      else
+        line_section += "-L#{File.read(code['source']).lines.count}"
+      end
+    end
+
+    start_section + file_section + line_section
   end
 end

--- a/app/filters/building_block_filter.rb
+++ b/app/filters/building_block_filter.rb
@@ -20,6 +20,7 @@ class BuildingBlockFilter < Banzai::Filter
           dependency_html = generate_dependencies(lexer.tag, config['dependencies'])
       end
 
+      source_url = generate_source_url(config['code']['source'])
       client_html = ""
       if highlighted_client_source
       id = SecureRandom.hex
@@ -41,6 +42,7 @@ class BuildingBlockFilter < Banzai::Filter
         <h2>Write the code</h2>
         <p>Add the following to <code>#{config['file_name']}</code>:</p>
         <pre class="highlight #{lexer.tag}"><code>#{highlighted_code_source}</code></pre>
+        <a href="#{source_url}">View full source</a>
       HEREDOC
 
       run_html = generate_run_command(config['run_command'], config['file_name'])
@@ -216,4 +218,11 @@ HEREDOC
         </div>
         HEREDOC
     end
+
+  def generate_source_url(source)
+    # Source example: .repos/nexmo-community/java-quickstart/ExampleClass.java
+    # Direct link on GitHub is in form https://github.com/nexmo-community/java-quickstart/blob/master/ExampleClass.java
+    # Insert "blob/master" and strip ".repos"
+    "https://github.com/" + source.sub(".repos", "").sub(/-quickstart\//, "\\0blob/master/")
+  end
 end


### PR DESCRIPTION
## Description

Added link generation to the building block filter which links to the underlying quickstart example that the source came from. This allows users to click and see the full working example in the quickstart repo from the building blocks.

The URL is formatted from the `.yml` file's source parameter and is modified to support GitHub's linking. Only impacts building blocks that are generated from config.

![image](https://user-images.githubusercontent.com/8314724/42764227-1a2223ae-88e3-11e8-8829-63f4dab8afd6.png)
