### PR TITLE
Fix pricing by country response examples

### DIFF
--- a/_examples/api/developer/account/pricing/per-country-pricing/JSON
+++ b/_examples/api/developer/account/pricing/per-country-pricing/JSON
@@ -1,14 +1,16 @@
 {
-  "country": "GB",
-  "name": "United Kingdom",
-  "prefix": "44",
-  "mt": "0.03330000",
+  "countryCode": "GB",
+  "countryDisplayName": "United Kingdom",
+  "countryName": "United Kingdom",
+  "currency": "EUR",
+  "defaultPrice": "0.03330000",
+  "dialingPrefix": "44",
   "networks": [
     {
-      "code": "12345",
-      "network": "Acme Telco",
-      "mtPrice": "0.03330000"
-    },
-  ],
-  "countryDisplayName": "United Kingdom"
+      "currency": "EUR",
+      "networkCode": "12345",
+      "networkName": "Acme Telco",
+      "price": "0.03330000"
+    }
+  ]
 }

--- a/_examples/api/developer/account/pricing/per-country-pricing/XML
+++ b/_examples/api/developer/account/pricing/per-country-pricing/XML
@@ -1,15 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <outbound-country-pricing>
-  <countryDisplayName>United Kingdom</countryDisplayName>
-  <country>GB</country>
-  <name>United Kingdom</name>
-  <prefix>44</prefix>
-  <mt>0.03330000</mt>
+  <country-code>GB</country-code>
+  <country-name>United Kingdom</country-name>
+  <dialing-prefix>44</dialing-prefix>
+  <default-price>0.03330000</default-price>
+  <currency>EUR</currency>
   <networks>
     <network>
-      <code>12345</code>
-      <name>Acme Telco</name>
-      <mtPrice>0.03330000</mtPrice>
+      <network-code>12345</network-code>
+      <network-name>Acme Telco</network-name>
+      <price>0.03330000</price>
     </network>
   </networks>
 </outbound-country-pricing>


### PR DESCRIPTION
The keys in the pricing by country [JSON/XML Response examples](https://developer.nexmo.com/api/developer/pricing#response) don't match what's returned by the API (and documented further down under [Keys and Values](https://developer.nexmo.com/api/developer/pricing#keys-and-values) and [Common elements in responses](https://developer.nexmo.com/api/developer/pricing#common-elements-in-responses)).

This pull request fixes the keys that are in the existing code samples, but there are some additional keys in the responses which could also be added.