### PR TITLE
Document the types field for number searching

### DIFF
--- a/_api/developer/numbers.md
+++ b/_api/developer/numbers.md
@@ -67,6 +67,7 @@ Parameter | Description | Required
 `country` | The two character country code in ISO 3166-1 alpha-2 format. | Yes
 `pattern` | A number pattern to search for. | No
 `search_pattern` | Strategy for matching pattern. Expected values: `0` (starts with, default), `1` (anywhere), `2` (ends with). | No
+`type` | The type of number to search for. Accepted values: `landline`, `landline-toll-free` and `mobile-lvn`. | No
 `features` | Available features are SMS and VOICE. For both features, use a comma-separated value SMS,VOICE. | No
 `size` | Page size [Max: 100] [Default: 10] | No
 `index` | Page index [Default: 1] | No

--- a/_api/developer/numbers.md
+++ b/_api/developer/numbers.md
@@ -6,7 +6,7 @@ api: Developer API
 
 # Developer - Numbers API Reference
 
-The Numbers API lets you manage your numbers and buy new virtual numbers for use with Nexmo's APIs. Read our (Authentication Guide)[/concepts/guides/authentication] for for information on how to pass your credentials by query string.
+The Numbers API lets you manage your numbers and buy new virtual numbers for use with Nexmo's APIs. Read our [Authentication Guide](/concepts/guides/authentication) for information on how to pass your credentials by query string.
 
 ## Numbers
 

--- a/_api/developer/numbers.md
+++ b/_api/developer/numbers.md
@@ -6,7 +6,7 @@ api: Developer API
 
 # Developer - Numbers API Reference
 
-The Numbers API lets you manage your numbers and buy new virtual numbers for use with Nexmo's APIs.
+The Numbers API lets you manage your numbers and buy new virtual numbers for use with Nexmo's APIs. Read our (Authentication Guide)[/concepts/guides/authentication] for for information on how to pass your credentials by query string.
 
 ## Numbers
 

--- a/_examples/api/developer/numbers/search-available-numbers/JSON
+++ b/_examples/api/developer/numbers/search-available-numbers/JSON
@@ -4,8 +4,8 @@
     {
       "country": "GB",
       "msisdn": "447700900000",
-      "cost": "0.50",
-      "type": "mobile",
+      "cost": "1.25",
+      "type": "mobile-lvn",
       "features": [
         "VOICE",
         "SMS",

--- a/_examples/api/developer/numbers/search-available-numbers/XML
+++ b/_examples/api/developer/numbers/search-available-numbers/XML
@@ -4,8 +4,8 @@
   <numbers>
      <country>GB</country>
      <msisdn>447700900000</msisdn>
-     <cost>0.50</cost>
-     <type>mobile</type>
+     <cost>1.25</cost>
+     <type>mobile-lvn</type>
      <features>
         <feature>VOICE</feature>
         <feature>SMS</feature>


### PR DESCRIPTION
## Description

Changes as requested in #370 - adding `type` as a request parameter and updating the response examples for number search.  Fixes #370.
