### PR TITLE
Add mention of external accounts.

### DIFF
--- a/_documentation/dispatch/overview.md
+++ b/_documentation/dispatch/overview.md
@@ -18,6 +18,7 @@ The following diagram illustrates the relationship between the Dispatch API and 
 
 * [Beta](#beta)
 * [Supported features](#supported-features)
+* [External Accounts API](#external-accounts-api)
 * [Getting started](#getting-started)
 * [Concepts](#concepts)
 * [Building Blocks](#building-blocks)
@@ -40,6 +41,10 @@ In this release you can:
 * **Failover** to the next message if the condition status is not met within the time period or if the message immediately fails.
 
 The condition status is the status that the message returns. With Facebook Messenger and Viber Service Messages, you can use `delivered` and `read` statuses as the condition status. With SMS you can only use `delivered`.
+
+## External Accounts API
+
+The [External Accounts API](/api/external-accounts) is used to manage your accounts for Viber Service Messages, Facebook Messenger and Whatsapp when using those channels with the Messages and Dispatch APIs.
 
 ## Getting started
 
@@ -83,3 +88,4 @@ product: dispatch
 ## Reference
 
 * [Dispatch API Reference](/api/dispatch)
+* [External Accounts API Reference](/api/external-accounts)

--- a/_documentation/messages/overview.md
+++ b/_documentation/messages/overview.md
@@ -22,6 +22,7 @@ The following diagram illustrates the relationship between the Messages API and 
 
 * [Beta](#beta)
 * [Supported features](#supported-features)
+* [External Accounts API](#external-accounts-api)
 * [Getting started](#getting-started)
 * [Concepts](#concepts)
 * [Building Blocks](#building-blocks)
@@ -57,6 +58,10 @@ WhatsApp | ✅ | ❎ | ❎ | ❎ | ❎ | ❎
 * ✅ = Supported.
 * ❎ = Supported by the channel, but not by Nexmo. 
 * n/a = Not supported by the channel.
+
+## External Accounts API
+
+The [External Accounts API](/api/external-accounts) is used to manage your accounts for Viber Service Messages, Facebook Messenger and Whatsapp when using those channels with the Messages and Dispatch APIs.
 
 ## Getting started
 
@@ -98,3 +103,5 @@ product: messages
 ## Reference
 
 * [Messages API Reference](/api/messages)
+* [External Accounts API Reference](/api/external-accounts)
+


### PR DESCRIPTION
## Description

There is now the External Accounts API for managing accounts for Facebook Messenger, WhatsApp, and Viber Service Messages. This should actually be a top-level API (with Concepts, Building Blocks, Tutorials etc). In this PR we simply link in the new API Reference from the Overviews of both Messages and Dispatch API, along with some explanatory text.

p.s. I will update API Reference page via another PR and add Messages, Dispatch and External Accounts APIs there. 

## Deployment

- [ ] Build review app
- [ ] Test