### PR TITLE
Reinstate the Messages and Dispatch APIs on the APIs page

### DIFF
--- a/app/views/api/index.html.erb
+++ b/app/views/api/index.html.erb
@@ -32,11 +32,6 @@
             <p>For verifying users with US Short Codes</p>
           </a>
         </nav>
-        <div class="Vlt-card__cta">
-          <a href="/api/sms" class="Vlt-btn Vlt-btn--secondary">
-            Go to Messaging APIs
-          </a>
-        </div>
       </div>
     </div>
   </div>
@@ -68,11 +63,6 @@
             <p>For managing your Facebook Messenger, WhatsApp and Viber Service Messages accounts for use with Messages and Dispatch APIs.</p>
           </a>
         </nav>
-        <div class="Vlt-card__cta">
-          <a href="/api/messages-olympus" class="Vlt-btn Vlt-btn--secondary">
-            Go to Messages and Dispatch APIs
-          </a>
-        </div>
       </div>
     </div>
   </div>
@@ -101,11 +91,6 @@
             <p>The JSON format for Nexmo's Voice API.</p>
           </a>
         </nav>
-        <div class="Vlt-card__cta">
-          <a href="/api/voice" class="Vlt-btn Vlt-btn--secondary">
-            Go to Voice APIs
-          </a>
-        </div>
       </div>
     </div>
   </div>
@@ -133,11 +118,6 @@
             <p>You use custom templates to modify the default messages sent by the Verify API.</p>
           </a>
         </nav>
-        <div class="Vlt-card__cta">
-          <a href="/api/verify" class="Vlt-btn Vlt-btn--secondary">
-            Go to Verify
-          </a>
-        </div>
       </div>
     </div>
   </div>
@@ -161,11 +141,6 @@
             <p>The smart way to get real-time intelligence on numbers anywhere in the world and protect yourself from fraud and spam.</p>
           </a>
         </nav>
-        <div class="Vlt-card__cta">
-          <a href="/api/number-insight" class="Vlt-btn Vlt-btn--secondary">
-            Go to Number Insight
-          </a>
-        </div>
       </div>
     </div>
   </div>
@@ -236,11 +211,6 @@
             <p>Retrieve details of service pricing</p>
           </a>
         </nav>
-        <div class="Vlt-card__cta">
-          <a href="/api/developer" class="Vlt-btn Vlt-btn--secondary">
-            Go to Developer API
-          </a>
-        </div>
       </div>
     </div>
   </div>

--- a/app/views/api/index.html.erb
+++ b/app/views/api/index.html.erb
@@ -43,6 +43,42 @@
 
   <div class="Vlt-col Vlt-col--1of3">
     <div class="Vlt-card Vlt-card--image">
+      <div class="Vlt-card__image Vlt-card__image--app Vlt-card__image--purple">
+        <div class="Vlt-card__image__icon">
+          <svg><use xlink:href="/symbol/volta-icons.svg#Vlt-icon-chat"/></svg>
+        </div>
+      </div>
+      <div class="Vlt-card__content">
+        <h2 id="messaging-apis">
+          <a href="/api/messages-olympus">
+            Messages and Dispatch APIs
+          </a>
+        </h2>
+        <nav>
+          <a href="/api/messages-olympus" class="Nxd-card__link">
+            <h5>Messages API</h5>
+            <p>For messaging through SMS/MMS, Facebook Messenger, WhatsApp and Viber Service Messages.</p>
+          </a>
+          <a href="/api/dispatch" class="Nxd-card__link">
+            <h5>Dispatch API</h5>
+            <p>For orchestrating messaging workflows with failover.</p>
+          </a>
+          <a href="/api/external-accounts" class="Nxd-card__link">
+            <h5>External Accounts API</h5>
+            <p>For managing your Facebook Messenger, WhatsApp and Viber Service Messages accounts for use with Messages and Dispatch APIs.</p>
+          </a>
+        </nav>
+        <div class="Vlt-card__cta">
+          <a href="/api/messages-olympus" class="Vlt-btn Vlt-btn--secondary">
+            Go to Messages and Dispatch APIs
+          </a>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="Vlt-col Vlt-col--1of3">
+    <div class="Vlt-card Vlt-card--image">
       <div class="Vlt-card__image Vlt-card__image--app Vlt-card__image--green">
         <div class="Vlt-card__image__icon">
           <svg><use xlink:href="/symbol/volta-icons.svg#Vlt-icon-phone" /></svg>


### PR DESCRIPTION
## Description

Fixes #1113 - we had lost the new APIs that were added to `/api` on NDP. I also removed the extra buttons that arrived with the redesign because they didn't make much sense, they linked to one of the APIs but the whole point was that there were lists of APIs to choose from. These two things are in different commits in case anyone wants to keep the buttons ...