### PR TITLE
Concepts filter

### DIFF
--- a/_documentation/voice/voice-api/guides/call-flow.md
+++ b/_documentation/voice/voice-api/guides/call-flow.md
@@ -1,5 +1,6 @@
 ---
 title: Call Flow
+description: The various stages of a call and how they interact.
 navigation_weight: 1
 ---
 

--- a/_documentation/voice/voice-api/guides/dtmf.md
+++ b/_documentation/voice/voice-api/guides/dtmf.md
@@ -1,5 +1,6 @@
 ---
 title: DTMF
+description: Capture user input by detecting DTMF tones (button presses) during a call.
 navigation_weight: 6
 ---
 

--- a/_documentation/voice/voice-api/guides/endpoints.md
+++ b/_documentation/voice/voice-api/guides/endpoints.md
@@ -1,5 +1,6 @@
 ---
 title: Endpoints
+description: When connecting a call, you can connect to another phone number, a `sip` endpoint or a `websocket`. These are known as endpoints.
 navigation_weight: 5
 ---
 

--- a/_documentation/voice/voice-api/guides/legs-conversations.md
+++ b/_documentation/voice/voice-api/guides/legs-conversations.md
@@ -1,5 +1,6 @@
 ---
 title: Legs and Conversations
+description: When a phone call is made or received by Nexmo it is added to a conversation. A single conversation contains one or more phone calls (sometimes referred to as legs).
 navigation_weight: 2
 ---
 

--- a/_documentation/voice/voice-api/guides/lex-connector.md
+++ b/_documentation/voice/voice-api/guides/lex-connector.md
@@ -1,7 +1,7 @@
 ---
 title: Amazon Lex Connector
+description: You can use the Lex Connector to connect a Nexmo voice call to an [AWS Lex](https://aws.amazon.com/lex/) bot and then have an audio conversation with the bot.
 navigation_weight: 8
-
 ---
 
 # Connecting voice calls to Amazon Lex bots

--- a/_documentation/voice/voice-api/guides/ncco.md
+++ b/_documentation/voice/voice-api/guides/ncco.md
@@ -1,7 +1,7 @@
 ---
 title: Nexmo Call Control Objects
 navigation_weight: 2
-description: The Nexmo Call Control Objects used to manage your Voice API calls.
+description: To tell Nexmo how to handle a phone call, you must provide Nexmo an Nexmo Call Control Objects (NCCO) when a call is placed or answered. There are various actions available, such as `talk`, `input` and `record`.
 ---
 
 # Nexmo Call Control Objects

--- a/_documentation/voice/voice-api/guides/numbers.md
+++ b/_documentation/voice/voice-api/guides/numbers.md
@@ -1,6 +1,6 @@
 ---
 title: Numbers
-description: The key concepts of using phone numbers in the Nexmo voice API
+description: Numbers are a key part of using the Nexmo Voice API. This guide covers number formatting, outgoing caller IDs and incoming call numbers.
 navigation_weight: 2
 ---
 

--- a/_documentation/voice/voice-api/guides/recording.md
+++ b/_documentation/voice/voice-api/guides/recording.md
@@ -1,5 +1,6 @@
 ---
 title: Recording
+description: Recording audio input from a caller or recording the conversation between two callers.
 navigation_weight: 4
 ---
 

--- a/_documentation/voice/voice-api/guides/text-to-speech.md
+++ b/_documentation/voice/voice-api/guides/text-to-speech.md
@@ -1,5 +1,6 @@
 ---
 title: Text to Speech
+description: Using our Text-To-Speech engine, you can play machine-generated speech to your callers
 navigation_weight: 3
 ---
 

--- a/_documentation/voice/voice-api/guides/troubleshooting.md
+++ b/_documentation/voice/voice-api/guides/troubleshooting.md
@@ -1,6 +1,7 @@
 ---
 title: Troubleshooting
 navigation_weight: 9
+ignore_in_list: true
 ---
 
 # Troubleshooting

--- a/_documentation/voice/voice-api/guides/websockets.md
+++ b/_documentation/voice/voice-api/guides/websockets.md
@@ -1,5 +1,6 @@
 ---
 title: Websockets
+description: You can connect the audio of a call to a websocket to work with it in real time.
 navigation_weight: 7
 ---
 

--- a/_documentation/voice/voice-api/overview.md
+++ b/_documentation/voice/voice-api/overview.md
@@ -60,16 +60,10 @@ application:
 
 ## Guides
 
-* [Call Flow](/voice/voice-api/guides/call-flow): The various stages of a call and how they interact.
-* [Legs & Conversations](/voice/voice-api/guides/legs-conversations): When a phone call is made or received by Nexmo it is added to a conversation. A single conversation contains one or more phone calls (sometimes referred to as legs).
-* [DTMF](/voice/voice-api/guides/dtmf): Capture user input by detecting DTMF tones (button presses) during a call.
-* [Endpoints](/voice/voice-api/guides/endpoints): When connecting a call, you can connect to another phone number, a `sip` endpoint or a `websocket`. These are known as endpoints.
-* [Lex connector](/voice/voice-api/guides/lex-connector): You can use the Lex Connector to connect a Nexmo voice call to an [AWS Lex](https://aws.amazon.com/lex/) bot and then have an audio conversation with the bot.
-* [NCCO](/voice/voice-api/guides/ncco): To tell Nexmo how to handle a phone call, you must provide Nexmo an Nexmo Call Control Objects (NCCO) when a call is placed or answered. There are various actions available, such as `talk`, `input` and `record`.
-* [Numbers](/voice/voice-api/guides/numbers): Numbers are a key part of using the Nexmo voice API. This guide covers number formatting, outgoing caller IDs and incoming call numbers.
-* [Recording](/voice/voice-api/guides/recording): Recording audio input from a caller or recording the conversation between two callers.
-* [Text to Speech](/voice/voice-api/guides/text-to-speech): Using our Text-To-Speech engine, you can play machine-generated speech to your callers
-* [Websockets](/voice/voice-api/guides/websockets): You can connect the audio of a call to a websocket to work with it in real time.
+```concept_list
+product: voice/voice-api
+```
+
 
 ## Building Blocks
 

--- a/app/filters/concept_list_filter.rb
+++ b/app/filters/concept_list_filter.rb
@@ -2,8 +2,12 @@ class ConceptListFilter < Banzai::Filter
   def call(input)
     input.gsub(/```concept_list(.+?)```/m) do |_s|
       config = YAML.safe_load($1)
-      @product = config['product']
-      @concepts = Concept.by_product(@product)
+      if config['product']
+        @product = config['product']
+        @concepts = Concept.by_product(@product)
+      elsif config['concepts']
+        @concepts = Concept.by_name(config['concepts'])
+      end
       erb = File.read("#{Rails.root}/app/views/concepts/list/plain.html.erb")
       html = ERB.new(erb).result(binding)
       "FREEZESTART#{Base64.urlsafe_encode64(html)}FREEZEEND"

--- a/app/filters/concept_list_filter.rb
+++ b/app/filters/concept_list_filter.rb
@@ -1,0 +1,12 @@
+class ConceptListFilter < Banzai::Filter
+  def call(input)
+    input.gsub(/```concept_list(.+?)```/m) do |_s|
+      config = YAML.safe_load($1)
+      @product = config['product']
+      @concepts = Concept.by_product(@product)
+      erb = File.read("#{Rails.root}/app/views/concepts/list/plain.html.erb")
+      html = ERB.new(erb).result(binding)
+      "FREEZESTART#{Base64.urlsafe_encode64(html)}FREEZEEND"
+    end
+  end
+end

--- a/app/models/concept.rb
+++ b/app/models/concept.rb
@@ -1,0 +1,55 @@
+class Concept
+  include ActiveModel::Model
+  attr_accessor :title, :product, :description, :navigation_weight, :document_path, :url
+
+  def self.by_product(product)
+    all.select do |block|
+      block.product == product
+    end
+  end
+
+  def self.all
+    blocks = files.map do |document_path|
+      document = File.read(document_path)
+      product = extract_product(document_path)
+
+      frontmatter = YAML.safe_load(document)
+
+      Concept.new({
+        title: frontmatter['title'],
+        description: frontmatter['description'],
+        navigation_weight: frontmatter['navigation_weight'] || 999,
+        product: product,
+        document_path: document_path,
+        url: generate_url(document_path),
+      })
+    end
+
+    blocks.sort_by(&:navigation_weight)
+  end
+
+  def self.generate_url(path)
+    '/' + path.gsub("#{origin}/", '').gsub('.md', '')
+  end
+
+  def self.extract_product(path)
+    # Remove the prefix
+    path = path.gsub!("#{origin}/", '')
+
+    # Each file is in the form building-blocks/<title>.md, so let's remove the last two segments
+    parts = path.split('/')
+    parts = parts[0...-2]
+
+    # What's left once we remove the start and end of the path is our product name. This could be any number
+    # of parts, but it's generally 1-2
+    parts.join('/')
+  end
+
+  def self.files
+    Dir.glob("#{origin}/**/guides/**/*.md")
+  end
+
+  def self.origin
+    "#{Rails.root}/_documentation"
+  end
+end

--- a/app/models/concept.rb
+++ b/app/models/concept.rb
@@ -1,6 +1,6 @@
 class Concept
   include ActiveModel::Model
-  attr_accessor :title, :product, :description, :navigation_weight, :document_path, :url
+  attr_accessor :title, :product, :description, :navigation_weight, :document_path, :url, :ignore_in_list
 
   def self.by_product(product)
     all.select do |block|
@@ -19,6 +19,7 @@ class Concept
         title: frontmatter['title'],
         description: frontmatter['description'],
         navigation_weight: frontmatter['navigation_weight'] || 999,
+        ignore_in_list: frontmatter['ignore_in_list'],
         product: product,
         document_path: document_path,
         url: generate_url(document_path),
@@ -36,7 +37,7 @@ class Concept
     # Remove the prefix
     path = path.gsub!("#{origin}/", '')
 
-    # Each file is in the form building-blocks/<title>.md, so let's remove the last two segments
+    # Each file is in the form guides/<title>.md, so let's remove the last two segments
     parts = path.split('/')
     parts = parts[0...-2]
 

--- a/app/models/concept.rb
+++ b/app/models/concept.rb
@@ -2,10 +2,26 @@ class Concept
   include ActiveModel::Model
   attr_accessor :title, :product, :description, :navigation_weight, :document_path, :url, :ignore_in_list
 
+  def self.by_name(names)
+    matches = all.select do |block|
+      concept = "#{block.product}/#{block.filename}"
+      match = names.include?(concept)
+      names.delete(concept) if match
+      match
+    end
+
+    raise "Could not find concepts: #{names.join(', ')}" unless names.empty?
+    matches
+  end
+
   def self.by_product(product)
     all.select do |block|
       block.product == product
     end
+  end
+
+  def filename
+    Pathname(document_path).basename.to_s.gsub('.md', '')
   end
 
   def self.all

--- a/app/pipelines/markdown_pipeline.rb
+++ b/app/pipelines/markdown_pipeline.rb
@@ -25,6 +25,7 @@ class MarkdownPipeline < Banzai::Pipeline
       TechioFilter,
       TutorialsFilter,
       BuildingBlockListFilter,
+      ConceptListFilter,
       LanguageFilter,
       ColumnsFilter,
       MarkdownFilter,

--- a/app/views/concepts/list/plain.html.erb
+++ b/app/views/concepts/list/plain.html.erb
@@ -1,6 +1,6 @@
 <ul>
   <% @concepts.each do |concept| %>
     <% next if concept.ignore_in_list %>
-    <li><a href="<%= concept.url %>"><%= concept.title %></a>: <%= concept.description.render_markdown.gsub(%r{^<p>},'').gsub(%r{^</p>}, '').strip %></li>
+    <li><a href="<%= concept.url %>"><%= concept.title %></a><% if concept.description %>: <%= concept.description.render_markdown.gsub(%r{^<p>},'').gsub(%r{^</p>}, '').strip %><% end %></li>
   <% end %>
 </ul>

--- a/app/views/concepts/list/plain.html.erb
+++ b/app/views/concepts/list/plain.html.erb
@@ -1,0 +1,6 @@
+<ul>
+  <% @concepts.each do |concept| %>
+    <% next if concept.ignore_in_list %>
+    <li><a href="<%= concept.url %>"><%= concept.title %></a>: <%= concept.description.render_markdown.gsub(%r{^<p>},'').gsub(%r{^</p>}, '').strip %></li>
+  <% end %>
+</ul>

--- a/app/views/contribute/guides/markdown-guide.md
+++ b/app/views/contribute/guides/markdown-guide.md
@@ -250,7 +250,7 @@ This produces the following output:
 
 ## Dynamic content
 
-You can use sytax such as:
+You can use syntax such as:
 
 ````
 Welcome to [~dynamic_content_example~]
@@ -259,3 +259,37 @@ Welcome to [~dynamic_content_example~]
 This will render as:
 
 Welcome to [~dynamic_content_example~]
+
+## Concept list (custom plugin)
+
+If you need to produce a list of concepts (also known as guides) on a page, you can specify a product and have it render an unstyled `<ul>`
+
+````
+```concept_list
+product: voice/voice-api
+```
+````
+
+This produces the following output:
+
+```concept_list
+product: voice/voice-api
+```
+
+Alternatively, you can specify the concepts to list manually if you need to show a subset of concepts, or concepts from multiple different products:
+
+````
+```concept_list
+concepts: 
+  - voice/voice-api/call-flow
+  - messaging/sms/delivery-receipts
+```
+````
+
+This produces the following output:
+
+```concept_list
+concepts: 
+  - voice/voice-api/call-flow
+  - messaging/sms/delivery-receipts
+```

--- a/spec/models/concept_spec.rb
+++ b/spec/models/concept_spec.rb
@@ -19,6 +19,17 @@ RSpec.describe Concept, type: :model do
     end
   end
 
+  describe '#by_name' do
+    it 'shows a single match' do
+      stub_available_concepts
+      expect(Concept.by_name(['voice/voice-api/pstn-update'])).to have(1).items
+    end
+    it 'shows multiple matches' do
+      stub_available_concepts
+      expect(Concept.by_name(['voice/voice-api/pstn-update', 'messaging/sms/shortcodes'])).to have(2).items
+    end
+  end
+
   describe '#by_product' do
     it 'shows only sms' do
       stub_available_concepts
@@ -44,17 +55,24 @@ RSpec.describe Concept, type: :model do
     end
   end
 
+  describe '#filename' do
+    it 'returns the correct filename' do
+      stub_available_concepts
+      expect(Concept.all.first.filename).to eq('pstn-update')
+    end
+  end
+
   describe '.instance' do
     it 'has the expected accessors' do
       stub_available_concepts
 
       block = Concept.all.first
-      expect(block.title).to eq('PSTN')
+      expect(block.title).to eq('PSTN Update')
       expect(block.description).to eq('Introduction to PSTN')
       expect(block.navigation_weight).to eq(1)
       expect(block.product).to eq('voice/voice-api')
-      expect(block.document_path).to eq('voice/voice-api/guides/pstn.md')
-      expect(block.url).to eq('/voice/voice-api/guides/pstn')
+      expect(block.document_path).to eq('voice/voice-api/guides/pstn-update.md')
+      expect(block.url).to eq('/voice/voice-api/guides/pstn-update')
       expect(block.ignore_in_list).to eq(true)
     end
   end
@@ -65,7 +83,7 @@ def stub_available_concepts
 
   i = 0
   {
-    'PSTN' => { 'product' => 'voice/voice-api', 'description' => 'Introduction to PSTN', 'ignore_in_list' => true },
+    'PSTN Update' => { 'product' => 'voice/voice-api', 'description' => 'Introduction to PSTN', 'ignore_in_list' => true },
     'Shortcodes' => { 'product' => 'messaging/sms', 'description' => 'You can use shortcodes whilst in the US' },
     'Demo' => { 'product' => 'voice/voice-api', 'description' => 'Demo Topic' },
   }.each do |title, details|

--- a/spec/models/concept_spec.rb
+++ b/spec/models/concept_spec.rb
@@ -1,0 +1,87 @@
+require 'rails_helper'
+
+RSpec.describe Concept, type: :model do
+  describe '#extract_product' do
+    it 'extracts voice successfully' do
+      allow(Concept).to receive(:origin).and_return('/path/to/_documentation')
+      expect(Concept.extract_product("#{Concept.origin}/voice/voice-api/guides/demo.md")).to eq('voice/voice-api')
+    end
+
+    it 'extracts sms successfully' do
+      allow(Concept).to receive(:origin).and_return('/path/to/_documentation')
+      expect(Concept.extract_product("#{Concept.origin}/messaging/sms/guides/demo.md")).to eq('messaging/sms')
+    end
+  end
+  describe '#all' do
+    it 'returns all building blocks' do
+      stub_available_concepts
+      expect(Concept.all).to have(3).items
+    end
+  end
+
+  describe '#by_product' do
+    it 'shows only sms' do
+      stub_available_concepts
+      expect(Concept.by_product('messaging/sms')).to have(1).items
+    end
+    it 'shows only voice' do
+      stub_available_concepts
+      expect(Concept.by_product('voice/voice-api')).to have(2).items
+    end
+  end
+
+  describe '#files' do
+    it 'has the correct glob pattern' do
+      allow(Concept).to receive(:origin).and_return('/path/to/_documentation')
+      expect(Dir).to receive(:glob).with('/path/to/_documentation/**/guides/**/*.md')
+      Concept.files
+    end
+  end
+
+  describe '#origin' do
+    it 'returns the correct origin' do
+      expect(Concept.origin).to eq("#{Rails.root}/_documentation")
+    end
+  end
+
+  describe '.instance' do
+    it 'has the expected accessors' do
+      stub_available_concepts
+
+      block = Concept.all.first
+      expect(block.title).to eq('PSTN')
+      expect(block.description).to eq('Introduction to PSTN')
+      expect(block.navigation_weight).to eq(1)
+      expect(block.product).to eq('voice/voice-api')
+      expect(block.document_path).to eq('voice/voice-api/guides/pstn.md')
+      expect(block.url).to eq('/voice/voice-api/guides/pstn')
+    end
+  end
+end
+
+def stub_available_concepts
+  paths = []
+
+  i = 0
+  {
+    'PSTN' => {'product' => 'voice/voice-api', 'description' => 'Introduction to PSTN'},
+    'Shortcodes' => {'product' => 'messaging/sms', 'description' => 'You can use shortcodes whilst in the US'},
+    'Demo' => {'product' => 'voice/voice-api', 'description' => 'Demo Topic'},
+  }.each do |title, details|
+    i += 1
+    slug = title.parameterize
+    path = "/path/to/_documentation/#{details['product']}/guides/#{slug}.md"
+    paths.push(path)
+
+    allow(File).to receive(:read).with(path) .and_return(
+      {
+        'title' => title,
+        'description' => details['description'],
+        'navigation_weight' => i,
+      }.to_yaml
+    )
+  end
+
+  allow(Concept).to receive(:origin).and_return('/path/to/_documentation')
+  allow(Concept).to receive(:files).and_return(paths)
+end

--- a/spec/models/concept_spec.rb
+++ b/spec/models/concept_spec.rb
@@ -55,6 +55,7 @@ RSpec.describe Concept, type: :model do
       expect(block.product).to eq('voice/voice-api')
       expect(block.document_path).to eq('voice/voice-api/guides/pstn.md')
       expect(block.url).to eq('/voice/voice-api/guides/pstn')
+      expect(block.ignore_in_list).to eq(true)
     end
   end
 end
@@ -64,9 +65,9 @@ def stub_available_concepts
 
   i = 0
   {
-    'PSTN' => {'product' => 'voice/voice-api', 'description' => 'Introduction to PSTN'},
-    'Shortcodes' => {'product' => 'messaging/sms', 'description' => 'You can use shortcodes whilst in the US'},
-    'Demo' => {'product' => 'voice/voice-api', 'description' => 'Demo Topic'},
+    'PSTN' => { 'product' => 'voice/voice-api', 'description' => 'Introduction to PSTN', 'ignore_in_list' => true },
+    'Shortcodes' => { 'product' => 'messaging/sms', 'description' => 'You can use shortcodes whilst in the US' },
+    'Demo' => { 'product' => 'voice/voice-api', 'description' => 'Demo Topic' },
   }.each do |title, details|
     i += 1
     slug = title.parameterize
@@ -78,6 +79,7 @@ def stub_available_concepts
         'title' => title,
         'description' => details['description'],
         'navigation_weight' => i,
+        'ignore_in_list' => details['ignore_in_list'] || false,
       }.to_yaml
     )
   end


### PR DESCRIPTION
## Description

Adds the ability to list building blocks automatically on any page

<pre><code>```concept_list
product: voice/voice-api
```
</code></pre>

The description is taken from `description` in the front matter of each markdown file. You can also set `ignore_in_list: true` on a file if you want it in the sidebar but not in the list rendered by the filter

![screen shot 2018-08-23 at 15 14 01](https://user-images.githubusercontent.com/59130/44530869-52b43c80-a6e7-11e8-87eb-b60156892c63.png)

If you want to mix and match concepts from various areas, you can do so by providing a list of concept products and names. This keeps styling consistent and reads the `description` as required

<pre><code>```concept_list
concepts: 
  - voice/voice-api/call-flow
  - messaging/sms/delivery-receipts
```
</code></pre>

![screen shot 2018-08-23 at 15 38 24](https://user-images.githubusercontent.com/59130/44532251-978da280-a6ea-11e8-9537-7931ea3b96f5.png)

## Deploy Notes

N/A