### PR TITLE
Mentioned outbound message in MT in short

### DIFF
--- a/_api/developer/messages.md
+++ b/_api/developer/messages.md
@@ -37,7 +37,7 @@ Parameter | Description | Required
 
 The following shows example Responses in JSON or XML:
 
-**Outbound Message**
+**Outbound Message (MT)**
 
 ```tabbed_examples
 source: /_examples/api/developer/message/search/outbound


### PR DESCRIPTION
## Description

The docs mention MT throughout the reference, however, MT isn't stated at the very first mention where the documentation explains the Outbound Message JSON response

## Deploy Notes

N/A
