### PR TITLE
Added rate limit notice to Verify search API

### DIFF
--- a/_api/verify.md
+++ b/_api/verify.md
@@ -174,6 +174,8 @@ Key | Value
 
 ## Verify Search
 
+> <strong>Please note that the Verify Search API is rate limited to one request per second.</strong>
+
 1. Send a Verify Search [request](#request-3) containing the [request_id](#keys-and-values)'s of the Verify requests to search for.
 2. Check the *status* response parameter in the Search [Response](#response-4) to see if the request was successfully completed.
 


### PR DESCRIPTION
## Description

The Verify search API is limited to 1 request/second. Other Verify endpoints have a higher throughput. Make this clear in the docs

## Deploy Notes

N/A