### PR TITLE
Add note about Messages API rate limit

### DIFF
--- a/_api/developer/messages.md
+++ b/_api/developer/messages.md
@@ -6,9 +6,14 @@ api: Developer API
 
 # Developer - Messages API Reference
 
+> <strong>Please note that the Messages API is rate limited to one request per second.</strong>
+
+> This API is intended for use during development and is not intended as a replacement for handling callbacks using a webhook
+
 ## Messages
 
 The Messages API lets you retrieve messages you have sent via the SMS API by ID, as well as retrieve details of messages that were rejected.
+
 
 ### Search
 


### PR DESCRIPTION
## Description

The messages API is limited to one request per second. Add a note to the API documentation page communicating this to customers

## Deploy Notes

N/A