### PR TITLE
Tabbed examples should no longer be used.

### DIFF
--- a/app/views/contribute/building-blocks/sample-building-block.md
+++ b/app/views/contribute/building-blocks/sample-building-block.md
@@ -26,6 +26,8 @@ application:
   name: 'Example Application'
 ```
 
+Note the `application` section of the `building_blocks` construct is optional. If not used there will be no prerequisite section in the rendered block.
+
 ## Try it out
 
 What did the user just build?  How should they use it?  Add the instructions

--- a/app/views/contribute/guides/code-examples.md
+++ b/app/views/contribute/guides/code-examples.md
@@ -158,29 +158,11 @@ print_hi('Adam')
 #=> prints 'Hi Adam' to STDOUT.
 ```
 
-### Tabbed Examples (custom plugin) + pulling code in from external repository
+### Tabbed examples
 
-The custom plugin for tabbed code also supports pulling code from an external repository.  This example shows code from [nexmo-community/nexmo-ruby-quickstart](https://github.com/nexmo-community/nexmo-ruby-quickstart):
+Tabbed examples via the use of the `tabbed_examples` construct should no longer be used. Instead use [building blocks](/contribute/building-blocks/sample-building-block).
 
-````
-```tabbed_examples
-tabs:
-  Ruby:
-    source: .repos/nexmo-community/nexmo-ruby-quickstart/sms/send.rb
-    from_line: 9
-```
-````
-
-And here's the example:
-
-```tabbed_examples
-tabs:
-  Ruby:
-    source: .repos/nexmo-community/nexmo-ruby-quickstart/sms/send.rb
-    from_line: 9
-```
-
-> There is an older version of the tabbed examples also in use, that uses a `source: ` field pointing to the `_examples/` directory, but this style is no longer used. Please use the new style above, and replace existing occurrences if possible.
+> Note: There are two formats of the `tabbed_examples` construct in current use, both of which are now deprecated.
 
 ### Linters, Formatters & Code Style Guides
 


### PR DESCRIPTION
## Description

Added note to the effect we should no longer be used `tabbed_examples` but rather `building_blocks`. 

Note was also added to building blocks guide on removing the application section for a minimalistic building block.

## Deploy Notes

Create a review app and then check the tabbed examples section of the Contrib guide, specifically the code examples page.