### PR TITLE
Respect navigation weight for nested building block types

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -45,13 +45,21 @@ module ApplicationHelper
   end
 
   def sort_navigation(context)
+    # Sort top level
     context[:children].sort_by! do |item|
       sort_array = []
-      sort_array << (NAVIGATION_WEIGHT[normalised_title(item)] || 1000)
-      sort_array << (item[:is_file?] ? 1 : 0)
-      sort_array << (item[:is_file?] && document_meta(item[:path])['navigation_weight'] ? document_meta(item[:path])['navigation_weight'] : 1000)
+      sort_array << (item[:is_file?] ? 0 : 1) if context[:path].include? 'building-blocks' # Directories *always* go after single files for building blocks (priority 1 rather than 0). This even overrides config entries
+      sort_array << (NAVIGATION_WEIGHT[normalised_title(item)] || 1000) # If we have a config entry for this, use it. Otherwise put it at the end
+      sort_array << (item[:is_file?] ? 0 : 1) # If it's a file it gets higher priority than a directory
+      sort_array << (item[:is_file?] && document_meta(item[:path])['navigation_weight'] ? document_meta(item[:path])['navigation_weight'] : 1000) # Use the config entry if we have it. Otherwise it goes to the end
       sort_array
     end
+
+    # Sort children if needed
+    context[:children].each do |child|
+      sort_navigation(child) if child[:children]
+    end
+
     context
   end
 


### PR DESCRIPTION
## Description

NDP will happily render building block sub types, but it ignores `navigation_weight` for children of children. This PR fixes it and adds some comments explaining the

It also adds new behaviour - within building blocks files are _always_ higher priority than directories.

![screen shot 2018-08-22 at 14 33 05](https://user-images.githubusercontent.com/59130/44466670-c3d8ee80-a618-11e8-9716-bdd2507d3e43.png)


## Deploy Notes

N/A