### PR TITLE
Webhook documentation for Voice API answer and event URLs

### DIFF
--- a/_documentation/concepts/guides/webhooks.md
+++ b/_documentation/concepts/guides/webhooks.md
@@ -34,7 +34,7 @@ Nexmo sends and retrieves the following information using webhooks:
 | API Name | Webhooks usage |
 |-------|--------|
 | SMS API | Sends the delivery status of your message and receives inbound SMS |
-| Voice API | Retrieves the [Nexmo Call Control Objects](/voice/voice-api/ncco-reference) you use to control the call from one webhook endpoint, and sends information about the call status to another |
+| Voice API | Retrieves the [Nexmo Call Control Objects](/voice/voice-api/ncco-reference) you use to control the call from one webhook endpoint, and sends information about the call status to another. View the [Webhook Reference](/voice/voice-api/webhook-reference) for more detail. |
 | Number Insight Advanced Async API | Receives complete information about a phone number |
 | US Short Codes API | Sends the delivery status of your message and receives inbound SMS |
 

--- a/_documentation/voice/voice-api/guides/call-flow.md
+++ b/_documentation/voice/voice-api/guides/call-flow.md
@@ -67,7 +67,7 @@ An example event object is shown here:
 }
 ```
 
-In addition, certain errors are sent to the `event_url` such as when your `answer_url` returns an invalid NCCO.
+In addition, certain errors are sent to the `event_url` such as when your `answer_url` returns an invalid NCCO. You can find more detail in the [Webhooks Reference](/voice/voice-api/webhook-reference#event-webhook).
 
 ## Answer URL payload
 
@@ -88,7 +88,7 @@ To illustrate this, an example GET request to the `answer_url` is given here:
 /webhooks/answer?to=447700900000&from=447700900001&conversation_uuid=CON-aaaaaaaa-bbbb-cccc-dddd-0123456789ab&uuid=aaaaaaaa-bbbb-cccc-dddd-0123456789cd
 ```
 
-In general, useful information such as the calling number and destination number is extracted from the query string and processed by your application.
+In general, useful information such as the calling number and destination number is extracted from the query string and processed by your application. For more information, refer to the [Webhooks Reference](/voice/voice-api/webhook-reference).
 
 ## Synchronous vs Asynchronous Actions
 

--- a/_documentation/voice/voice-api/webhook-reference.md
+++ b/_documentation/voice/voice-api/webhook-reference.md
@@ -64,6 +64,8 @@ The format of the data included depends on which event has occurred:
 * [`answered`](#answered)
 * [`busy`](#busy)
 * [`cancelled`](#cancelled)
+* [`unanswered`](#unanswered)
+* [`failed`](#failed)
 * [`human/machine`](#human-machine)
 * [`timeout`](#timeout)
 * [`completed`](#completed)
@@ -140,6 +142,34 @@ Field | Example | Description
 `uuid` | `aaaaaaaa-bbbb-cccc-dddd-0123456789ab` | The unique identifier for this call
 `conversation_uuid` | `CON-aaaaaaaa-bbbb-cccc-dddd-0123456789ab` | The unique identifier for this conversation
 `status` | `cancelled` | Call status
+`direction` | `outbound` | Call direction, this will be `outbound` in this context
+`timestamp` | `2020-01-01T12:00:00.000Z` | Timestamp (ISO 8601 format)
+
+### Unanswered
+
+The outgoing call is ringing, but is never answered.
+
+Field | Example | Description
+ -- | -- | --
+`from` | `442079460000` | The number the call came from
+`to` | `447700900000` | The number the call was made to 
+`uuid` | `aaaaaaaa-bbbb-cccc-dddd-0123456789ab` | The unique identifier for this call
+`conversation_uuid` | `CON-aaaaaaaa-bbbb-cccc-dddd-0123456789ab` | The unique identifier for this conversation
+`status` | `unanswered` | Call status
+`direction` | `outbound` | Call direction, this will be `outbound` in this context
+`timestamp` | `2020-01-01T12:00:00.000Z` | Timestamp (ISO 8601 format)
+
+### Failed
+
+The outgoing call could not be connected.
+
+Field | Example | Description
+ -- | -- | --
+`from` | `442079460000` | The number the call came from
+`to` | `447700900000` | The number the call was made to 
+`uuid` | `aaaaaaaa-bbbb-cccc-dddd-0123456789ab` | The unique identifier for this call
+`conversation_uuid` | `CON-aaaaaaaa-bbbb-cccc-dddd-0123456789ab` | The unique identifier for this conversation
+`status` | `failed` | Call status
 `direction` | `outbound` | Call direction, this will be `outbound` in this context
 `timestamp` | `2020-01-01T12:00:00.000Z` | Timestamp (ISO 8601 format)
 

--- a/_documentation/voice/voice-api/webhook-reference.md
+++ b/_documentation/voice/voice-api/webhook-reference.md
@@ -66,6 +66,7 @@ The format of the data included depends on which event has occurred:
 * [`busy`](#busy)
 * [`cancelled`](#cancelled)
 * [`unanswered`](#unanswered)
+* [`rejected`](#rejected)
 * [`failed`](#failed)
 * [`human/machine`](#human-machine)
 * [`timeout`](#timeout)
@@ -75,7 +76,7 @@ The format of the data included depends on which event has occurred:
 
 ### Started
 
-Indicates that the call has begun.
+Indicates that the call has been created.
 
 Field | Example | Description
  -- | -- | --
@@ -126,7 +127,7 @@ Field | Example | Description
 
 ### Busy
 
-The destination number was busy.
+The destination is on the line with another caller.
 
 Field | Example | Description
  -- | -- | --
@@ -142,7 +143,7 @@ Field | Example | Description
 
 ### Cancelled
 
-An outgoing call was cancelled before it was answered.
+An outgoing call is cancelled by the originator before being answered.
 
 Field | Example | Description
  -- | -- | --
@@ -158,7 +159,7 @@ Field | Example | Description
 
 ### Unanswered
 
-The outgoing call is ringing, but is never answered.
+Either the recipient is unreachable or the recipient declined the call.
 
 Field | Example | Description
  -- | -- | --
@@ -167,6 +168,22 @@ Field | Example | Description
 `uuid` | `aaaaaaaa-bbbb-cccc-dddd-0123456789ab` | The unique identifier for this call
 `conversation_uuid` | `CON-aaaaaaaa-bbbb-cccc-dddd-0123456789ab` | The unique identifier for this conversation
 `status` | `unanswered` | Call status
+`direction` | `outbound` | Call direction, this will be `outbound` in this context
+`timestamp` | `2020-01-01T12:00:00.000Z` | Timestamp (ISO 8601 format)
+
+[Back to event webhooks list](#event-webhook)
+
+### Rejected
+
+The call was rejected by Nexmo before it was connected.
+
+Field | Example | Description
+ -- | -- | --
+`from` | `442079460000` | The number the call came from
+`to` | `447700900000` | The number the call was made to 
+`uuid` | `aaaaaaaa-bbbb-cccc-dddd-0123456789ab` | The unique identifier for this call
+`conversation_uuid` | `CON-aaaaaaaa-bbbb-cccc-dddd-0123456789ab` | The unique identifier for this conversation
+`status` | `rejected` | Call status
 `direction` | `outbound` | Call direction, this will be `outbound` in this context
 `timestamp` | `2020-01-01T12:00:00.000Z` | Timestamp (ISO 8601 format)
 

--- a/_documentation/voice/voice-api/webhook-reference.md
+++ b/_documentation/voice/voice-api/webhook-reference.md
@@ -1,5 +1,5 @@
 ---
-title: Voice Webhook reference
+title: Webhook Reference
 description: Details of the webhooks that Nexmo sends relating to voice calls.
 api: "Voice API: Webhooks"
 ---

--- a/_documentation/voice/voice-api/webhook-reference.md
+++ b/_documentation/voice/voice-api/webhook-reference.md
@@ -9,16 +9,16 @@ api: "Voice API: Webhooks"
 Nexmo uses webhooks alongside its Voice API to enable your application to interact with the call. There are two webhook endpoints:
 
 * [Answer webhook](#answer-webhook) is sent when a call is answered. This is for both incoming and outgoing calls.
-* [Event webhook](#event-webhook) is sent for all the events during a call. Your application can log, react to or ignore each event type.
+* [Event webhook](#event-webhook) is sent for all the events that occur during a call. Your application can log, react to or ignore each event type.
 * [Errors](#errors) are also delivered to the event webhook endpoint if they occur.
 
 For more general information, check out our [webhooks guide](/concepts/guides/webhooks).
 
 ## Answer Webhook
 
-When an incoming call is answered, an HTTP request will be sent to the `answer_url` you specified when setting up the application. For outgoing calls, the `answer_url` is specified when making the call.
+When an incoming call is answered, an HTTP request is sent to the `answer_url` you specified when setting up the application. For outgoing calls, specify the `answer_url` when you make the call.
 
-By default, the answer webhook will be a `GET` request but this can be overridden to `POST` by setting the `answer_method` when making an outbound call with the Nexmo Voice API.
+By default, the answer webhook will be a `GET` request but this can be overridden to `POST` by setting the `answer_method` field. For incoming calls, you configure these values when you create the application. For outgoing calls, you specify these values when making a call.
 
 ### Answer webhook data fields
 
@@ -50,13 +50,13 @@ If you set the `answer_method` to `POST` then you will receive the request with 
 
 ### Responding to the answer webhook
 
-Nexmo expect you to return an array of [NCCO](/voice/voice-api/ncco-reference) in JSON.
+Nexmo expect you to return an [NCCO](/voice/voice-api/ncco-reference) in JSON format containing the actions to perform.
 
 ## Event webhook
 
 HTTP requests will arrive at the event webhook endpoint when there is any status change for a call. The URL will be the `event_url` you specified when creating your application unless you override it by setting a specific `event_url` when starting a call.
 
-The incoming requests are `POST` requests with a JSON body.
+By default the incoming requests are `POST` requests with a JSON body. You can override the method to `GET` by configuring the `event_method` in addition to the `event_url`.
 
 The format of the data included depends on which event has occurred:
 
@@ -223,7 +223,7 @@ Field | Example | Description
 
 ### Record
 
-This webhook arrives when an NCCO with a "record" action has finished. When creating a record action, you can set a different `eventURL` for this event to be sent to if you wish.
+This webhook arrives when an NCCO with a "record" action has finished. When creating a record action, you can set a different `eventURL` for this event to be sent to. This can be useful if you want to use separate code to handle this event type.
 
 Field | Example | Description
  -- | -- | --

--- a/_documentation/voice/voice-api/webhook-reference.md
+++ b/_documentation/voice/voice-api/webhook-reference.md
@@ -10,6 +10,7 @@ Nexmo uses webhooks alongside its Voice API to enable your application to intera
 
 * [Answer webhook](#answer-webhook) is sent when a call is answered. This is for both incoming and outgoing calls.
 * [Event webhook](#event-webhook) is sent for all the events during a call. Your application can log, react to or ignore each event type.
+* [Errors](#errors) are also delivered to the event webhook endpoint if they occur.
 
 For more general information, check out our [webhooks guide](/concepts/guides/webhooks).
 
@@ -245,3 +246,14 @@ Field | Example | Description
 `uuid` | `aaaaaaaa-bbbb-cccc-dddd-0123456789ab` | The unique identifier for this call
 `conversation_uuid` | `CON-aaaaaaaa-bbbb-cccc-dddd-0123456789ab` | The unique identifier for this conversation
 `timestamp` | `2020-01-01T12:00:00.000Z` | Timestamp (ISO 8601 format)
+
+## Errors
+
+The event endpoint will also receive webhooks in the event of an error. This can be useful when debugging your application.
+
+Field | Example | Description
+ -- | -- | --
+`reason` | `Syntax error in NCCO. Invalid value type or action.` | Information about the nature of the error
+`conversation_uuid` | `CON-aaaaaaaa-bbbb-cccc-dddd-0123456789ab` | The unique identifier for this conversation
+`timestamp` | `2020-01-01T12:00:00.000Z` | Timestamp (ISO 8601 format)
+

--- a/_documentation/voice/voice-api/webhook-reference.md
+++ b/_documentation/voice/voice-api/webhook-reference.md
@@ -87,6 +87,8 @@ Field | Example | Description
 `direction` | `outbound` | Call direction, can be either `inbound` or `outbound`
 `timestamp` | `2020-01-01T12:00:00.000Z` | Timestamp (ISO 8601 format)
 
+[Back to event webhooks list](#event-webhook)
+
 ### Ringing
 
 The destination is reachable and ringing.
@@ -100,6 +102,8 @@ Field | Example | Description
 `status` | `ringing` | Call status
 `direction` | `outbound` | Call direction, can be either `inbound` or `outbound`
 `timestamp` | `2020-01-01T12:00:00.000Z` | Timestamp (ISO 8601 format)
+
+[Back to event webhooks list](#event-webhook)
 
 ### Answered
 
@@ -118,6 +122,8 @@ Field | Example | Description
 `network` | - | *empty*
 `timestamp` | `2020-01-01T12:00:00.000Z` | Timestamp (ISO 8601 format)
 
+[Back to event webhooks list](#event-webhook)
+
 ### Busy
 
 The destination number was busy.
@@ -131,6 +137,8 @@ Field | Example | Description
 `status` | `busy` | Call status
 `direction` | `outbound` | Call direction, this will be `outbound` in this context
 `timestamp` | `2020-01-01T12:00:00.000Z` | Timestamp (ISO 8601 format)
+
+[Back to event webhooks list](#event-webhook)
 
 ### Cancelled
 
@@ -146,6 +154,8 @@ Field | Example | Description
 `direction` | `outbound` | Call direction, this will be `outbound` in this context
 `timestamp` | `2020-01-01T12:00:00.000Z` | Timestamp (ISO 8601 format)
 
+[Back to event webhooks list](#event-webhook)
+
 ### Unanswered
 
 The outgoing call is ringing, but is never answered.
@@ -159,6 +169,8 @@ Field | Example | Description
 `status` | `unanswered` | Call status
 `direction` | `outbound` | Call direction, this will be `outbound` in this context
 `timestamp` | `2020-01-01T12:00:00.000Z` | Timestamp (ISO 8601 format)
+
+[Back to event webhooks list](#event-webhook)
 
 ### Failed
 
@@ -174,6 +186,8 @@ Field | Example | Description
 `direction` | `outbound` | Call direction, this will be `outbound` in this context
 `timestamp` | `2020-01-01T12:00:00.000Z` | Timestamp (ISO 8601 format)
 
+[Back to event webhooks list](#event-webhook)
+
 ### Human / Machine
 
 For an outbound call made programmatically, if the `machine_detection` option is set then an event with a status of `human` or `machine` will be sent depending whether a person answered the call or not.
@@ -186,6 +200,8 @@ Field | Example | Description
 `status` | `human` | Call status, can be either `human` if a person answered or `machine` if the call was answered by voicemail or another automated service
 `conversation_uuid` | `CON-aaaaaaaa-bbbb-cccc-dddd-0123456789ab` | The unique identifier for this conversation
 `timestamp` | `2020-01-01T12:00:00.000Z` | Timestamp (ISO 8601 format)
+
+[Back to event webhooks list](#event-webhook)
 
 ### Timeout
 
@@ -200,6 +216,8 @@ Field | Example | Description
 `status` | `timeout` | Call status
 `direction` | `outbound` | Call direction, this will be `outbound` in this context
 `timestamp` | `2020-01-01T12:00:00.000Z` | Timestamp (ISO 8601 format)
+
+[Back to event webhooks list](#event-webhook)
 
 ### Completed
 
@@ -221,6 +239,8 @@ Field | Example | Description
 `direction` | inbound | Call direction, can be either `inbound` or `outbound`
 `timestamp` | `2020-01-01T12:00:00.000Z` | Timestamp (ISO 8601 format)
 
+[Back to event webhooks list](#event-webhook)
+
 ### Record
 
 This webhook arrives when an NCCO with a "record" action has finished. When creating a record action, you can set a different `eventURL` for this event to be sent to. This can be useful if you want to use separate code to handle this event type.
@@ -235,6 +255,8 @@ Field | Example | Description
 `conversation_uuid` | `CON-aaaaaaaa-bbbb-cccc-dddd-0123456789ab` | The unique identifier for this conversation
 `timestamp` | `2020-01-01T12:00:00.000Z` | Timestamp (ISO 8601 format)
 
+[Back to event webhooks list](#event-webhook)
+
 ### Input 
 
 This webhook is sent by Nexmo when an NCCO with an action of "input" has finished.
@@ -246,6 +268,8 @@ Field | Example | Description
 `uuid` | `aaaaaaaa-bbbb-cccc-dddd-0123456789ab` | The unique identifier for this call
 `conversation_uuid` | `CON-aaaaaaaa-bbbb-cccc-dddd-0123456789ab` | The unique identifier for this conversation
 `timestamp` | `2020-01-01T12:00:00.000Z` | Timestamp (ISO 8601 format)
+
+[Back to event webhooks list](#event-webhook)
 
 ## Errors
 

--- a/_documentation/voice/voice-api/webhook-reference.md
+++ b/_documentation/voice/voice-api/webhook-reference.md
@@ -1,0 +1,217 @@
+---
+title: Voice Webhook reference
+description: Details of the webhooks that Nexmo sends relating to voice calls.
+api: "Voice API: Webhooks"
+---
+
+# Voice API Webhooks Reference
+
+Nexmo uses webhooks alongside its Voice API to enable your application to interact with the call. There are two webhook endpoints:
+
+* [Answer webhook](#answer-webhook) is sent when a call is answered. This is for both incoming and outgoing calls.
+* [Event webhook](#event-webhook) is sent for all the events during a call. Your application can log, react to or ignore each event type.
+
+For more general information, check out our [webhooks guide](/concepts/guides/webhooks).
+
+## Answer Webhook
+
+When an incoming call is answered, an HTTP request will be sent to the `answer_url` you specified when setting up the application. For outgoing calls, the `answer_url` is specified when making the call.
+
+By default, the answer webhook will be a `GET` request but this can be overridden to `POST` by setting the `answer_method` when making an outbound call with the Nexmo Voice API.
+
+### Answer webhook data fields
+
+Field | Example | Description 
+ -- | -- | --
+`to` | `442079460000` | The number the call came from (this could be your Nexmo number if the call is started programmatically)
+`from` | `447700900000` | The call the number is to (this could be a Nexmo number or another phone number)
+`uuid` | `aaaaaaaa-bbbb-cccc-dddd-0123456789ab` | A unique identifier for this call
+`conversation_uuid` | `CON-aaaaaaaa-bbbb-cccc-dddd-0123456789ab` | A unique identifier for this conversation
+
+### Answer webhook data field examples
+
+For a `GET` request, the variables will be in the URL, like this:
+
+```
+/answer.php?to=442079460000&from=447700900000&conversation_uuid=CON-aaaaaaaa-bbbb-cccc-dddd-0123456789ab&uuid=aaaaaaaa-bbbb-cccc-dddd-0123456789ab
+```
+
+If you set the `answer_method` to `POST` then you will receive the request with JSON-format data in the body:
+
+```
+{
+  "from": "442079460000",
+  "to": "447700900000",
+  "uuid": "aaaaaaaa-bbbb-cccc-dddd-0123456789ab",
+  "conversation_uuid": "CON-aaaaaaaa-bbbb-cccc-dddd-0123456789ab"
+}
+```
+
+### Responding to the answer webhook
+
+Nexmo expect you to return an array of [NCCO](/voice/voice-api/ncco-reference) in JSON.
+
+## Event webhook
+
+HTTP requests will arrive at the event webhook endpoint when there is any status change for a call. The URL will be the `event_url` you specified when creating your application unless you override it by setting a specific `event_url` when starting a call.
+
+The incoming requests are `POST` requests with a JSON body.
+
+The format of the data included depends on which event has occurred:
+
+* [`started`](#started)
+* [`ringing`](#ringing)
+* [`answered`](#answered)
+* [`busy`](#busy)
+* [`cancelled`](#cancelled)
+* [`human/machine`](#human-machine)
+* [`timeout`](#timeout)
+* [`completed`](#completed)
+* [`record`](#record)
+* [`input`](#input)
+
+### Started
+
+Indicates that the call has begun.
+
+Field | Example | Description
+ -- | -- | --
+`from` | `442079460000` | The number the call came from
+`to` | `447700900000` | The number the call was made to 
+`uuid` | `aaaaaaaa-bbbb-cccc-dddd-0123456789ab` | The unique identifier for this call
+`conversation_uuid` | `CON-aaaaaaaa-bbbb-cccc-dddd-0123456789ab` | The unique identifier for this conversation
+`status` | `started` | Call status
+`direction` | `outbound` | Call direction, can be either `inbound` or `outbound`
+`timestamp` | `2020-01-01T12:00:00.000Z` | Timestamp (ISO 8601 format)
+
+### Ringing
+
+The destination is reachable and ringing.
+
+Field | Example | Description
+ -- | -- | --
+`from` | `442079460000` | The number the call came from
+`to` | `447700900000` | The number the call was made to 
+`uuid` | `aaaaaaaa-bbbb-cccc-dddd-0123456789ab` | The unique identifier for this call
+`conversation_uuid` | `CON-aaaaaaaa-bbbb-cccc-dddd-0123456789ab` | The unique identifier for this conversation
+`status` | `ringing` | Call status
+`direction` | `outbound` | Call direction, can be either `inbound` or `outbound`
+`timestamp` | `2020-01-01T12:00:00.000Z` | Timestamp (ISO 8601 format)
+
+### Answered
+
+The call was answered.
+
+Field | Example | Description
+ -- | -- | --
+`start_time` | - | *empty*
+`rate` | - | *empty*
+`from` | `442079460000` | The number the call came from
+`to` | `447700900000` | The number the call was made to 
+`uuid` | `aaaaaaaa-bbbb-cccc-dddd-0123456789ab` | The unique identifier for this call
+`conversation_uuid` | `CON-aaaaaaaa-bbbb-cccc-dddd-0123456789ab` | The unique identifier for this conversation
+`status` | `answered` | Call status
+`direction` | `inbound` | Call direction, can be either `inbound` or `outbound`
+`network` | - | *empty*
+`timestamp` | `2020-01-01T12:00:00.000Z` | Timestamp (ISO 8601 format)
+
+### Busy
+
+The destination number was busy.
+
+Field | Example | Description
+ -- | -- | --
+`from` | `442079460000` | The number the call came from
+`to` | `447700900000` | The number the call was made to 
+`uuid` | `aaaaaaaa-bbbb-cccc-dddd-0123456789ab` | The unique identifier for this call
+`conversation_uuid` | `CON-aaaaaaaa-bbbb-cccc-dddd-0123456789ab` | The unique identifier for this conversation
+`status` | `busy` | Call status
+`direction` | `outbound` | Call direction, this will be `outbound` in this context
+`timestamp` | `2020-01-01T12:00:00.000Z` | Timestamp (ISO 8601 format)
+
+### Cancelled
+
+An outgoing call was cancelled before it was answered.
+
+Field | Example | Description
+ -- | -- | --
+`from` | `442079460000` | The number the call came from
+`to` | `447700900000` | The number the call was made to 
+`uuid` | `aaaaaaaa-bbbb-cccc-dddd-0123456789ab` | The unique identifier for this call
+`conversation_uuid` | `CON-aaaaaaaa-bbbb-cccc-dddd-0123456789ab` | The unique identifier for this conversation
+`status` | `cancelled` | Call status
+`direction` | `outbound` | Call direction, this will be `outbound` in this context
+`timestamp` | `2020-01-01T12:00:00.000Z` | Timestamp (ISO 8601 format)
+
+### Human / Machine
+
+For an outbound call made programmatically, if the `machine_detection` option is set then an event with a status of `human` or `machine` will be sent depending whether a person answered the call or not.
+
+Field | Example | Description
+ -- | -- | --
+`call_uuid` | `aaaaaaaa-bbbb-cccc-dddd-0123456789ab` | The unique identifier for this call (**Note** `call_uuid`, not `uuid` as in some other endpoints)
+`from` | `442079460000` | The number the call came from
+`to` | `447700900000` | The number the call was made to 
+`status` | `human` | Call status, can be either `human` if a person answered or `machine` if the call was answered by voicemail or another automated service
+`conversation_uuid` | `CON-aaaaaaaa-bbbb-cccc-dddd-0123456789ab` | The unique identifier for this conversation
+`timestamp` | `2020-01-01T12:00:00.000Z` | Timestamp (ISO 8601 format)
+
+### Timeout
+
+If the duration of the ringing phase exceeds the specified `ringing_timeout` duration, this event will be sent.
+
+Field | Example | Description
+ -- | -- | --
+`from` | `442079460000` | The number the call came from
+`to` | `447700900000` | The number the call was made to 
+`uuid` | `aaaaaaaa-bbbb-cccc-dddd-0123456789ab` | The unique identifier for this call
+`conversation_uuid` | `CON-aaaaaaaa-bbbb-cccc-dddd-0123456789ab` | The unique identifier for this conversation
+`status` | `timeout` | Call status
+`direction` | `outbound` | Call direction, this will be `outbound` in this context
+`timestamp` | `2020-01-01T12:00:00.000Z` | Timestamp (ISO 8601 format)
+
+### Completed
+
+The call is over, this event also includes summary data about the call.
+
+Field | Example | Description
+ -- | -- | --
+`end_time` | `2020-01-01T12:00:00.000Z` | Timestamp (ISO 8601 format)
+`uuid` | `aaaaaaaa-bbbb-cccc-dddd-0123456789ab` | The unique identifier for this call
+`network` | `GB-FIXED` | The type of network that was used in the call
+`duration` | `2` | Call length (in seconds)
+`start_time` | `2020-01-01T12:00:00.000Z` | Timestamp (ISO 8601 format)
+`rate` | `0.00450000` | Cost per minute of the call (EUR)
+`price` | `0.00015000` | Total cost of the call (EUR)
+`from` | `442079460000` | The number the call came from
+`to` | `447700900000` | The number the call was made to 
+`conversation_uuid` | `CON-aaaaaaaa-bbbb-cccc-dddd-0123456789ab` | The unique identifier for this conversation
+`status` | `completed` | Call status
+`direction` | inbound | Call direction, can be either `inbound` or `outbound`
+`timestamp` | `2020-01-01T12:00:00.000Z` | Timestamp (ISO 8601 format)
+
+### Record
+
+This webhook arrives when an NCCO with a "record" action has finished. When creating a record action, you can set a different `eventURL` for this event to be sent to if you wish.
+
+Field | Example | Description
+ -- | -- | --
+`start_time` | `2020-01-01T12:00:00.000Z` | Timestamp (ISO 8601 format)
+`recording_url` | `https://api.nexmo.com/v1/files/bbbbbbbb-aaaa-cccc-dddd-0123456789ab` | Where to download the recording
+`size` | 12222 | The size of the recording file (in bytes)
+`recording_uuid` | `aaaaaaaa-bbbb-cccc-dddd-0123456789ab` | A unique identifer for this recording
+`end_time` | `2020-01-01T12:00:00.000Z` | Timestamp (ISO 8601 format)
+`conversation_uuid` | `CON-aaaaaaaa-bbbb-cccc-dddd-0123456789ab` | The unique identifier for this conversation
+`timestamp` | `2020-01-01T12:00:00.000Z` | Timestamp (ISO 8601 format)
+
+### Input 
+
+This webhook is sent by Nexmo when an NCCO with an action of "input" has finished.
+
+Field | Example | Description
+ -- | -- | --
+`dtmf` | `42` | The buttons pressed by the user
+`timed_out` | `1` | Whether the input action timed out: `1` if it did, or an empty field if not
+`uuid` | `aaaaaaaa-bbbb-cccc-dddd-0123456789ab` | The unique identifier for this call
+`conversation_uuid` | `CON-aaaaaaaa-bbbb-cccc-dddd-0123456789ab` | The unique identifier for this conversation
+`timestamp` | `2020-01-01T12:00:00.000Z` | Timestamp (ISO 8601 format)


### PR DESCRIPTION
## Description

This adds some documentation of the fields and possible values for each of the webhooks that we have for both answer and event on the Voice API.

This covers the main use cases but misses a few things including the `failed`, `rejected` and `error` events that I'm not sure how to trigger. If anyone can fill the gaps as well as review if the documentation is a useful format etc, then that would be grand. I think we need to look at where we link to it from and how it is rendered in the menu as well.

We probably need some discussion before it merges, but I'd appreciate reviews.