### PR TITLE
Add clarification about `channel` in recording action

### DIFF
--- a/_documentation/voice/voice-api/ncco-reference.md
+++ b/_documentation/voice/voice-api/ncco-reference.md
@@ -60,7 +60,7 @@ Option | Description | Required
  -- | -- | --
 `format` | Record the Call in a specific format.  Options are: <ul><li>`mp3`</li><li>`wav`</li></ul> The default value is `mp3`. | No
 `split` | Record the sent and received audio in separate channels of a stereo recording—set to `conversation` to enable this.|No
-`channel` | Record up to `32` separate channels. split `conversation` must also be enabled.| No
+`channel` | The number of channels to record (maximum `32`). If the number of participants exceeds `channel` any additional participants will be added to the last channel in file. split `conversation` must also be enabled.| No
 `endOnSilence` | Stop recording after n seconds of silence. Once the recording is stopped the recording data is sent to `event_url`. The range of possible values is 3<=`endOnSilence`<=10. | No
 `endOnKey` | Stop recording when a digit is pressed on the handset. Possible values are: `*`, `#` or any single digit e.g. `9` | No
 `timeOut` | The maximum length of a recording in seconds. One the recording is stopped the recording data is sent to `event_url`. The range of possible values is between `3` seconds and `7200` seconds (2 hours) | No


### PR DESCRIPTION
## Description

After reading the `channel` description I didn't understand how to use it. @JonathanFarrow117 clarified the behaviour to me and I updated the docs

## Deploy Notes

N/A