### PR TITLE
Update GitHub Event to Pull Repo-Specific Updates

### DIFF
--- a/app/controllers/jobs_controller.rb
+++ b/app/controllers/jobs_controller.rb
@@ -11,7 +11,7 @@ class JobsController < ApplicationController
           "request": {
             "branch": 'master',
             "config": {
-              "script": 'bundle exec rake diff:execute',
+              "script": "bundle exec rake diff:execute #{params['repository']['full_name']}",
               "env": {
                 "SSH_KEY_REQUIRED": true,
               },

--- a/lib/tasks/diff.rake
+++ b/lib/tasks/diff.rake
@@ -5,7 +5,7 @@ namespace :diff do
     Rake::Task['diff:build:base'].invoke
 
     puts 'Updating repos'.colorize(:yellow)
-    Rake::Task['repos:pull'].invoke
+    Rake::Task['repos:pull'].invoke(ARGV[1] ? ARGV[1] : '')
 
     puts 'Building comparison'.colorize(:yellow)
     Rake::Task['diff:build:compare'].invoke


### PR DESCRIPTION
## Description

Currently the quickstart update job triggers a complete update of all quickstart repos by executing `rake repos:pull` without any arguments. This updates the job to trigger a repository-specific update via `rake repos:pull <repository>` where `<repository>` is taken from the push event sent by GitHub.

## Deploy Notes

No additional deploy notes.
