### PR TITLE
Add a link to webhook settings in the dashboard when mentioning webhooks

### DIFF
--- a/_api/sms/us-short-codes/alerts/sending.md
+++ b/_api/sms/us-short-codes/alerts/sending.md
@@ -124,7 +124,7 @@ Each request you make using the Nexmo API returns a:
 * Response - the status and cost of your request to Nexmo in JSON or XML format.
 * Delivery Receipt - if you have set a webhook endpoint, Nexmo forwards this delivery receipt to it. Carriers return a Delivery Receipt (DLR) to Nexmo to explain the delivery status of your message. If the message is not received, the delivery receipt explains why your message failed to arrive.
 
-The Delivery Receipt is sent using a [GET] HTTP request to your webhook endpoint. When you receive the DLR, you must send a 200 OK response. If you do not send the `200 OK`, Nexmo resends the delivery receipt for the next 72 hours.
+The Delivery Receipt is sent using a [GET] HTTP request to your webhook endpoint. When you receive the DLR, you must send a 200 OK response. If you do not send the `200 OK`, Nexmo resends the delivery receipt for the next 72 hours. Please ensure that you have configured [a webhook endpoint](https://dashboard.nexmo.com/settings) in the Nexmo dashboard.
 
 When you implement your response, ensure that your logic is not case-sensitive for the response codes.
 

--- a/_documentation/concepts/guides/webhooks.md
+++ b/_documentation/concepts/guides/webhooks.md
@@ -27,7 +27,7 @@ Webhooks provide a convenient mechanism for Nexmo to send information to your ap
 
 ## Which APIs support webhooks?
 
-Information resulting from requests to the SMS API, Voice API, Number Insight API, US Short Codes API, and Nexmo virtual numbers are sent in an HTTP request to your webhook endpoint on an HTTP server.
+Information resulting from requests to the SMS API, Voice API, Number Insight API, US Short Codes API, and Nexmo virtual numbers are sent in an HTTP request to your webhook endpoint on an HTTP server. To configure your webhook endpoint, please visit the [Nexmo dashboard](https://dashboard.nexmo.com/settings)
 
 Nexmo sends and retrieves the following information using webhooks:
 


### PR DESCRIPTION
## Description

We are getting a lot of tickets at the moment where people haven't set their callback URL in the dashboard so it would be good to head them off in docs if possible.

## Deploy Notes

N/A