### PR TITLE
Add stats by product summary page

### DIFF
--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -18,6 +18,32 @@ class DashboardController < ApplicationController
     end
   end
 
+  def stats_summary
+    return unless created_after || created_before
+    @feedbacks = Feedback::Feedback.joins(:resource)
+
+    if created_after && created_before
+      @feedbacks = @feedbacks.created_between(created_after, created_before)
+    elsif created_after
+      @feedbacks = @feedbacks.created_after(created_after)
+    elsif created_before
+      @feedbacks = @feedbacks.created_before(created_before)
+    end
+
+    grouped_results = @feedbacks.group(["DATE_TRUNC('month', feedback_feedbacks.created_at)", 'feedback_resources.product', 'feedback_feedbacks.sentiment']).count(:id)
+
+    # Reformat in to something usable
+    @summary = {}
+    grouped_results.each do |meta, count|
+      month = meta[0]
+      prod = meta[1] # Can't call it product due to the method defined in this class
+      sentiment = meta[2]
+      @summary[prod] = @summary[prod] || {}
+      @summary[prod][month] = @summary[prod][month] || {}
+      @summary[prod][month][sentiment] = count
+    end
+  end
+
   def coverage
     @supported_languages = %w[
       curl

--- a/app/views/dashboard/stats_summary.html.erb
+++ b/app/views/dashboard/stats_summary.html.erb
@@ -1,0 +1,59 @@
+<div  class="Vlt-card Vlt-article">
+<center>
+  <h1>Product Feedback Summary</h1>
+</center>
+  <div>
+    <%= form_tag({}, {:method => :get}) do %>
+       <div class="Vlt-form__group">
+        <div class="Vlt-form__element Vlt-form__element--elastic">
+          <label class="Vlt-label">
+          Created After
+        </label> 
+        <div class="Vlt-input"><%= date_field_tag :created_after, @created_after %></div>
+        </div>
+        <div class="Vlt-form__element Vlt-form__element--elastic">
+          <label class="Vlt-label">
+          Created Before
+        </label> 
+        <div class="Vlt-input"><%= date_field_tag :created_before, @created_before %></div>
+        </div>
+      
+      <%= link_to 'Reset', '/stats', class: "Vlt-btn Vlt-btn--tertiary Vlt-btn--app" %> &nbsp;
+      <%= submit_tag 'Update', class: 'Vlt-btn Vlt-btn--secondary Vlt-btn--app' %>
+      </div>
+    <% end %>
+  </div>
+
+  <div>
+    <% unless @summary %>
+    <p>Please choose a date range</p>
+    <% else %>
+    <% @summary.each do |product, months| %>
+    <h3><%= product %></h3>
+    <div class="Vlt-table Vlt-table--data Vlt-table--bordered"><table>
+      <thead>
+      <tr>
+        <th>Month</th>
+        <th>Positive</th>
+        <th>Negative</th>
+        <th>Percentage</th>
+      </tr>
+      </thead>
+      <tbody>
+      <% months.each do |month, data| %>
+      <% data['positive'] = data['positive'] || 0 %>
+      <% data['negative'] = data['negative'] || 0 %>
+      <tr>
+        <td><%= month.strftime("%b %Y") %></td>
+        <td><%= data['positive'] %></td>
+        <td><%= data['negative'] %></td>
+        <td><%= (data['positive']/((data['positive'] + data['negative']).to_f)*100).round(2) %>%</td>
+      </tr>
+      <% end %>
+      </tbody>
+    </table>
+    </div>
+    <% end %>
+    <% end %>
+  </div>
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -28,6 +28,7 @@ Rails.application.routes.draw do
 
   get '/coverage', to: 'dashboard#coverage'
   get '/stats', to: 'dashboard#stats'
+  get '/stats/summary', to: 'dashboard#stats_summary'
 
   get '/tutorials/(:code_language)', to: 'tutorials#index', constraints: DocumentationConstraint.code_language
   get '/tutorials/*document(/:code_language)', to: 'tutorials#show', constraints: DocumentationConstraint.code_language


### PR DESCRIPTION
## Description

Adds a page that lists stats per product for a given date range. This is admin-only functionality

## Deploy Notes

N/A