### PR TITLE
Bring input title in line with other titles. Fixes #1110

### DIFF
--- a/_documentation/voice/voice-api/ncco-reference.md
+++ b/_documentation/voice/voice-api/ncco-reference.md
@@ -229,7 +229,7 @@ WAV:
 * G.711 A-law/u-law
 * Microsoft GSM
 
-## `input`
+## Input
 
 You can use the `input` action to collect digits input by the person you are calling. This action is synchronous, Nexmo processes the input and forwards it in the [parameters](#Input-Return-Parameters) sent to the `eventURL` webhook endpoint you configure in your request. Your webhook endpoint should return another NCCO that replaces the existing NCCO and controls the Call based on the user input. You could use this functionality to create an Interactive Voice Response (IVR). For example, if your user presses *4*, you return a [connect](#connect) NCCO that forwards the call to your sales department.
 


### PR DESCRIPTION
## Description

One title was weird and red because it was `fixed width` - this makes it plain heading text like the other titles.