### PR TITLE
Expand curl and node async trigger blocks, use correct var names for .NET

### DIFF
--- a/_examples/number-insight/advanced/csharp.yml
+++ b/_examples/number-insight/advanced/csharp.yml
@@ -4,9 +4,9 @@ language: dotnet
 dependencies:
     - Nexmo.Csharp.Client
 client:
-    source: .repos/nexmo-community/nexmo-dotnet-quickstart/NexmoDotNetQuickStarts/Authentication/BasicAuth.cs
-    from_line: 13
-    to_line: 17
+    source: .repos/nexmo-community/nexmo-dotnet-quickstart/NexmoDotNetQuickStarts/Controllers/NumberInsightController.cs
+    from_line: 12
+    to_line: 16
 code:
     source: .repos/nexmo-community/nexmo-dotnet-quickstart/NexmoDotNetQuickStarts/Controllers/NumberInsightController.cs
     from_line: 133

--- a/_examples/number-insight/async-trigger/curl.yml
+++ b/_examples/number-insight/async-trigger/curl.yml
@@ -4,6 +4,6 @@ language: curl
 code:
     source: .repos/nexmo/curl-building-blocks/number-insight/ni-advanced-async.sh
     from_line: 5
-    to_line: 8
+    to_line: 9
 file_name: ni-advanced-async.sh
 run_command: 'sh ni-advanced-async.sh'

--- a/_examples/number-insight/async-trigger/node.yml
+++ b/_examples/number-insight/async-trigger/node.yml
@@ -8,6 +8,6 @@ dependencies:
 code:
     source: .repos/nexmo-community/nexmo-node-quickstart/number_insight/ni-advanced-async-client.js
     from_line: 9
-    to_line: 16
+    to_line: 27
 file_name: ni-advanced-async-client.js
 run_command: 'node ni-advanced-async-client.js'

--- a/_examples/number-insight/basic/csharp.yml
+++ b/_examples/number-insight/basic/csharp.yml
@@ -4,9 +4,9 @@ language: dotnet
 dependencies:
     - Nexmo.Csharp.Client
 client:
-    source: .repos/nexmo-community/nexmo-dotnet-quickstart/NexmoDotNetQuickStarts/Authentication/BasicAuth.cs
-    from_line: 13
-    to_line: 17
+    source: .repos/nexmo-community/nexmo-dotnet-quickstart/NexmoDotNetQuickStarts/Controllers/NumberInsightController.cs
+    from_line: 12
+    to_line: 16
 code:
     source: .repos/nexmo-community/nexmo-dotnet-quickstart/NexmoDotNetQuickStarts/Controllers/NumberInsightController.cs
     from_line: 34

--- a/_examples/number-insight/standard/csharp.yml
+++ b/_examples/number-insight/standard/csharp.yml
@@ -4,9 +4,9 @@ language: dotnet
 dependencies:
     - Nexmo.Csharp.Client
 client:
-    source: .repos/nexmo-community/nexmo-dotnet-quickstart/NexmoDotNetQuickStarts/Authentication/BasicAuth.cs
-    from_line: 13
-    to_line: 17
+    source: .repos/nexmo-community/nexmo-dotnet-quickstart/NexmoDotNetQuickStarts/Controllers/NumberInsightController.cs
+    from_line: 12
+    to_line: 16
 code:
     source: .repos/nexmo-community/nexmo-dotnet-quickstart/NexmoDotNetQuickStarts/Controllers/NumberInsightController.cs
     from_line: 72


### PR DESCRIPTION
## Description

The Async trigger `curl` and `node` building blocks were not showing the complete code.
The `dotnet` building blocks are using `BasicAuth.cs` for the client code, but this is incorrect because the variable name for the Nexmo client is `client` and not `Client` as per the `NumberInsightController.cs` file. Use the `NumberInsightController.cs` client creation code instead.

## Deploy Notes

In the sample app:

- Check that the basic/standard/advanced .NET number insight blocks look OK.
- In the Async trigger building blocks (`/number-insight/building-blocks/number-insight-advanced-async`)
    - Check that you can see the `$WEBHOOK_URL` query parameter in the `curl` example
    - Check that you can see the code that creates the Nexmo client and calls the API in the `node` example
