### PR TITLE
Render all documentation pages at build time in case exceptions are thrown

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ services:
   - postgresql
 addons:
   postgresql: '9.4'
-install: bundle install --deployment --path vendor/bundle
+install: bundle install --deployment --path vendor/bundle && yarn install
 before_script:
   - |
     if [ -z "$SSH_KEY_REQUIRED" ]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,4 +24,5 @@ before_script:
 script:
   - bundle exec rake spec
   - bundle exec rubocop
-  - bundle exec rake ci:render_pages
+  - bundle exec rake ci:verify_pages
+  - bundle exec rake ci:verify_navigation

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,3 +24,4 @@ before_script:
 script:
   - bundle exec rake spec
   - bundle exec rubocop
+  - bundle exec rake ci:render_pages

--- a/lib/tasks/ci.rake
+++ b/lib/tasks/ci.rake
@@ -1,6 +1,6 @@
 namespace :ci do
-  desc 'Render all pages to make sure that no exceptions are thrown'
-  task 'render_pages': :environment do
+  desc 'Verify all pages to make sure that no exceptions are thrown'
+  task 'verify_pages': :environment do
     document_paths =
       [
         "#{Rails.root}/_documentation/**/*.md",
@@ -13,5 +13,12 @@ namespace :ci do
         MarkdownPipeline.new.call(document)
       end
     end
+  end
+
+  desc 'Verify side navigation to make sure every page has valid YAML metadata'
+  task 'verify_navigation': :environment do
+    session = ActionDispatch::Integration::Session.new(Rails.application)
+    res = session.get '/documentation'
+    raise 'Error rendering documentation index page' if res == 500
   end
 end

--- a/lib/tasks/ci.rake
+++ b/lib/tasks/ci.rake
@@ -1,0 +1,17 @@
+namespace :ci do
+  desc 'Render all pages to make sure that no exceptions are thrown'
+  task 'render_pages': :environment do
+    document_paths =
+      [
+        "#{Rails.root}/_documentation/**/*.md",
+        "#{Rails.root}/_api/**/*.md",
+        "#{Rails.root}/_tutorials/**/*.md",
+      ]
+    document_paths.each do |path|
+      Dir.glob(path).each do |filename|
+        document = File.read(filename)
+        MarkdownPipeline.new.call(document)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Description

In a recent commit a change was made that added a new `type` field to
building blocks without a default. The decision to fail fast was made as
it looked like all building blocks had been updated.

It wasn't until we tried to update the search index (which renders every
page) that we noticed an exception being thrown by a building block that
hadn't been updated.

This commit adds a build step that renders every markdown file at build
time to prevent this happening again

## Deploy Notes

N/A