### PR TITLE
Quick fix to add Node example to Verify guide

### DIFF
--- a/_examples/verify/building-blocks/send-verification-request/Node
+++ b/_examples/verify/building-blocks/send-verification-request/Node
@@ -1,0 +1,11 @@
+var nexmo = new Nexmo({apiKey: NEXMO_API_KEY, apiSecret: NEXMO_API_SECRET});
+
+var verifyRequestId = null; // use in the check process
+
+nexmo.verify.request({number: NEXMO_TO_NUMBER, brand: BRAND_NAME}, function(err, result) {
+  if(err) { console.error(err); }
+  else {
+    verifyRequestId = result.request_id;
+    console.log('request_id', verifyRequestId);
+  }
+});


### PR DESCRIPTION
This uses an old style Building Block but is a quick fix to ensure we have a Node example in the guide.

Note: this has been added via the GitHub UI so we should test on a staging app.