### PR TITLE
Fix API error page table styling

### DIFF
--- a/app/views/api_errors/_error_table.html.erb
+++ b/app/views/api_errors/_error_table.html.erb
@@ -1,3 +1,4 @@
+<div class="Vlt-table Vlt-table--data Vlt-table--bordered">
 <table>
   <thead>
     <th>Error ID</th>
@@ -24,3 +25,4 @@
     <% end %>
   </tbody>
 </table>
+</div>


### PR DESCRIPTION
## Description

The API errors page e.g. https://developer.nexmo.com/api-errors/redact is unstyled

Before:

<img width="1149" alt="screen shot 2018-10-18 at 22 27 25" src="https://user-images.githubusercontent.com/59130/47151290-0c650d80-d325-11e8-8763-9c864584dbfc.png">

After:

<img width="1312" alt="screen shot 2018-10-18 at 22 27 34" src="https://user-images.githubusercontent.com/59130/47151296-10912b00-d325-11e8-8e56-3371fd9da8d4.png">

## Deploy Notes

N/A