### PR TITLE
Rename account_id to api_key in Secret Management

### DIFF
--- a/_open_api/definitions/account/secret-management.yml
+++ b/_open_api/definitions/account/secret-management.yml
@@ -9,12 +9,12 @@ info:
 security:
   - basicAuth: []
 paths:
-  /accounts/{account_id}/secrets:
+  /accounts/{api_key}/secrets:
     get:
       summary: Retrieve API Secrets
       operationId: retrieveSecrets
       parameters:
-        - $ref: '#/components/parameters/accountId'
+        - $ref: '#/components/parameters/apiKey'
       responses:
         '200':
           description: API secret response
@@ -48,7 +48,7 @@ paths:
       summary: Create API Secret
       operationId: createSecret
       parameters:
-        - $ref: '#/components/parameters/accountId'
+        - $ref: '#/components/parameters/apiKey'
       requestBody:
         required: true
         content:
@@ -126,12 +126,12 @@ paths:
         '404':
           $ref: '#/components/responses/NotFoundError'
 
-  /accounts/{account_id}/secrets/{secret_id}:
+  /accounts/{api_key}/secrets/{secret_id}:
     get:
       summary: Retrieve API Secret
       operationId: retrieveSecret
       parameters:
-        - $ref: '#/components/parameters/accountId'
+        - $ref: '#/components/parameters/apiKey'
         - $ref: '#/components/parameters/secretId'
       responses:
         '200':
@@ -148,7 +148,7 @@ paths:
       summary: Revoke API Secret
       operationId: revokeSecret
       parameters:
-        - $ref: '#/components/parameters/accountId'
+        - $ref: '#/components/parameters/apiKey'
         - $ref: '#/components/parameters/secretId'
       responses:
         '204':
@@ -183,10 +183,10 @@ components:
       type: http
       scheme: basic
   parameters:
-    accountId:
-     name: account_id
+    apiKey:
+     name: api_key
      in: path
-     description: ID of the account
+     description: The API key to manage secrets for
      example: abcd1234
      required: true
      schema:


### PR DESCRIPTION
## Description

The path parameter being called `account_id` was misleading. This PR updates it to be called `api_key` like all other endpoints

## Deploy Notes

N/A