### PR TITLE
Events, then videos, then slack on community page. Fixes #1107

### DIFF
--- a/app/views/static/community.html.erb
+++ b/app/views/static/community.html.erb
@@ -5,25 +5,6 @@
 
 </div>
 
-<% if @sessions.any? %>
-  
-  <div class="Vlt-card">
-    <div class="Vlt-grid">
-      <% @sessions.each_with_position do |session, first, last| %>
-        <div class="Vlt-col Vlt-col--1of3">
-          <h4><%= session.title %></h4>
-          <%= session.video_content.html_safe %>
-          <p><%= session.description %></p>
-          <br>
-        </div>
-      <% end %>
-    </div>
-  </div>
-
-<% end %>
-
-<hr>
-
 <div class="Vlt-grid Vlt-grid--margin-bottom1">
   <div class="Vlt-col Vlt-col--2of3">
     <h2>You can find us at these upcoming events</h2>
@@ -43,6 +24,25 @@
     <%= render 'event', event: event, first: first, last: last %>
   <% end %>
 </div>
+
+<hr>
+
+<% if @sessions.any? %>
+  
+  <div class="Vlt-card">
+    <div class="Vlt-grid">
+      <% @sessions.each_with_position do |session, first, last| %>
+        <div class="Vlt-col Vlt-col--1of3">
+          <h4><%= session.title %></h4>
+          <%= session.video_content.html_safe %>
+          <p><%= session.description %></p>
+          <br>
+        </div>
+      <% end %>
+    </div>
+  </div>
+
+<% end %>
 
 <hr>
 


### PR DESCRIPTION
## Description

The redesign seems to have put videos at the top of the page, but we had recently moved them to below the events entries. This puts the events back at the top, followed by videos.