### PR TITLE
Upgrade minimum version of ffi

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -167,3 +167,7 @@ end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: %i[mingw mswin x64_mingw jruby]
+
+# The following are dependencies of dependencies, but we require them here to
+# force minimum versions due to security issues
+gem 'ffi', '>= 1.9.24'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -139,7 +139,7 @@ GEM
       i18n (~> 0.5)
     faraday (0.13.1)
       multipart-post (>= 1.2, < 3)
-    ffi (1.9.23)
+    ffi (1.9.25)
     formatador (0.2.5)
     formtastic (3.1.5)
       actionpack (>= 3.2.13)
@@ -431,6 +431,7 @@ DEPENDENCIES
   dotenv-rails
   factory_bot_rails (= 4.8.2)
   faker (= 1.8.4)
+  ffi (>= 1.9.24)
   foundation-rails (= 6.4.1.2)
   friendly_id (= 5.2.3)
   gravatar_image_tag (= 1.2.0)


### PR DESCRIPTION
## Description

> ruby-ffi version 1.9.23 and earlier has a DLL loading issue which can be hijacked on Windows OS, when a Symbol is used as DLL name instead of a String This vulnerability appears to have been fixed in v1.9.24 and later.

We don't run on Windows, but better safe than sorry

## Deploy Notes

N/A