### PR TITLE
typo : Double use of words

### DIFF
--- a/_documentation/messaging/sns/building-blocks/sending-a-message.md
+++ b/_documentation/messaging/sns/building-blocks/sending-a-message.md
@@ -13,7 +13,7 @@ Key | Description
 `FROM_NUMBER` | The number you are sending the message from.
 `API_KEY` | You can find this in your [account overview](https://dashboard.nexmo.com/account-overview)
 `API_SECRET` | You can find this in your [account overview](https://dashboard.nexmo.com/account-overview)
-`SNS_ARN` | The ARN for the the SNS that you are broadcasting to. It's policy must allow the Nexmo user ID `564623767830` to subscribe & publish.
+`SNS_ARN` | The ARN for the SNS that you are broadcasting to. It's policy must allow the Nexmo user ID `564623767830` to subscribe & publish.
 
 ```sh
 curl -X "POST" "https://sns.nexmo.com/sns/json?api_key=API_KEY&api_secret=API_SECRET" \

--- a/_documentation/messaging/sns/building-blocks/subscribe-a-user.md
+++ b/_documentation/messaging/sns/building-blocks/subscribe-a-user.md
@@ -12,7 +12,7 @@ Key | Description
 `TO_NUMBER` | The number you would like to subscribe
 `API_KEY` | You can find this in your [account overview](https://dashboard.nexmo.com/account-overview)
 `API_SECRET` | You can find this in your [account overview](https://dashboard.nexmo.com/account-overview)
-`SNS_ARN` | The ARN for the the SNS that you are subscribing the user to. It's policy must allow the Nexmo user ID `564623767830` to subscribe & publish.
+`SNS_ARN` | The ARN for the SNS that you are subscribing the user to. It's policy must allow the Nexmo user ID `564623767830` to subscribe & publish.
 
 ```sh
 curl -X "POST" "https://sns.nexmo.com/sns/json?api_key=API_KEY&api_secret=API_SECRET" \

--- a/_documentation/messaging/us-short-codes/guides/campaign-subscription-management.md
+++ b/_documentation/messaging/us-short-codes/guides/campaign-subscription-management.md
@@ -7,7 +7,7 @@ description: Create an opt-in and opt-out process for recipients of your campaig
 
 Messaging activities fall under the regulatory guidelines of several groups, depending on the nation in which you send the messages. For more information see [Pre approved US Short Codes compliance requirements](https://help.nexmo.com/hc/en-us/articles/204015403-Pre-approved-US-Short-Codes-compliance-requirements)
 
-You use the The *opt-in* API to:
+You use the *opt-in* API to:
 
 * Create an opt-out process so a user can [unsubscribe to your campaign](#unsubscribe-to-your-campaign)
 * [Resubscribe](#resubscribe-to-your-campaign) a user to you campaign

--- a/_documentation/number-insight/overview.md
+++ b/_documentation/number-insight/overview.md
@@ -50,7 +50,7 @@ Access asynchronously | ❎ | ❎ | ✅
 
 ## Getting Started
 
-This example shows you how to use the the [Nexmo CLI](/tools) to access the Number Insight Basic API and display information about a number.
+This example shows you how to use the [Nexmo CLI](/tools) to access the Number Insight Basic API and display information about a number.
 
 > For examples of how to use Basic, Standard and Advanced Number Insight with `curl` and the developer SDKs see the [Building Blocks](#building-blocks).
 

--- a/_documentation/numbers/guides/management.md
+++ b/_documentation/numbers/guides/management.md
@@ -67,7 +67,7 @@ You use the *api_key* and *api_secret* associated with primary and secondary acc
 
 ## Manage your profile
 
-Dashboard uses the the information you gave during setup to create your Nexmo profile. This includes:
+Dashboard uses the information you gave during setup to create your Nexmo profile. This includes:
 
 * Contact information - phone number, email, skype and password.
 * Company information - name, address and VAT number.
@@ -84,7 +84,7 @@ To reset your Nexmo password:
 
 1. Navigate to [Forgot your password?](https://dashboard.nexmo.com/sign-in/forgot-password).
 2. Enter the email address associated with your Nexmo account and click **Reset password**.
-3. You receive a password reset link at the the email address associated with your Nexmo account. This link is valid for 15 minutes.
+3. You receive a password reset link at the email address associated with your Nexmo account. This link is valid for 15 minutes.
 4. Navigate to the reset link and reset your password.
 
 If having are still having issues, please contact <support@nexmo.com>.

--- a/_extend/google-ccml-Integration.md
+++ b/_extend/google-ccml-Integration.md
@@ -13,7 +13,7 @@ For this solution, we have taken a fully programmable approach, using our Nexmo 
 
 The first part of this solution, brings together the Dialogflow Virtual agent, our integration to a CRM platform and the Contact center AI, all flowing over VAPI our voice API. This allows us to pull contextual information about the caller from CRM, helping to inform the virtual agent then collect responses from the customer, giving the virtual agent all the information it needs to return a suggested answer thru the Google Contact Center AI APIs.
 
-The Vonage Team had worked hard to foster a close relationship to be involved in key alpha product developments and we were able to show an integration live at the the Google Next conference in San Francisco in July 2018.
+The Vonage Team had worked hard to foster a close relationship to be involved in key alpha product developments and we were able to show an integration live at the Google Next conference in San Francisco in July 2018.
 
 ## Usage
 For the Google Next demo we produced an application that leveraged the Voice API, Comms Router and Google CC AI as well as Dialogflow.

--- a/_open_api/errors/messages-and-workflows-apis/messages.md
+++ b/_open_api/errors/messages-and-workflows-apis/messages.md
@@ -44,6 +44,6 @@ Code | Text | Meaning
 `1320` | Message already sent | The message was already sent.
 `1330` | Unknown | An unknown error was received from the carrier who tried to send this this message. Depending on the carrier, that to is unknown. When you see this error, and status is rejected, always check if to in your request was valid.
 `1340` | Outside of the allowed window | This message is sent outside of allowed response window.
-`1350` | Phone matching fee not paid | Requires phone matching access fee to be paid by the the Facebook Page.
+`1350` | Phone matching fee not paid | Requires phone matching access fee to be paid by the Facebook Page.
 `1360` | TTL was activated | TTL was activated, no callbacks and no charge will be issued.
 `1370` | Expired access Token | The access token has expired, for Facebook Messenger, the consent has to be periodically given every 90 days. Try to delete and reconnect the Facebook page to Nexmo.

--- a/_partials/stitch/guides/enable-audio/ios.md
+++ b/_partials/stitch/guides/enable-audio/ios.md
@@ -170,7 +170,7 @@ After the user logs in, they'll press the "Chat" button which will take them to 
 
 ### 1.6 Navigate to ChatViewController
 
-As we mentioned above, creating a conversation results from a call to the the `new()` method. In the absence of a server we’ll 'simulate' the creation of a conversation within the app when the user clicks the chatBtn.
+As we mentioned above, creating a conversation results from a call to the `new()` method. In the absence of a server we’ll 'simulate' the creation of a conversation within the app when the user clicks the chatBtn.
 
 When we construct the segue for `ChatViewController`, we pass the first conversation so that the new controller. Remember that the `CONVERSATION_ID` comes from the id generated in [the first quickstart](/stitch/in-app-messaging/guides/simple-conversation/ios).
 

--- a/_partials/stitch/guides/simple-conversation/ios.md
+++ b/_partials/stitch/guides/simple-conversation/ios.md
@@ -279,7 +279,7 @@ After the user logs in, they'll press the "Chat" button which will take them to 
 
 ### 2.5 Navigate to ChatViewController
 
-As we mentioned above, creating a conversation results from a call to the the new() method. In the absence of a server we’ll ‘simulate’ the creation of a conversation within the app when the user clicks the chatBtn.
+As we mentioned above, creating a conversation results from a call to the new() method. In the absence of a server we’ll ‘simulate’ the creation of a conversation within the app when the user clicks the chatBtn.
 
 When we construct the segue for `ChatViewController`, we pass the first conversation so that the new controller. Remember that the `CONVERSATION_ID` comes from the id generated in step 1.2.
 

--- a/_partials/stitch/guides/utilizing-events/ios.md
+++ b/_partials/stitch/guides/utilizing-events/ios.md
@@ -66,7 +66,7 @@ tableView.delegate = self
 tableView.dataSource = self
 ```
 
-Designating `ChatViewController` as delegate for the `UITableView` means that the `ChatViewController` agrees to act on behalf of the `UITableView` to take care of whatever delegate methods are required for our instance of `UITableView`. Similarly, designating `ChatViewController` as the the dataSource means that the `ChatViewController` agrees to act on behalf of the `UITableView` to handle methods required for funneling data into the UITableView. Accordingly, we must now program these methods. This is called 'conforming'.
+Designating `ChatViewController` as delegate for the `UITableView` means that the `ChatViewController` agrees to act on behalf of the `UITableView` to take care of whatever delegate methods are required for our instance of `UITableView`. Similarly, designating `ChatViewController` as the dataSource means that the `ChatViewController` agrees to act on behalf of the `UITableView` to handle methods required for funneling data into the UITableView. Accordingly, we must now program these methods. This is called 'conforming'.
 
 ### 2.3.1 Programming Delegate and Datasource
 

--- a/_tutorials/interactive-voice-response.md
+++ b/_tutorials/interactive-voice-response.md
@@ -170,7 +170,7 @@ A Nexmo Call Control Object (NCCO) is a JSON array that is used to control the f
 
 To manage NCCOs this example application uses array manipulation and a few simple methods.
 
-The router handles encoding to JSON, the `Menu` object provides access to the the NCCO stack with its `getStack()` method:
+The router handles encoding to JSON, the `Menu` object provides access to the NCCO stack with its `getStack()` method:
 
 ```php
 <?php

--- a/_tutorials/two-factor-authentication.md
+++ b/_tutorials/two-factor-authentication.md
@@ -315,7 +315,7 @@ end
 
 To validate the PIN submitted by the user you use the [Nexmo REST API client for Ruby](https://github.com/Nexmo/nexmo-ruby) to make a [Verify Check](/api/verify#check) request. You pass the *request_id* and the PIN entered by the user to Verify.  
 
-The Verify API response tells you if the the user entered the correct PIN. If *status* is *0*, log the user in:
+The Verify API response tells you if the user entered the correct PIN. If *status* is *0*, log the user in:
 
 **app/controllers/verifications_controller.rb**
 

--- a/app/views/contribute/guides/platform.md
+++ b/app/views/contribute/guides/platform.md
@@ -55,11 +55,11 @@ Document | Description
 >
 > §
 >
-> The ordering is a flat lookup of the name. This can cause issues if two different orderings are required relating to two or more menu items with the same name. An example of this is that at the time of writing this Concepts sits as the very first and top-most element. If a product was to need a concepts section this would be forced to the the top the the product tree since they would both share a common name.
+> The ordering is a flat lookup of the name. This can cause issues if two different orderings are required relating to two or more menu items with the same name. An example of this is that at the time of writing this Concepts sits as the very first and top-most element. If a product was to need a concepts section this would be forced to the top the product tree since they would both share a common name.
 >
 > §
 >
-> Although this specific issue hasn't been addressed some work has been made towards having a tree based overides, this could allow an individual item to be overridden by specifying it's location within the the document hirearchy. You can see the start of this work under `navigation_overrides` within the `/config/navigation.yml` file.
+> Although this specific issue hasn't been addressed some work has been made towards having a tree based overides, this could allow an individual item to be overridden by specifying it's location within the document hirearchy. You can see the start of this work under `navigation_overrides` within the `/config/navigation.yml` file.
 
 ## Pages and content
 
@@ -136,7 +136,7 @@ Here is a quick explanation of all of the filters:
 Filter | Current User Context | Type | Description
 --- | --- | --- | ---
 Frontmatter | No | [Implicit] | Strips frontmatter from documents
-PHPInliner | No | [Implicit] | Fixes a quirk with our code parser that requires PHP code to to have `<?php` at the start. This filter adds an option onto PHP code examples that makes this not required.
+PHPInliner | No | [Implicit] | Fixes a quirk with our code parser that requires PHP code to have `<?php` at the start. This filter adds an option onto PHP code examples that makes this not required.
 InlineEscape | No | [Extended] | Allows for escaping of inline code where normally the internals would be processes by the markdown. For example this isn't turned into a ``[label]`` when surrounded by two backticks.
 BlockEscape | No | [Extended] | Allows for escaping of code fences where normally the internals would be processes by the markdown.
 Screenshot | No | [Plugin] | Allows for screenshots be put into documentation that are captured by a headless browser so they can be easily refreshed.


### PR DESCRIPTION
## Description

Fixing typo double use of "the", "to". 

## Deploy Notes

Purely documentational changes.