### PR TITLE
Fixing broken link, probably from renamed building block

### DIFF
--- a/_documentation/voice/voice-api/overview.md
+++ b/_documentation/voice/voice-api/overview.md
@@ -78,7 +78,7 @@ application:
 * [Download a recording](/voice/voice-api/building-blocks/download-a-recording)
 * [Earmuff a call](/voice/voice-api/building-blocks/earmuff-a-call)
 * [Handle user input with DTMF](/voice/voice-api/building-blocks/handle-user-input-with-dtmf)
-* [Join multiple calls into a conversation](/voice/voice-api/building-blocks/join-multiple-calls-into-a-conversation)
+* [Connect callers to a conference](/voice/voice-api/building-blocks/connect-callers-into-a-conference)
 * [Make an outbound call](/voice/voice-api/building-blocks/make-an-outbound-call)
 * [Mute a call](/voice/voice-api/building-blocks/mute-a-call)
 * [Play an audio stream into a call](/voice/voice-api/building-blocks/play-an-audio-stream-into-a-call)


### PR DESCRIPTION
## Description

Broken link was pointing to `/voice/voice-api/building-blocks/join-multiple-calls-into-a-conversation` and I think we just renamed the building block without realising the link was also on the overview page.  Fixed.
