### PR TITLE
Make Heroku env vars optional for production only features

### DIFF
--- a/app.json
+++ b/app.json
@@ -18,11 +18,11 @@
     { "url": "heroku/ruby" }
   ],
   "env": {
-    "ALGOLIA_API_KEY": { "required": true },
-    "ALGOLIA_APPLICATION_ID": { "required": true },
-    "ALGOLIA_CONFIG": { "required": true },
-    "ALGOLIA_PUBLISHABLE_KEY": { "required": true },
-    "BUGSNAG_API_KEY": { "required": true },
+    "ALGOLIA_API_KEY": { "required": false },
+    "ALGOLIA_APPLICATION_ID": { "required": false },
+    "ALGOLIA_CONFIG": { "required": false },
+    "ALGOLIA_PUBLISHABLE_KEY": { "required": false },
+    "BUGSNAG_API_KEY": { "required": false },
     "RACK_ENV": { "required": true },
     "RAILS_ENV": { "required": true }
   }


### PR DESCRIPTION
## Description

Make Heroku env vars optional for production only features. We don't want production Algolia search indexes updating on review apps, and Bugsnag is optional

## Deploy Notes

N/A