### PR TITLE
Fixing a broken link seen on SEMRush report

### DIFF
--- a/_documentation/voice/voice-api/guides/lex-connector.md
+++ b/_documentation/voice/voice-api/guides/lex-connector.md
@@ -13,7 +13,7 @@ Lex](https://aws.amazon.com/lex/) bot and then have an audio
 conversation with the bot.
 
 Lex Connector makes use of the [WebSockets
-feature](/concepts/guides/websockets) of Nexmo's Voice API. When a
+feature](/voice/voice-api/guides/websockets) of Nexmo's Voice API. When a
 call is established, the API makes a websocket connection to Lex
 Connector and streams the audio to and from the call in real-time.
 


### PR DESCRIPTION
## Description

Found that traffic to a broken link was coming from within our own site.  Fixed.
