### PR TITLE
Block copy stats

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,6 +25,10 @@ gem 'coffee-rails', '~> 4.2'
 
 # Use jquery as the JavaScript library
 gem 'jquery-rails'
+# Add clipboard for copying content
+gem 'clipboard-rails'
+# Icons!
+gem 'octicons_helper'
 # Turbolinks makes navigating your web application faster. Read more: https://github.com/turbolinks/turbolinks
 gem 'turbolinks', '~> 5'
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -95,6 +95,7 @@ GEM
     builder (3.2.3)
     byebug (9.0.6)
     chartkick (2.2.5)
+    clipboard-rails (1.7.1)
     coderay (1.1.2)
     coffee-rails (4.2.2)
       coffee-script (>= 2.2.0)
@@ -249,6 +250,11 @@ GEM
       guard-rspec (~> 4.7.3)
       json_schema (~> 0.15.0)
       nokogiri (~> 1.8.1)
+    octicons (8.0.0)
+      nokogiri (>= 1.6.3.1)
+    octicons_helper (8.0.0)
+      octicons (= 8.0.0)
+      rails
     octokit (4.7.0)
       sawyer (~> 0.8.0, >= 0.5.3)
     orm_adapter (0.5.0)
@@ -420,6 +426,7 @@ DEPENDENCIES
   bugsnag
   byebug
   chartkick (= 2.2.5)
+  clipboard-rails
   coffee-rails (~> 4.2)
   colorize
   crack (= 0.4.3)
@@ -442,6 +449,7 @@ DEPENDENCIES
   nexmo_api_specification (= 0.11.6)
   nokogiri (= 1.8.2)
   oas_parser (= 0.11.2)
+  octicons_helper
   octokit
   pg (~> 0.18)
   pry

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -15,3 +15,5 @@
 //= require turbolinks
 //= require smooth-scroll
 //= require jquery-scrolltofixed
+//= require clipboard
+

--- a/app/assets/stylesheets/_typography.scss
+++ b/app/assets/stylesheets/_typography.scss
@@ -189,7 +189,7 @@ a {
   margin-left: $spacing * 1.5;
 }
 
-pre.highlight {
+.highlight {
   background: $code-background;
   padding: $spacing;
   color: $white;

--- a/app/assets/stylesheets/nexmo.scss
+++ b/app/assets/stylesheets/nexmo.scss
@@ -75,6 +75,7 @@ $font-family: 'Averta', sans-serif;
 @import "objects/api-status";
 @import "objects/avatar";
 @import "objects/button";
+@import "objects/building-block";
 @import "objects/box";
 @import "objects/card";
 @import "objects/collapsible";

--- a/app/assets/stylesheets/objects/_building-block.scss
+++ b/app/assets/stylesheets/objects/_building-block.scss
@@ -1,0 +1,29 @@
+.copy-button {
+  background: $pink;
+  width: 140px;
+  height: 24px;
+  padding-top: 3px;
+  text-align: center;
+  clear: both;
+  position: absolute;
+  top: 0px;
+  right: 0px;
+  color: $white;
+  font-size: 0.8em;
+  cursor: pointer;
+  font-weight: bold;
+}
+
+.octicon {
+  display: inline-block;
+  vertical-align: text-top;
+  fill: $white;
+}
+
+.highlight {
+  position: relative;
+}
+
+div.highlight pre {
+  margin-top: 10px;
+}

--- a/app/assets/stylesheets/objects/_labels.scss
+++ b/app/assets/stylesheets/objects/_labels.scss
@@ -47,6 +47,11 @@
     margin-right: 5px;
   }
 
+  &--small {
+    font-size: 10px !important;
+    background: $pink;
+  }
+
   &--code {
     font-family: Consolas, monospace;
     font-size: 15px;

--- a/app/controllers/usage/building_block_controller.rb
+++ b/app/controllers/usage/building_block_controller.rb
@@ -7,6 +7,7 @@ module Usage
         language: params['language'],
         block: params['block'],
         action: params['event'],
+        section: params['section'],
         ip: request.remote_ip
       )
 

--- a/app/controllers/usage/building_block_controller.rb
+++ b/app/controllers/usage/building_block_controller.rb
@@ -1,0 +1,18 @@
+module Usage
+  class BuildingBlockController < ApplicationController
+    skip_before_action :verify_authenticity_token
+
+    def create
+      event = ::Usage::BuildingBlockEvent.new(
+        language: params['language'],
+        block: params['block'],
+        action: params['event'],
+        ip: request.remote_ip
+      )
+
+      event.save!
+
+      render json: event
+    end
+  end
+end

--- a/app/filters/building_block_filter.rb
+++ b/app/filters/building_block_filter.rb
@@ -8,6 +8,7 @@ class BuildingBlockFilter < Banzai::Filter
       @renderer = get_renderer(config['language'])
 
       lexer = CodeLanguageResolver.find(config['language']).lexer
+      lang = config['title'].delete('.')
 
       application_html = generate_application_block(config['application'])
 
@@ -34,7 +35,6 @@ class BuildingBlockFilter < Banzai::Filter
         client_html = ERB.new(erb).result(binding)
       end
 
-      lang = config['title'].delete('.')
       erb = File.read("#{Rails.root}/app/views/building_blocks/_write_code.html.erb")
       code_html = ERB.new(erb).result(binding)
 

--- a/app/filters/building_block_filter.rb
+++ b/app/filters/building_block_filter.rb
@@ -1,4 +1,6 @@
 class BuildingBlockFilter < Banzai::Filter
+  include OcticonsHelper
+
   def call(input)
     input.gsub(/```single_building_block(.+?)```/m) do |_s|
       config = YAML.safe_load($1)
@@ -32,6 +34,7 @@ class BuildingBlockFilter < Banzai::Filter
         client_html = ERB.new(erb).result(binding)
       end
 
+      lang = config['title'].delete('.')
       erb = File.read("#{Rails.root}/app/views/building_blocks/_write_code.html.erb")
       code_html = ERB.new(erb).result(binding)
 

--- a/app/filters/building_blocks_filter.rb
+++ b/app/filters/building_blocks_filter.rb
@@ -102,13 +102,13 @@ class BuildingBlocksFilter < Banzai::Filter
       content[:platform_key] = content['platform']
       content[:tab_title] = content['title']
 
-      application = ''
+      parent_config = ''
       if @config['application']
-        application = { 'application' => @config['application'] }.to_yaml.lines[1..-1].join
+        parent_config = { 'source' => @config['source'].gsub('_examples/', ''), 'application' => @config['application'] }.to_yaml.lines[1..-1].join
       end
       source = <<~HEREDOC
         ```single_building_block
-        #{source}#{application}
+        #{source}#{parent_config}
         ```
       HEREDOC
 

--- a/app/javascript/packs/BuildingBlockEvents.js
+++ b/app/javascript/packs/BuildingBlockEvents.js
@@ -53,12 +53,12 @@ export default () => {
         if (e.which === 3) { return; }
         let trigger = $(this);
 
-        let type = trigger.attr("data-type");
+        let section = trigger.attr("data-section");
 
         let params = {
             "language": trigger.attr("data-lang"),
             "block": trigger.attr("data-block"),
-            "section": type,
+            "section": section,
             "event": "source"
         };
 

--- a/app/javascript/packs/BuildingBlockEvents.js
+++ b/app/javascript/packs/BuildingBlockEvents.js
@@ -5,8 +5,7 @@ export default () => {
     // Track copy to clipboard usage
     var clipboard = new Clipboard('.copy-button',{
         text: function(trigger) {
-            const lang = $(trigger).attr("data-lang");
-            return $(".copy-to-clipboard." + lang).text();
+            return $(trigger).next().text();
         }
     });
 
@@ -16,11 +15,14 @@ export default () => {
         let params = {
             "language": trigger.attr("data-lang"),
             "block": trigger.attr("data-block"),
+            "section": trigger.attr("data-section"),
             "event": "copy"
         };
 
+        let key = params['language'] + params['section'];
+
         // We only want to track each copy once per page load
-        if (hasTriggeredCopyStat[params['language']]) { return true; }
+        if (hasTriggeredCopyStat[key]) { return true; }
 
         trigger.find('span').text('Copied');
 
@@ -30,7 +32,7 @@ export default () => {
                 return Promise.reject({ message: 'Bad response from server', response })
             })
             .then((payload) => {
-                hasTriggeredCopyStat[params['language']] = true;
+                hasTriggeredCopyStat[key] = true;
             })
     });
 
@@ -50,12 +52,13 @@ export default () => {
         let params = {
             "language": trigger.attr("data-lang"),
             "block": trigger.attr("data-block"),
-            "event": "source-" + type
+            "section": type,
+            "event": "source"
         };
 
-        hasTriggeredLinkStat[params['language']] = hasTriggeredLinkStat[params['language']] || {};
+        let key = params['language'] + params['section'];
 
-        if (hasTriggeredLinkStat[params['language']][type]) { return true; }
+        if (hasTriggeredLinkStat[key]) { return true; }
 
         fetch(createRequest(params))
             .then((response) => {
@@ -63,7 +66,7 @@ export default () => {
                 return Promise.reject({ message: 'Bad response from server', response })
             })
             .then((payload) => {
-                hasTriggeredLinkStat[params['language']][type] = true;
+                hasTriggeredLinkStat[key] = true;
             })
     });
 };

--- a/app/javascript/packs/BuildingBlockEvents.js
+++ b/app/javascript/packs/BuildingBlockEvents.js
@@ -34,6 +34,12 @@ export default () => {
             .then((payload) => {
                 hasTriggeredCopyStat[key] = true;
             })
+
+        // Can we point them to the dependencies too?
+        if (trigger.parent().hasClass("main-code")) {
+            trigger.parent().parent().find(".configure-dependencies").prepend("<span class='label label--small'>Don't forget me!</span>");
+        }
+
     });
 
 

--- a/app/javascript/packs/BuildingBlockEvents.js
+++ b/app/javascript/packs/BuildingBlockEvents.js
@@ -1,0 +1,80 @@
+export default () => {
+    let hasTriggeredCopyStat = {};
+    let hasTriggeredLinkStat = {};
+
+    // Track copy to clipboard usage
+    var clipboard = new Clipboard('.copy-button',{
+        text: function(trigger) {
+            const lang = $(trigger).attr("data-lang");
+            return $(".copy-to-clipboard." + lang).text();
+        }
+    });
+
+    clipboard.on('success', function(e) {
+        let trigger = $(e.trigger);
+
+        let params = {
+            "language": trigger.attr("data-lang"),
+            "block": trigger.attr("data-block"),
+            "event": "copy"
+        };
+
+        // We only want to track each copy once per page load
+        if (hasTriggeredCopyStat[params['language']]) { return true; }
+
+        trigger.find('span').text('Copied');
+
+        fetch(createRequest(params))
+            .then((response) => {
+                if (response.ok) { return response.json() }
+                return Promise.reject({ message: 'Bad response from server', response })
+            })
+            .then((payload) => {
+                hasTriggeredCopyStat[params['language']] = true;
+            })
+    });
+
+
+    clipboard.on('error', function(e) {
+        console.error('Action:', e.action);
+        console.error('Trigger:', e.trigger);
+    });
+
+    // Track source link usage
+    $(document).on('mousedown', '.source-link', function(e){
+        if (e.which === 3) { return; }
+        let trigger = $(this);
+
+        let type = trigger.attr("data-type");
+
+        let params = {
+            "language": trigger.attr("data-lang"),
+            "block": trigger.attr("data-block"),
+            "event": "source-" + type
+        };
+
+        hasTriggeredLinkStat[params['language']] = hasTriggeredLinkStat[params['language']] || {};
+
+        if (hasTriggeredLinkStat[params['language']][type]) { return true; }
+
+        fetch(createRequest(params))
+            .then((response) => {
+                if (response.ok) { return response.json() }
+                return Promise.reject({ message: 'Bad response from server', response })
+            })
+            .then((payload) => {
+                hasTriggeredLinkStat[params['language']][type] = true;
+            })
+    });
+};
+
+function createRequest(params) {
+    return new Request('/usage/building_block', {
+        method: 'POST',
+        credentials: 'same-origin',
+        body: JSON.stringify(params),
+        headers: {
+            'Content-Type': 'application/json'
+        }
+    });
+}

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -27,6 +27,7 @@ import Feedback from './Feedback'
 import Concatenation from './Concatenation'
 import APIStatus from './APIStatus'
 import Markdown from './Markdown'
+import BuildingBlockEvents from './BuildingBlockEvents'
 
 import {
   preventSamePage as turbolinksPreventSamePage,
@@ -48,6 +49,7 @@ let refresh = () => {
   new Format
   Modals()
   APIStatus()
+  BuildingBlockEvents()
 
   if (document.getElementById('SearchComponent')) {
     ReactDOM.render(<Search/>, document.getElementById('SearchComponent'))

--- a/app/models/usage.rb
+++ b/app/models/usage.rb
@@ -1,0 +1,5 @@
+module Usage
+  def self.table_name_prefix
+    'usage_'
+  end
+end

--- a/app/models/usage/building_block_event.rb
+++ b/app/models/usage/building_block_event.rb
@@ -1,0 +1,4 @@
+module Usage
+  class BuildingBlockEvent < ApplicationRecord
+  end
+end

--- a/app/views/building_blocks/_configure_client.html.erb
+++ b/app/views/building_blocks/_configure_client.html.erb
@@ -12,7 +12,7 @@
       </div>
       <pre><code class="copy-to-clipboard <%= config['title'] %>"><%= highlighted_client_source %></code></pre>
     </div>
-    <a class="source-link" data-type="config" data-lang="<%= lang %>" data-block="<%= config['source'] %>" href="<%= client_url %>">View full source</a>
+    <a class="source-link" data-section="configure" data-lang="<%= lang %>" data-block="<%= config['source'] %>" href="<%= client_url %>">View full source</a>
 </div>
 
 

--- a/app/views/building_blocks/_configure_client.html.erb
+++ b/app/views/building_blocks/_configure_client.html.erb
@@ -1,5 +1,5 @@
 <h3 class="collapsible">
-    <a class="js-collapsible" data-collapsible-id="<%= id %>">
+    <a class="js-collapsible configure-dependencies" data-collapsible-id="<%= id %>">
         Initialize your dependencies
     </a>
 </h3>

--- a/app/views/building_blocks/_configure_client.html.erb
+++ b/app/views/building_blocks/_configure_client.html.erb
@@ -6,7 +6,12 @@
 
 <div id="<%= id %>" class="collapsible-content" style="display: none;">
     <p>Create a file named <code><%= config['file_name'] %></code> and add the following code:</p>
-    <pre class="highlight bash"><code class="copy-to-clipboard <%= config['title'] %>"><%= highlighted_client_source %></code></pre>
+    <div class="highlight <%= lexer.tag %>">
+      <div class="copy-button" data-lang="<%= lang %>" data-block="<%= config['source'] %>" data-section="configure">
+        <%= octicon "clippy", :class => 'top left' %> <span>Copy to Clipboard</span>
+      </div>
+      <pre><code class="copy-to-clipboard <%= config['title'] %>"><%= highlighted_client_source %></code></pre>
+    </div>
     <a class="source-link" data-type="config" data-lang="<%= lang %>" data-block="<%= config['source'] %>" href="<%= client_url %>">View full source</a>
 </div>
 

--- a/app/views/building_blocks/_configure_client.html.erb
+++ b/app/views/building_blocks/_configure_client.html.erb
@@ -6,8 +6,8 @@
 
 <div id="<%= id %>" class="collapsible-content" style="display: none;">
     <p>Create a file named <code><%= config['file_name'] %></code> and add the following code:</p>
-    <pre class="highlight bash"><code><%= highlighted_client_source %></code></pre>
-    <a href="<%= client_url %>">View full source</a>
+    <pre class="highlight bash"><code class="copy-to-clipboard <%= config['title'] %>"><%= highlighted_client_source %></code></pre>
+    <a class="source-link" data-type="config" data-lang="<%= lang %>" data-block="<%= config['source'] %>" href="<%= client_url %>">View full source</a>
 </div>
 
 

--- a/app/views/building_blocks/_write_code.html.erb
+++ b/app/views/building_blocks/_write_code.html.erb
@@ -6,5 +6,5 @@
 </div>
 <pre><code><%= highlighted_code_source %></code></pre>
 </div>
-<a class="source-link" data-type="main" data-lang="<%= lang %>" data-block="<%= config['source'] %>" href="<%= source_url %>">View full source</a>
+<a class="source-link" data-section="code" data-lang="<%= lang %>" data-block="<%= config['source'] %>" href="<%= source_url %>">View full source</a>
 

--- a/app/views/building_blocks/_write_code.html.erb
+++ b/app/views/building_blocks/_write_code.html.erb
@@ -1,10 +1,10 @@
 <h2>Write the code</h2>
 <p>Add the following to <code><%= config['file_name'] %></code>:</p>
 <div class="highlight <%= lexer.tag %>">
-<div class="copy-button" data-lang="<%= lang %>" data-block="<%= config['source'] %>">
+<div class="copy-button" data-lang="<%= lang %>" data-block="<%= config['source'] %>" data-section="code">
   <%= octicon "clippy", :class => 'top left' %> <span>Copy to Clipboard</span>
 </div>
-<pre><code class="copy-to-clipboard <%= lang %>"><%= highlighted_code_source %></code></pre>
+<pre><code><%= highlighted_code_source %></code></pre>
 </div>
 <a class="source-link" data-type="main" data-lang="<%= lang %>" data-block="<%= config['source'] %>" href="<%= source_url %>">View full source</a>
 

--- a/app/views/building_blocks/_write_code.html.erb
+++ b/app/views/building_blocks/_write_code.html.erb
@@ -1,6 +1,6 @@
 <h2>Write the code</h2>
 <p>Add the following to <code><%= config['file_name'] %></code>:</p>
-<div class="highlight <%= lexer.tag %>">
+<div class="highlight <%= lexer.tag %> main-code">
 <div class="copy-button" data-lang="<%= lang %>" data-block="<%= config['source'] %>" data-section="code">
   <%= octicon "clippy", :class => 'top left' %> <span>Copy to Clipboard</span>
 </div>

--- a/app/views/building_blocks/_write_code.html.erb
+++ b/app/views/building_blocks/_write_code.html.erb
@@ -1,5 +1,10 @@
 <h2>Write the code</h2>
 <p>Add the following to <code><%= config['file_name'] %></code>:</p>
-<pre class="highlight <%= lexer.tag %>"><code><%= highlighted_code_source %></code></pre>
-<a href="<%= source_url %>">View full source</a>
+<div class="highlight <%= lexer.tag %>">
+<div class="copy-button" data-lang="<%= lang %>" data-block="<%= config['source'] %>">
+  <%= octicon "clippy", :class => 'top left' %> <span>Copy to Clipboard</span>
+</div>
+<pre><code class="copy-to-clipboard <%= lang %>"><%= highlighted_code_source %></code></pre>
+</div>
+<a class="source-link" data-type="main" data-lang="<%= lang %>" data-block="<%= config['source'] %>" href="<%= source_url %>">View full source</a>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,10 @@ Rails.application.routes.draw do
     resources :feedbacks
   end
 
+  namespace :usage do
+    resources :building_block
+  end
+
   namespace :admin_api, defaults: { format: 'json' } do
     resources :feedback, only: [:index]
   end

--- a/db/migrate/20180827133110_usage_building_block_events.rb
+++ b/db/migrate/20180827133110_usage_building_block_events.rb
@@ -3,6 +3,7 @@ class UsageBuildingBlockEvents < ActiveRecord::Migration[5.1]
     create_table :usage_building_block_events, id: :uuid do |t|
       t.string :language, null: false
       t.string :block, null: false
+      t.string :section, null: false
       t.string :action, null: false
       t.string :ip, null: false
       t.timestamps

--- a/db/migrate/20180827133110_usage_building_block_events.rb
+++ b/db/migrate/20180827133110_usage_building_block_events.rb
@@ -1,0 +1,15 @@
+class UsageBuildingBlockEvents < ActiveRecord::Migration[5.1]
+  def change
+    create_table :usage_building_block_events, id: :uuid do |t|
+      t.string :language, null: false
+      t.string :block, null: false
+      t.string :action, null: false
+      t.string :ip, null: false
+      t.timestamps
+    end
+    add_index :usage_building_block_events, :language
+    add_index :usage_building_block_events, :block
+    add_index :usage_building_block_events, :action
+    add_index :usage_building_block_events, :ip
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -125,6 +125,7 @@ ActiveRecord::Schema.define(version: 20180827133110) do
   create_table "usage_building_block_events", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "language", null: false
     t.string "block", null: false
+    t.string "section", null: false
     t.string "action", null: false
     t.string "ip", null: false
     t.datetime "created_at", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180404124814) do
+ActiveRecord::Schema.define(version: 20180827133110) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -120,6 +120,19 @@ ActiveRecord::Schema.define(version: 20180404124814) do
     t.datetime "updated_at", null: false
     t.boolean "published"
     t.index ["published"], name: "index_sessions_on_published"
+  end
+
+  create_table "usage_building_block_events", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.string "language", null: false
+    t.string "block", null: false
+    t.string "action", null: false
+    t.string "ip", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["action"], name: "index_usage_building_block_events_on_action"
+    t.index ["block"], name: "index_usage_building_block_events_on_block"
+    t.index ["ip"], name: "index_usage_building_block_events_on_ip"
+    t.index ["language"], name: "index_usage_building_block_events_on_language"
   end
 
   create_table "users", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|


### PR DESCRIPTION
## Description

Adds a copy to clipboard button to building blocks. It works, but needs some design love.

![screen shot 2018-08-27 at 15 09 31](https://user-images.githubusercontent.com/59130/44664483-4bed3880-aa0b-11e8-8192-6543d721b149.png)

Clicking copy will copy dependency configuration *and* the code itself as people seem to miss the dependency config section.

This only works on blocks using the `building_block` filter (currently Voice)

When the user clicks on the copy button for the first time per page load, we store which language they have selected, and which building block they're using.

## Deploy Notes

This adds a new DB migration to create the usage_copy_to_clipboard table. I believe they're run automatically but we should take care when deploying this