### PR TITLE
Add the GSM extended characters when we check if we need to send a message as unicode on the try-it-out page

### DIFF
--- a/app/javascript/packs/Concatenation.jsx
+++ b/app/javascript/packs/Concatenation.jsx
@@ -29,7 +29,6 @@ const safeCharacters = [
   '§', 'o', 'à', ' '
 ]
 
-// TODO: Need to realize that these characters do not require Unicode type, but do require two bytes per character.
 // These require two bytes per character: ESC followed by the character
 const extGSMChars = [
   '|', '^', '€', '{', '}', '[', ']', '~', '\\'
@@ -68,7 +67,7 @@ class Concatenation extends React.Component {
   }
 
   shouldEncodeAs16Bit() {
-    var remainder = difference(this.splitStringByCodePoint(), safeCharacters)
+    var remainder = difference(this.splitStringByCodePoint(), [...safeCharacters, ...extGSMChars])
     return remainder.length !== 0
   }
 


### PR DESCRIPTION
## Description

Fixes #725 - we weren't checking for the extended characters before deciding that everything except the safe characters must mean we need unicode.  This stops the unicode symbol from turning on if the extended characters are used.