### PR TITLE
Add note that US numbers don't return portability/reachability info

### DIFF
--- a/_documentation/number-insight/building-blocks/number-insight-advanced.md
+++ b/_documentation/number-insight/building-blocks/number-insight-advanced.md
@@ -8,7 +8,7 @@ navigation_weight: 4
 The Number Insight Advanced API provides all the data from the [Number Insight Standard API](/number-insight/building-blocks/number-insight-standard) together with the following additional information:
 
 * If the number is likely to be valid
-* If the number is reachable
+* If the number is reachable (not for US numbers)
 * If the number is roaming and, if so, the carrier and country
 
 Use this information to determine the risk associated with a number.

--- a/_documentation/number-insight/building-blocks/number-insight-advanced.md
+++ b/_documentation/number-insight/building-blocks/number-insight-advanced.md
@@ -8,7 +8,7 @@ navigation_weight: 4
 The Number Insight Advanced API provides all the data from the [Number Insight Standard API](/number-insight/building-blocks/number-insight-standard) together with the following additional information:
 
 * If the number is likely to be valid
-* If the number is reachable (not for US numbers)
+* If the number is reachable
 * If the number is roaming and, if so, the carrier and country
 
 Use this information to determine the risk associated with a number.

--- a/_documentation/number-insight/building-blocks/number-insight-standard.md
+++ b/_documentation/number-insight/building-blocks/number-insight-standard.md
@@ -9,7 +9,7 @@ The Number Insight Standard API provides all the information from the [Number In
 
 * The line type (mobile/landline/virtual number/premium/toll-free)
 * The Mobile Country Code (MCC) and Mobile Network Code (MNC)
-* If the number is ported
+* If the number is ported (not for US numbers)
 * The name of the caller (USA only)
 
 Use this information to determine the best type of communication for a number (SMS or voice) and block virtual numbers.

--- a/_documentation/number-insight/overview.md
+++ b/_documentation/number-insight/overview.md
@@ -46,7 +46,7 @@ Identify network when roaming | ❎ | ❎ | ✅
 Confirm that user's IP address is in same location as their mobile phone | ❎ | ❎ | ✅
 Access asynchronously | ❎ | ❎ | ✅
 
-\* This information is only available for US numbers in the Advanced API.
+\* For US numbers this information is only available in the Advanced API.
 
 > Check the legislation in your country to ensure that you are allowed to save user roaming information.
 

--- a/_documentation/number-insight/overview.md
+++ b/_documentation/number-insight/overview.md
@@ -39,12 +39,14 @@ Retrieve international and local format | ✅ | ✅ | ✅
 Identify origin country | ✅ | ✅ | ✅
 Detect line type (mobile/landline/virtual number/premium/toll-free) | ❎ | ✅ | ✅
 Determine mobile country code (MCC) and mobile network code (MNC) | ❎ | ✅ | ✅
-Check if number is ported (not for US numbers) | ❎ | ✅ | ✅
+Check if number is ported * | ❎ | ✅ | ✅
 Identify caller name (USA only) | ❎ | ✅ | ✅
-Verify that number is reachable (not for US numbers) | ❎ | ❎ | ✅
+Verify that number is reachable | ❎ | ❎ | ✅
 Identify network when roaming | ❎ | ❎ | ✅
 Confirm that user's IP address is in same location as their mobile phone | ❎ | ❎ | ✅
 Access asynchronously | ❎ | ❎ | ✅
+
+\* This information is only available for US numbers in the Advanced API.
 
 > Check the legislation in your country to ensure that you are allowed to save user roaming information.
 

--- a/_documentation/number-insight/overview.md
+++ b/_documentation/number-insight/overview.md
@@ -39,9 +39,9 @@ Retrieve international and local format | ✅ | ✅ | ✅
 Identify origin country | ✅ | ✅ | ✅
 Detect line type (mobile/landline/virtual number/premium/toll-free) | ❎ | ✅ | ✅
 Determine mobile country code (MCC) and mobile network code (MNC) | ❎ | ✅ | ✅
-Check if number is ported | ❎ | ✅ | ✅
+Check if number is ported (not for US numbers) | ❎ | ✅ | ✅
 Identify caller name (USA only) | ❎ | ✅ | ✅
-Verify that number is reachable | ❎ | ❎ | ✅
+Verify that number is reachable (not for US numbers) | ❎ | ❎ | ✅
 Identify network when roaming | ❎ | ❎ | ✅
 Confirm that user's IP address is in same location as their mobile phone | ❎ | ❎ | ✅
 Access asynchronously | ❎ | ❎ | ✅


### PR DESCRIPTION
## Description

@13webstreet (JP Chenot) advises that US numbers don't return portability/reachability info in NI Standard (and also, therefore, in NI Advanced)

## Deploy Notes

JP to check the following pages in test app:

- Overview
- Number Insight Standard building block
- Number Insight Advanced building block

Marking as "do not merge" until JP verifies