### PR TITLE
Remove hardcoded mention of voice package in java building block rend…

### DIFF
--- a/app/services/building_block_renderer/java.rb
+++ b/app/services/building_block_renderer/java.rb
@@ -20,7 +20,7 @@ module BuildingBlockRenderer
         mainClassName = project.hasProperty('main') ? project.getProperty('main') : ''
         ```
 
-         Run the following `gradle` command to execute your application, replacing `#{package}` with the package containing `#{filename.gsub('.java', '')}`:
+         Run the following `gradle` command to execute your application, replacing `#{package.chomp('.')}` with the package containing `#{filename.gsub('.java', '')}`:
 
          ```sh
         gradle run -Pmain=#{package}#{filename.gsub('.java', '')}

--- a/app/services/building_block_renderer/java.rb
+++ b/app/services/building_block_renderer/java.rb
@@ -20,7 +20,7 @@ module BuildingBlockRenderer
         mainClassName = project.hasProperty('main') ? project.getProperty('main') : ''
         ```
 
-         Run the following command to execute your application replacing `com.nexmo.quickstart.voice` with the package containing `#{filename.gsub('.java', '')}`:
+         Run the following `gradle` command to execute your application:
 
          ```sh
         gradle run -Pmain=#{package}#{filename.gsub('.java', '')}

--- a/app/services/building_block_renderer/java.rb
+++ b/app/services/building_block_renderer/java.rb
@@ -20,7 +20,7 @@ module BuildingBlockRenderer
         mainClassName = project.hasProperty('main') ? project.getProperty('main') : ''
         ```
 
-         Run the following `gradle` command to execute your application:
+         Run the following `gradle` command to execute your application, replacing `#{package}` with the package containing `#{filename.gsub('.java', '')}`:
 
          ```sh
         gradle run -Pmain=#{package}#{filename.gsub('.java', '')}


### PR DESCRIPTION
…erer

## Description

The existing building block renderer instructed the reader to replace the `com.nexmo.quickstart.voice` package with the one shown in the output. This is no longer required since @cr0wst made populated the package name dynamically in https://github.com/Nexmo/nexmo-developer/pull/970.

## Deploy Notes

In a sample app, check the "Run the Code" section of a Java building block (e.g. http://localhost:3000/voice/voice-api/building-blocks/earmuff-a-call). The explanatory text should instruct you to "execute the following `gradle` command" and not "replace `com.nexmo.quickstart.voice` with your package name.""
