### PR TITLE
Highlight unpublished jobs as pink in Nexmo Developer when not logged in

### DIFF
--- a/app/assets/stylesheets/objects/_box.scss
+++ b/app/assets/stylesheets/objects/_box.scss
@@ -26,3 +26,14 @@
     margin-bottom: $spacing;
   }
 }
+
+.box--pink {
+  background: #E6547B;
+  color: white;
+  h2 {
+    color: white;
+  }
+  small {
+    color: white;
+  }
+}

--- a/app/views/careers/show.html.erb
+++ b/app/views/careers/show.html.erb
@@ -2,6 +2,9 @@
   <h3>
     <i class="icon icon-<%= @career.icon %>"></i>
     <%= @career.title %>
+    <% unless @career.published %>
+      [Hidden]
+    <% end %>
   </h3>
   <p><%= @career.summary %></p>
   <i><%= @career.location %></i>

--- a/app/views/static/team.html.erb
+++ b/app/views/static/team.html.erb
@@ -46,10 +46,13 @@
     <div class="jobs">
       <% careers.each do |career| %>
         <div class="jobs__job">
-          <div class="box box--white">
+          <div class="box box--<%= career.published ? 'white' : 'pink' %>">
             <h2>
               <i class="icon icon--large icon-<%= career.icon %>"></i><br><br>
               <%= career.title %>
+              <% unless career.published %>
+                  [Hidden]
+              <% end %>
               <br><br><i><small class="subtle"><%= career.location %></small></i>
             </h2>
             <div class="left spacious">


### PR DESCRIPTION
## Description

@leggetter was wondering why some jobs were showing up on NDP and he realised it's because he's logged in. This PR adds visual feedback that a role has not been published yet

### On the team page

![screen shot 2018-08-23 at 13 52 58](https://user-images.githubusercontent.com/59130/44526456-fd266280-a6db-11e8-880c-fdb33f55edda.png)

### On the individual post page

![screen shot 2018-08-23 at 13 53 20](https://user-images.githubusercontent.com/59130/44526451-fa2b7200-a6db-11e8-963a-9228c3aab2fe.png)

## Deploy Notes

N/A