### PR TITLE
Add allOf support for OAS documents

### DIFF
--- a/_open_api/definitions/number-insight.yml
+++ b/_open_api/definitions/number-insight.yml
@@ -47,10 +47,10 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/responses/niResponseJsonBasic'
+                $ref: '#/components/schemas/niResponseJsonBasic'
             text/xml:
               schema:
-                $ref: '#/components/responses/niResponseXmlBasic'
+                $ref: '#/components/schemas/niResponseXmlBasic'
   '/standard/{format}':
     parameters:
       - $ref: '#/components/parameters/format'
@@ -70,10 +70,10 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/responses/niResponseJsonStandard'
+                $ref: '#/components/schemas/niResponseJsonStandard'
             text/xml:
               schema:
-                $ref: '#/components/responses/niResponseXmlStandard'
+                $ref: '#/components/schemas/niResponseXmlStandard'
   '/advanced/{format}':
     parameters:
       - $ref: '#/components/parameters/format'
@@ -94,10 +94,10 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/responses/niResponseJsonAdvanced'
+                $ref: '#/components/schemas/niResponseJsonAdvanced'
             text/xml:
               schema:
-                $ref: '#/components/responses/niResponseXmlAdvanced'
+                $ref: '#/components/schemas/niResponseXmlAdvanced'
   '/advanced/async/{format}':
     parameters:
       - $ref: '#/components/parameters/format'
@@ -119,10 +119,10 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/responses/niResponseAsync'
+                $ref: '#/components/schemas/niResponseAsync'
             text/xml:
               schema:
-                $ref: '#/components/responses/niResponseAsync'
+                $ref: '#/components/schemas/niResponseAsync'
       callbacks:
         onData:
           '{$request.query.callback}':
@@ -134,10 +134,10 @@ paths:
                 content:
                   application/json:
                     schema:
-                      $ref: '#/components/responses/niResponseJsonAdvanced'
+                      $ref: '#/components/schemas/niResponseJsonAdvanced'
                   text/xml:
                     schema:
-                      $ref: '#/components/responses/niResponseXmlAdvanced'
+                      $ref: '#/components/schemas/niResponseXmlAdvanced'
               responses:
                 '200':
                   description: OK
@@ -196,7 +196,7 @@ components:
         type: string
         format: uriref
 
-  responses:
+  schemas:
 
     niResponseAsync:
       type: object
@@ -694,7 +694,6 @@ components:
 
     niResponseJsonBasic:
       type: object
-      description: Basic
       properties:
         status:
           $ref: '#/components/schemas/niBasicStatus'
@@ -734,105 +733,71 @@ components:
           description: 'The numeric prefix for the country that `number` is registered in.'
           example: '44'
 
+
     niResponseJsonStandard:
-      type: object
-      description: Standard
-      properties:
-        status:
-          $ref: '#/components/schemas/niStandardAdvancedStatus'
-        status_message:
-          type: string
-          description: 'The status description of your request.'
-          example: 'Success'
-        request_id:
-          type: string
-          description: 'The unique identifier for your request. This is a alphanumeric string up to 40 characters.'
-          example: 'aaaaaaaa-bbbb-cccc-dddd-0123456789ab'
-          maxLength: 40
-        international_format_number:
-          type: string
-          description: "The `number` in your request in international format."
-          example: "447700900000"
-        national_format_number:
-          type: string
-          description: "The `number` in your request in the format used by the country the number belongs to."
-          example: "07700 900000"
-        country_code:
-          type: string
-          description: 'Two character country code for `number`. This is in [ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2) format.'
-          example: "GB"
-          pattern: '[A-Z]{2}'
-        country_code_iso3:
-          type: string
-          description: 'Three character country code for `number`. This is in [ISO 3166-1 alpha-3](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-3) format.'
-          example: "GBR"
-          pattern: '[A-Z]{3}'
-        country_name:
-          type: string
-          description: 'The full name of the country that `number` is registered in.'
-          example: "United Kingdom"
-        country_prefix:
-          type: string
-          description: 'The numeric prefix for the country that `number` is registered in.'
-          example: '44'
-        request_price:
-          type: number
-          description: 'The amount in EUR charged to your account.'
-          example: "0.04000000"
-        refund_price:
-          type: number
-          description: 'If there is an internal lookup error, the `refund_price` will reflect the lookup price. If `cnam` is requested for a non-US number the `refund_price` will reflect the `cnam` price. If both of these conditions occur, `refund_price` is the sum of the lookup price and `cnam` price.'
-          example: '0.01500000'
-        remaining_balance:
-          type: number
-          description: 'Your account balance in EUR after this request. Not returned with Number Insight Advanced Async API.'
-          example: '1.23456789'
-        current_carrier:
-          type: object
-          x-nexmo-developer-collection-description-shown: true
-          description: 'Information about the network `number` is currently connected to.'
+      allOf:
+        - $ref: "#/components/schemas/niResponseJsonBasic"              
+        - type: object
           properties:
-            $ref: '#/components/schemas/niCarrierProperties'
-        original_carrier:
-          type: object
-          x-nexmo-developer-collection-description-shown: true
-          description: 'Information about the network `number` was initially connected to.'
-          properties:
-            $ref: '#/components/schemas/niCarrierProperties'
-        ported:
-          type: string
-          description: 'If the user has changed carrier for `number`. The assumed status means that the information supplier has replied to the request but has not said explicitly that the number is ported.'
-          enum:
-            - unknown
-            - ported
-            - not_ported
-            - assumed_not_ported
-            - assumed_ported
-          example: 'not_ported'
-        roaming:
-          $ref: '#/components/schemas/niRoaming'
-        caller_identity:
-          $ref: '#/components/schemas/niCallerIdentity'
-        caller_name:
-          type: string
-          description: 'Full name of the person or business who owns the phone number. `unknown` if this information is not available. This parameter is only present if `cnam` had a value of `true` within the request.'
-          example: 'John Smith'
-        last_name:
-          type: string
-          description: 'Last name of the person who owns the phone number if the owner is an individual. This parameter is only present if `cnam` had a value of `true` within the request.'
-          example: 'Smith'
-        first_name:
-          type: string
-          description: 'First name of the person who owns the phone number if the owner is an individual. This parameter is only present if `cnam` had a value of `true` within the request.'
-          example: 'John'
-        caller_type:
-          type: string
-          description: 'The value will be `business` if the owner of a phone number is a business. If the owner is an individual the value will be `consumer`. The value will be `unknown` if this information is not available. This parameter is only present if `cnam` had a value of `true` within the request.'
-          enum:
-            - business
-            - consumer
-            - unknown
-          example: 'consumer'
+            request_price:
+              type: number
+              description: 'The amount in EUR charged to your account.'
+              example: "0.04000000"
+            refund_price:
+              type: number
+              description: 'If there is an internal lookup error, the `refund_price` will reflect the lookup price. If `cnam` is requested for a non-US number the `refund_price` will reflect the `cnam` price. If both of these conditions occur, `refund_price` is the sum of the lookup price and `cnam` price.'
+              example: '0.01500000'
+            remaining_balance:
+              type: number
+              description: 'Your account balance in EUR after this request. Not returned with Number Insight Advanced Async API.'
+              example: '1.23456789'
+            current_carrier:
+              type: object
+              x-nexmo-developer-collection-description-shown: true
+              description: 'Information about the network `number` is currently connected to.'
+              properties:
+                $ref: '#/components/schemas/niCarrierProperties'
+            original_carrier:
+              type: object
+              x-nexmo-developer-collection-description-shown: true
+              description: 'Information about the network `number` was initially connected to.'
+              properties:
+                $ref: '#/components/schemas/niCarrierProperties'
+            ported:
+              type: string
+              description: 'If the user has changed carrier for `number`. The assumed status means that the information supplier has replied to the request but has not said explicitly that the number is ported.'
+              enum:
+                - unknown
+                - ported
+                - not_ported
+                - assumed_not_ported
+                - assumed_ported
+              example: 'not_ported'
+            roaming:
+              $ref: '#/components/schemas/niRoaming'
+            caller_identity:
+              $ref: '#/components/schemas/niCallerIdentity'
+            caller_name:
+              type: string
+              description: 'Full name of the person or business who owns the phone number. `unknown` if this information is not available. This parameter is only present if `cnam` had a value of `true` within the request.'
+              example: 'John Smith'
+            last_name:
+              type: string
+              description: 'Last name of the person who owns the phone number if the owner is an individual. This parameter is only present if `cnam` had a value of `true` within the request.'
+              example: 'Smith'
+            first_name:
+              type: string
+              description: 'First name of the person who owns the phone number if the owner is an individual. This parameter is only present if `cnam` had a value of `true` within the request.'
+              example: 'John'
+            caller_type:
+              type: string
+              description: 'The value will be `business` if the owner of a phone number is a business. If the owner is an individual the value will be `consumer`. The value will be `unknown` if this information is not available. This parameter is only present if `cnam` had a value of `true` within the request.'
+              enum:
+                - business
+                - consumer
+                - unknown
+              example: 'consumer'
+
 
     niResponseJsonAdvanced:
       type: object
@@ -971,9 +936,6 @@ components:
         - country_name
         - country_prefix
 
-
-
-  schemas:
     # niCarrier:
     #   type: object
     #   properties:
@@ -1204,6 +1166,6 @@ components:
 #     order: 1
 #     # schema:
 #     #   application/json:
-#     #     $ref: '#/components/responses/niResponseJsonAdvanced'
+#     #     $ref: '#/components/schemas/niResponseJsonAdvanced'
 #     #   text/xml:
-#     #     $ref: '#/components/responses/niResponseXmlAdvanced'
+#     #     $ref: '#/components/schemas/niResponseXmlAdvanced'

--- a/app/views/open_api/_parameter_groups.html.erb
+++ b/app/views/open_api/_parameter_groups.html.erb
@@ -15,13 +15,28 @@
 <% if endpoint.request_body %>
   <% format = endpoint.request_body.formats[0] %>
   <% unless endpoint.request_body.exhibits_one_of_multiple_schemas?(format) %>
-    <% if endpoint.request_body.properties_for_format(format).any? %>
+
+    <%
+      # @mheap: This is hacky handling for allOf, but it works for now
+      # We probably want real allOf support in OasParser, but that's more time than I have right now
+      allOf = endpoint.request_body.content[format]['schema']['allOf']
+      if allOf
+        params = allOf.reduce { |a,b| a.deep_merge(b) }
+        params = params['properties'].map do |name, definition|
+          OasParser::Property.new(nil, params, name, definition)
+        end
+      else
+        params = endpoint.request_body.properties_for_format(format)
+      end
+      if params
+    %>
+
       <h4>
         Request body
         <span class="Vlt-badge Vlt-badge--blue"><%= format %></span>
       </h4>
 
-      <%= render 'parameters', parameters: endpoint.request_body.properties_for_format(format), callback: callback %>
+      <%= render 'parameters', parameters: params, callback: callback %>
     <% end %>
   <% else %>
     <% endpoint.request_body.split_properties_for_format(format).each_with_index do |parameters, index| %>

--- a/app/views/open_api/_response_description_parameters.html.erb
+++ b/app/views/open_api/_response_description_parameters.html.erb
@@ -1,3 +1,11 @@
+<%
+  # @mheap: This is hacky handling for allOf, but it works for now
+  allOf = schema['allOf']
+  if allOf
+    schema = allOf.reduce { |a,b| a.deep_merge(b) }
+  end
+%>
+
 <% if schema['properties'] %>
 <% schema['properties'].each do |key, value| %>
   <% next if key == '_links' %>


### PR DESCRIPTION
## Description

This should probably be in OasParser itself and we should update our
rendering to check explicitly for allOf. As the semantics are the same
no matter if we loop over each allOf, or merge all of the schemas this
is the quickest way to keep us moving with valid OAS documents

## Deploy Notes

Check API reference pages carefully please!