### PR TITLE
VAPI from field can only be an E164 number

### DIFF
--- a/_open_api/definitions/voice.yml
+++ b/_open_api/definitions/voice.yml
@@ -31,12 +31,7 @@ paths:
                     - "$ref": "#/components/schemas/endpoints/properties/sip"
                     - "$ref": "#/components/schemas/endpoints/properties/websocket"
                 from:
-                  type: array
-                  items:
-                    oneOf:
-                    - "$ref": "#/components/schemas/endpoints/properties/phone"
-                    - "$ref": "#/components/schemas/endpoints/properties/sip"
-                    - "$ref": "#/components/schemas/endpoints/properties/websocket"
+                  "$ref": "#/components/schemas/endpoints/properties/phone"
                 answer_url:
                   description: The webhook endpoint where you provide the Nexmo Call
                     Control Object that governs this call.


### PR DESCRIPTION
## Description

From - The endpoint you are calling from. Possible value are the same as to.

This is incorrect as the From can only be a number in E164 that you own. You cannot set it as a websocket or SIP URI.

## Deploy Notes

N/A