### PR TITLE
Add tutorials_list filter

### DIFF
--- a/_documentation/verify/overview.md
+++ b/_documentation/verify/overview.md
@@ -28,8 +28,10 @@ TTS messages are read in the locale that matches the phone number. (For example,
 
 ## Tutorials
 
-* [Two-factor authentication for security and spam prevention](/tutorials/two-factor-authentication)
-* [Passwordless authentication](/tutorials/passwordless-authentication)
+```tutorials
+product: verify
+```
+
 
 ## Further Reading
 

--- a/_documentation/voice/voice-api/overview.md
+++ b/_documentation/voice/voice-api/overview.md
@@ -95,7 +95,9 @@ application:
 
 ## Tutorials
 
-* [Tutorials](/voice/voice-api/tutorials)
+```tutorials
+product: voice/voice-api
+```
 
 ## Reference
 

--- a/app/filters/tutorials_filter.rb
+++ b/app/filters/tutorials_filter.rb
@@ -4,7 +4,11 @@ class TutorialsFilter < Banzai::Filter
       config = YAML.safe_load($1)
       @product = config['product']
       @tutorials = Tutorial.by_product(@product)
-      erb = File.read("#{Rails.root}/app/views/tutorials/_index.html.erb")
+
+      # Default to plain layout, but allow people to override it
+      config['layout'] = 'list/plain' unless config['layout']
+
+      erb = File.read("#{Rails.root}/app/views/tutorials/#{config['layout']}.html.erb")
       html = ERB.new(erb).result(binding)
       "FREEZESTART#{Base64.urlsafe_encode64(html)}FREEZEEND"
     end

--- a/app/views/tutorials/list/plain.html.erb
+++ b/app/views/tutorials/list/plain.html.erb
@@ -1,0 +1,5 @@
+<ul>
+  <% @tutorials.each do |tutorial| %>
+    <li><a href="<%= tutorial.path %>"><%= tutorial.title %></a></li>
+  <% end %>
+</ul>


### PR DESCRIPTION
## Description

This previously existed and rendered large cards like on the tutorials
page. This PR changes the default to be a plain list as it was not used
anywhere, and updates the existing tutorial lists to use this filter

## Deploy Notes

N/A