### PR TITLE
Use docker image that matches ruby version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Base image:
-FROM ruby:2.5.0
+FROM ruby:2.5.1
 
 # Install dependencies
 RUN apt-get update -qq && apt-get install -y build-essential libpq-dev lsof


### PR DESCRIPTION
## Description

Fixes #927 . We bumped the required Ruby version in #918 but didn't update the development docker setup to match.