### PR TITLE
Add ability for a Tutorial to provide external_link in frontmatter

### DIFF
--- a/app/assets/stylesheets/objects/_card.scss
+++ b/app/assets/stylesheets/objects/_card.scss
@@ -52,7 +52,7 @@ $card-animation-speed: 200ms;
   font-size: 16px;
 
   .icon-external-link {
-    display: none;
+    display: inline;
   }
 
   .spacious {

--- a/app/models/tutorial.rb
+++ b/app/models/tutorial.rb
@@ -1,12 +1,13 @@
 class Tutorial
   include ActiveModel::Model
-  attr_accessor :title, :description, :products, :document_path, :languages
+  attr_accessor :title, :description, :external_link, :products, :document_path, :languages
 
   def body
     File.read(document_path)
   end
 
   def path
+    return external_link if external_link
     "/tutorials/#{document_path.relative_path_from(Tutorial.origin)}".gsub('.md', '')
   end
 
@@ -44,6 +45,7 @@ class Tutorial
       Tutorial.new({
         title: frontmatter['title'],
         description: frontmatter['description'],
+        external_link: frontmatter['external_link'],
         products: frontmatter['products'].split(',').map(&:strip),
         languages: frontmatter['languages'] || [],
         document_path: document_path,

--- a/app/views/tutorials/_index.html.erb
+++ b/app/views/tutorials/_index.html.erb
@@ -1,11 +1,12 @@
 <div class="masonry" data-turbolinks="false">
   <% @tutorials.each_with_index do |tutorial, index| %>
     <div class="item">
-      <a href="<%= tutorial.path %>" class="card card--with-icon">
+      <a href="<%= tutorial.path %>" class="card card--with-icon" <%= tutorial.external_link ? 'target="blank"': '' %>>
         <h2>
           <span class="unstyled spacious">
             <small><i><%= tutorial.subtitle %></i></small>
             <%= tutorial.title %>
+            <span class="<%= tutorial.external_link ? 'icon-external-link' : '' %>">&nbsp;</span>
           </span>
         </h2>
 


### PR DESCRIPTION
Add ability for a Tutorial to provide external_link in frontmatter to 
link to non-NDP content

This will allow us to add placeholder tutorials in NDP that link to
X with Y content on the blog, raising visibility of other content that
we've written.

In the future the X with Y content may move in to NDP, but this is
a step in the right direction for now

## Example usage

Create `_tutorials/anything-to-sms-ifttt.md` with the following contents:

```
---
title: Anything-to-SMS with IFTTT and Nexmo
products: messaging/sms
description: This is a description that will be shown on the tutorials list page
external_link: https://www.nexmo.com/blog/2018/09/18/anything-to-sms-ifttt-nexmo-dr/
languages:
    - Node
---
```

This will render a Tutorial block than when clicked will open a new window showing the blog post