### PR TITLE
Fix nested list rendering

### DIFF
--- a/app/assets/volta/scss/components/_lists.scss
+++ b/app/assets/volta/scss/components/_lists.scss
@@ -53,7 +53,7 @@ ol.Vlt-list--simple {
 		counter-reset: list;
 	}
 
-	li {
+	> li {
 		&:before {
 			content: counter(list) '.';
 			counter-increment: list;


### PR DESCRIPTION
## Description

On pages such as https://developer.nexmo.com/concepts/guides/applications/ where we have numbered bullets inside tabs, the numbers sometimes appear on some of the tabs.

Resolves #1188

## Deploy Notes

N/A