### PR TITLE
Tiny fix for a broken link in the new glossary

### DIFF
--- a/_documentation/concepts/guides/glossary.md
+++ b/_documentation/concepts/guides/glossary.md
@@ -461,7 +461,7 @@ Cloud numbers enabled to receive [SMS](#sms).
 
 ## SMS-Enabled Virtual Number
 
-See [SMS Cloud Numbers](sms-cloud-numbers).
+See [SMS Cloud Numbers](#sms-cloud-numbers).
 
 ## Supplier
 


### PR DESCRIPTION
## Description

Noticed that one of the glossary links was missing its `#` and directing to a 404.