### PR TITLE
Display nested object descriptions in OAS response fields descriptions

### DIFF
--- a/app/views/open_api/_response_description_parameters.html.erb
+++ b/app/views/open_api/_response_description_parameters.html.erb
@@ -1,0 +1,45 @@
+<% if schema['properties'] %>
+<% schema['properties'].each do |key, value| %>
+  <% next if key == '_links' %>
+  <% next if value['x-skip-response-description'] %>
+  <tr<% if value['properties'] %> class=" Vlt-table__row--noline" <% end %>>
+      <td>
+          <b><%= key %></b>
+          <% if value['items'] %>
+              <br />
+              <small>array of <%= value['items']['type'] %>s</small>
+          <% end %>
+      </td>
+    <td>
+    <%= value['description'] ? value['description'].render_markdown : '' %>
+      <% if value['enum']%>
+       <small class="Vlt-grey-dark">
+          One of: <%= value['enum'].map { |s| "<code>#{s}</code>" }.to_sentence(last_word_connector: ' or ', two_words_connector: ' or ').html_safe %>
+        </small>
+      <% end %>
+
+      <% if value['items'] # If this is an array, we need to show the structure of the children %>
+          <% value['properties'] = value['items']['properties'] %>
+      <% end %>
+      <% if value['properties'] %>
+        </td></tr>
+        <tr class="Vlt-table__row--nohighlight">
+        <td colspan="2">
+        <div class="Vlt-table Vlt-table--data Vlt-table--bordered">
+        <table>
+          <thead>
+          <tr>
+            <th>Field</th>
+            <th>Description</th>
+          </tr>
+          </thead>
+          <tbody>
+          <%= render 'response_description_parameters', schema: value %>
+          </tbody>
+        </table>
+        </div>
+      <% end %>
+    </td>
+  </tr>
+<% end %>
+<% end %>

--- a/app/views/open_api/_response_descriptions.html.erb
+++ b/app/views/open_api/_response_descriptions.html.erb
@@ -25,33 +25,11 @@
                 <tbody>
                     <% if response.exhibits_one_of_multiple_schemas?(format) %>
                         <% response.split_schemas(format).each_with_index do |schema, index| %>
-                            <% next unless schema['properties'] %>
-                            <% schema['properties'].each do |key, value| %>
-                                <% next if key == '_links' %>
-                                <% next if value['x-skip-response-description'] %>
-                                <tr>
-                                    <td><b><%= key %></b></td>
-                                    <td><%= value['description'] ? value['description'].render_markdown : '' %></td>
-                                </tr>
-                            <% end %>
-                        <% end %>
+                            <%= render 'response_description_parameters', schema: schema %>
+                       <% end %>
                     <% else %>
                         <% schema = response.schema(format) %>
-                        <% if schema['properties']%>
-                            <% schema['properties'].each do |key, value| %>
-                                <% next if key == '_links' %>
-                                <% next if value['x-skip-response-description'] %>
-                                <%
-                                    desc = ''
-                                    desc = value['title'].render_markdown if value['title']
-                                    desc = value['description'].render_markdown if value['description']
-                                %>
-                                <tr>
-                                    <td><b><%= key %></b></td>
-                                    <td><%= desc %></td>
-                                </tr>
-                            <% end %>
-                        <% end %>
+                        <%= render 'response_description_parameters', schema: schema %>
                     <% end %>
 
                 </tbody>


### PR DESCRIPTION
## Description

This resolves the following issues discovered in #1061 

* Render `enum` fields in response descriptions when present
* Display nested descriptions when type is an object (request bodies already did this)

See /api/number-insight#getNumberInsightStandard for an example

## Deploy Notes

N/A