### PR TITLE
Fix an incorrect link in auth block

### DIFF
--- a/app/views/open_api/_endpoint.html.erb
+++ b/app/views/open_api/_endpoint.html.erb
@@ -61,7 +61,7 @@
 
                 <div class="table-list-column" flex="3">
                   <b>Base64 encoded API key and secret joined by a colon.</b><br>
-                  <small><%= link_to "Read more", "/concepts/guides/authentication#header-based-api-key-secret-authentication" %></small>
+                  <small><%= link_to "Read more", "/concepts/guides/authentication#header-based-api-key-and-secret-authentication" %></small>
                 </div>
                 <div class="table-list-column" flex="2"><code>Basic &lt;base64&gt;</code></div>
              <div class="table-list-column">


### PR DESCRIPTION
## Description

Our OAS docs link to a slightly misformatted internal link on the auth instructions page. This fixes it.
