### PR TITLE
Fixed Broken Links

### DIFF
--- a/_tutorials/retrieve-audit-events.md
+++ b/_tutorials/retrieve-audit-events.md
@@ -29,7 +29,7 @@ In order to work through this tutorial you'll need:
 * A Terminal application running into which you can type or paste Curl commands. Alternatively you could use Paw, Postman or a similar application.
 * You will need to know your `NEXMO_API_KEY` and `NEXMO_API_SECRET` which you can obtain from your [Nexmo Dashboard](https://dashboard.nexmo.com/sign-in).
 
-You can also refer to the [Audit API documentation](/audit/overview).
+You can also refer to the [Audit API documentation](_documentation/audit/overview).
 
 > **NOTE:** In the examples below, please replace `NEXMO_API_KEY` and `NEXMO_API_SECRET` with actual values obtained from your [Nexmo Dashboard](https://dashboard.nexmo.com).
 
@@ -50,7 +50,7 @@ The list of audit events you receive in the previous step may well be overwhelmi
 
 Query Parameter | Description
 --- | ---
-`event_type` | The type of the audit event, for example: `APP_CREATE`, `NUMBER_ASSIGN`, and so on. You can specify a comma-delimited list of [event types](/audit/concepts/audit-events#audit-event-types) here.
+`event_type` | The type of the audit event, for example: `APP_CREATE`, `NUMBER_ASSIGN`, and so on. You can specify a comma-delimited list of [event types](_documentation/audit/concepts/audit-events#audit-event-types) here.
 `search_text` | JSON compatible search string. Look for specific text in an audit event.
 `date_from` | Retrieve audit events from this date (in ISO-8601 format).
 `date_to` | Retrieve audit events to this date (in ISO-8601 format).
@@ -67,7 +67,7 @@ $ curl "https://api.nexmo.com/beta/audit/events?date_from=2018-08-01&date_to=201
 
 This will return all audit events that occurred during August 2018.
 
-You can narrow this down further in various ways. For example you can also filter based on [audit event type](/audit/concepts/audit-events#audit-event-types).
+You can narrow this down further in various ways. For example you can also filter based on [audit event type](_documentation/audit/concepts/audit-events#audit-event-types).
 
 So for example, to find audit events in August of type `NUMBER_ASSIGN` you could enter the following:
 
@@ -100,5 +100,5 @@ Using the filtering capabilities of the Audit API you have complete control rega
 
 ## Resources
 
-* [Audit API docs](/audit/overview)
+* [Audit API docs](_documentation/audit/overview)
 * [Audit API Reference](/api/audit)


### PR DESCRIPTION
## Description

Fixed some broken links in ***_tutorials/retrieve-audit-events.md***

## Deploy Notes

No db migrations, etc. has been made. Just fixed the links to documents which were redirecting to unavailable page & thus giving an error 404 not found.
