### PR TITLE
Correct namespacing for Facebook IDs and update repo code.

### DIFF
--- a/.repos/nexmo/curl-building-blocks/.gitignore
+++ b/.repos/nexmo/curl-building-blocks/.gitignore
@@ -1,1 +1,4 @@
 config.local.sh
+private.key
+_config.sh
+.nexmo-app

--- a/.repos/nexmo/curl-building-blocks/config.sh
+++ b/.repos/nexmo/curl-building-blocks/config.sh
@@ -10,8 +10,8 @@ FROM_NUMBER=""
 NEXMO_NUMBER=""
 
 # For FaceBook messaging
-SENDER_ID=""
-RECIPIENT_ID=""
+FB_SENDER_ID=""
+FB_RECIPIENT_ID=""
 
 # For Viber messaging
 VIBER_SERVICE_MESSAGE_ID=""
@@ -29,6 +29,9 @@ EVENT_UUID=""  # UUID of audit event
 SEARCH_TEXT="number"
 DATE_FROM="2018-07-01"
 DATE_TO="2018-08-01"
+
+# Number Insight API
+NEXMO_TO_LOOKUP="447700900000"
 
 # If we have a local config, override using that
 CONFIG_DIR=$(dirname "${BASH_SOURCE[0]}")

--- a/.repos/nexmo/curl-building-blocks/olympus/send-facebook-message.sh
+++ b/.repos/nexmo/curl-building-blocks/olympus/send-facebook-message.sh
@@ -8,8 +8,8 @@ curl -X POST https://api.nexmo.com/beta/messages \
   -H 'Content-Type: application/json' \
   -H 'Accept: application/json' \
   -d $'{
-    "from": { "type": "messenger", "id": '$SENDER_ID' },
-    "to": { "type": "messenger", "id": '$RECIPIENT_ID' },
+    "from": { "type": "messenger", "id": '$FB_SENDER_ID' },
+    "to": { "type": "messenger", "id": '$FB_RECIPIENT_ID' },
     "message": {
       "content": {
         "type": "text",

--- a/.repos/nexmo/curl-building-blocks/olympus/send-message-with-failover.sh
+++ b/.repos/nexmo/curl-building-blocks/olympus/send-message-with-failover.sh
@@ -11,8 +11,8 @@ curl -X POST https://api.nexmo.com/beta/workflows \
     "template":"failover",
     "workflow": [
       {
-        "from": { "type": "messenger", "id": '$SENDER_ID' },
-        "to": { "type": "messenger", "id": '$RECIPIENT_ID' },
+        "from": { "type": "messenger", "id": '$FB_SENDER_ID' },
+        "to": { "type": "messenger", "id": '$FB_RECIPIENT_ID' },
         "message": {
           "content": {
             "type": "text",

--- a/_documentation/messages-and-workflows-apis/messages/building-blocks/send-with-facebook-messenger.md
+++ b/_documentation/messages-and-workflows-apis/messages/building-blocks/send-with-facebook-messenger.md
@@ -14,8 +14,8 @@ Ensure the following variables are set to your required values using any conveni
 Key | Description
 -- | --
 `NEXMO_APPLICATION_ID` | The ID of the application that you created.
-`SENDER_ID` | Your Page ID. The `SENDER_ID` is the same as the `to.id` value you received in the inbound messenger event on your Inbound Message Webhook URL.
-`RECIPIENT_ID` | The PSID of the user you want to reply to. The `RECIPIENT_ID` is the PSID of the Facebook User you are messaging. This value is the `from.id` value you received in the inbound messenger event on your Inbound Message Webhook URL.
+`FB_SENDER_ID` | Your Page ID. The `FB_SENDER_ID` is the same as the `to.id` value you received in the inbound messenger event on your Inbound Message Webhook URL.
+`FB_RECIPIENT_ID` | The PSID of the user you want to reply to. The `FB_RECIPIENT_ID` is the PSID of the Facebook User you are messaging. This value is the `from.id` value you received in the inbound messenger event on your Inbound Message Webhook URL.
 
 ```building_blocks
 source: '_examples/olympus/send-facebook-message'

--- a/_documentation/messages-and-workflows-apis/messages/guides/facebook-messenger.md
+++ b/_documentation/messages-and-workflows-apis/messages/guides/facebook-messenger.md
@@ -129,8 +129,8 @@ Replace the following variables in the example below with actual values:
 
 Key | Description
 -- | --
-`SENDER_ID` | Your Page ID. The `SENDER_ID` is the same as the `to.id` value you received in the inbound messenger event on your Inbound Message Webhook URL.
-`RECIPIENT_ID` | The PSID of the user you want to reply to. The `RECIPIENT_ID` is the PSID of the Facebook User you are messaging. This value is the `from.id` value you received in the inbound messenger event on your Inbound Message Webhook URL.
+`FB_SENDER_ID` | Your Page ID. The `FB_SENDER_ID` is the same as the `to.id` value you received in the inbound messenger event on your Inbound Message Webhook URL.
+`FB_RECIPIENT_ID` | The PSID of the user you want to reply to. The `FB_RECIPIENT_ID` is the PSID of the Facebook User you are messaging. This value is the `from.id` value you received in the inbound messenger event on your Inbound Message Webhook URL.
 
 ### Example
 

--- a/_documentation/messages-and-workflows-apis/workflows/building-blocks/send-a-facebook-message-with-failover.md
+++ b/_documentation/messages-and-workflows-apis/workflows/building-blocks/send-a-facebook-message-with-failover.md
@@ -15,8 +15,8 @@ Key | Description
 `NEXMO_APPLICATION_ID` | The ID of the application that you created.
 `FROM_NUMBER` | The phone number you are sending the message from.
 `TO_NUMBER` | The phone number you are sending the message to.
-`SENDER_ID` | Your Page ID. The `SENDER_ID` is the same as the `to.id` value you received in the inbound messenger event on your Inbound Message Webhook URL.
-`RECIPIENT_ID` | The PSID of the user you want to reply to. The `RECIPIENT_ID` is the PSID of the Facebook User you are messaging. This value is the `from.id` value you received in the inbound messenger event on your Inbound Message Webhook URL.
+`FB_SENDER_ID` | Your Page ID. The `FB_SENDER_ID` is the same as the `to.id` value you received in the inbound messenger event on your Inbound Message Webhook URL.
+`FB_RECIPIENT_ID` | The PSID of the user you want to reply to. The `FB_RECIPIENT_ID` is the PSID of the Facebook User you are messaging. This value is the `from.id` value you received in the inbound messenger event on your Inbound Message Webhook URL.
 
 > **NOTE:** Don't use a leading `+` or `00` when entering a phone number, start with the country code, for example 447700900000.
 

--- a/_documentation/messages-and-workflows-apis/workflows/guides/failover.md
+++ b/_documentation/messages-and-workflows-apis/workflows/guides/failover.md
@@ -76,8 +76,8 @@ In this example you will implement the following workflow:
 Key | Description
 -- | --
 `FROM_NUMBER` | The phone number you are sending the message from. **Don't use a leading `+` or `00` when entering a phone number, start with the country code, for example, 447700900000.**
-`SENDER_ID` | Your Page ID. The `SENDER_ID` is the same as the `to.id` value you received in the inbound messenger event on your Inbound Message Webhook URL.
-`RECIPIENT_ID` | The PSID of the user you want to reply to. The `RECIPIENT_ID` is the PSID of the Facebook User you are messaging. This value is the `from.id` value you received in the inbound messenger event on your Inbound Message Webhook URL.
+`FB_SENDER_ID` | Your Page ID. The `FB_SENDER_ID` is the same as the `to.id` value you received in the inbound messenger event on your Inbound Message Webhook URL.
+`FB_RECIPIENT_ID` | The PSID of the user you want to reply to. The `FB_RECIPIENT_ID` is the PSID of the Facebook User you are messaging. This value is the `from.id` value you received in the inbound messenger event on your Inbound Message Webhook URL.
 
 ### Example
 

--- a/_documentation/messages-and-workflows-apis/workflows/overview.md
+++ b/_documentation/messages-and-workflows-apis/workflows/overview.md
@@ -43,8 +43,8 @@ Key | Description
 -- | --
 `NEXMO_API_KEY` | Nexmo API key which can be obtained from your [Nexmo Dashboard](https://dashboard.nexmo.com).
 `NEXMO_API_SECRET` | Nexmo API secret which can be obtained from your [Nexmo Dashboard](https://dashboard.nexmo.com).
-`SENDER_ID` | Your Page ID. The `SENDER_ID` is the same as the `to.id` value you received in the inbound messenger event on your Inbound Message Webhook URL.
-`RECIPIENT_ID` | The PSID of the user you want to reply to. The `RECIPIENT_ID` is the PSID of the Facebook User you are messaging. This value is the `from.id` value you received in the inbound messenger event on your Inbound Message Webhook URL.
+`FB_SENDER_ID` | Your Page ID. The `FB_SENDER_ID` is the same as the `to.id` value you received in the inbound messenger event on your Inbound Message Webhook URL.
+`FB_RECIPIENT_ID` | The PSID of the user you want to reply to. The `FB_RECIPIENT_ID` is the PSID of the Facebook User you are messaging. This value is the `from.id` value you received in the inbound messenger event on your Inbound Message Webhook URL.
 `FROM_NUMBER` | A phone number you own or some text to identify the sender.
 `TO_NUMBER` | The number of the phone to which the message will be sent.
 


### PR DESCRIPTION
## Description

The namespacing was changed in Curl building blocks for Facebook IDs. This PR reflects the change in the docs:

* SENDER_ID -> FB_SENDER_ID
* RECIPIENT_ID -> FB_RECIPIENT_ID

## Deploy Notes

Create review app and check Facebook related pages.

NOTE: Blocks PR #999 