### PR TITLE
Answer URL was not appearing in app:create construct due to typo.

### DIFF
--- a/app/views/building_blocks/_application.html.erb
+++ b/app/views/building_blocks/_application.html.erb
@@ -20,6 +20,6 @@
             <p>Nexmo needs to connect to your local machine to access your <code>answer_url</code>. We recommend using <a href="https://www.nexmo.com/blog/2017/07/04/local-development-nexmo-ngrok-tunnel-dr/">ngrok</a> to do this. Make sure to change <code>demo.ngrok.io</code> in the examples below to your own ngrok URL.</p>
         <% end %>
 
-        <pre class="highlight shell"><code>$ nexmo app:create "<%=app['name'] %>" <%=app['answer_ur'] %> <%=app['event_url'] %> --keyfile private.key</code></pre>
+        <pre class="highlight shell"><code>$ nexmo app:create "<%=app['name'] %>" <%=app['answer_url'] %> <%=app['event_url'] %> --keyfile private.key</code></pre>
     <% end %>
 </div>


### PR DESCRIPTION
## Description

Fixes answer URL not appearing in building blocks app create command line due to typo.

## Deploy Notes

Create review app. Check that in Voice building blocks (for example) the app create command line specifies both `event_url` and `answer_url`.