### PR TITLE
Broken link in messaging docs

### DIFF
--- a/_partials/reusable/create-a-nexmo-application.md
+++ b/_partials/reusable/create-a-nexmo-application.md
@@ -4,7 +4,7 @@ In order to create a JWT to authenticate your API requests, you will need to fir
 
 ### Create a Nexmo Messages and Dispatch Application using the Dashboard
 
-This can be done under the [Messages and Dispatch tab in the Dashboard](https://https://dashboard.nexmo.com/messages/create-application).
+This can be done under the [Messages and Dispatch tab in the Dashboard](https://dashboard.nexmo.com/messages/create-application).
 
 When you are creating the Nexmo Application in the [Nexmo Dashboard](https://dashboard.nexmo.com/messages/create-application) you can click the link _Generate public/private key pair_ - this will create a public/private key pair and the private key will be downloaded by your browser.
 


### PR DESCRIPTION
## Description

This pull request fixes a very minor typo that stopped a link from working, reported via the support email.