### PR TITLE
Fix mailto links in SMS DLR guide

### DIFF
--- a/_documentation/messaging/sms/guides/delivery-receipts.md
+++ b/_documentation/messaging/sms/guides/delivery-receipts.md
@@ -87,12 +87,12 @@ The `err-code` field in the DLR provides more detailed information and can help 
 | 8 | Network Error | The message failed due to a network error - retry  |
 | 9 | Illegal Number | The user has specifically requested not to receive messages from a specific service |
 | 10 | Illegal Message | There is an error in a message parameter, e.g. wrong encoding flag |
-| 11 | Unroutable  | Nexmo cannot find a suitable route to deliver the message - contact <mailto://support@nexmo.com> |
+| 11 | Unroutable  | Nexmo cannot find a suitable route to deliver the message - contact <mailto:support@nexmo.com> |
 | 12 | Destination Unreachable | A route to the number cannot be found - confirm the recipient's number  |
 | 13 | Subscriber Age Restriction | The target cannot receive your message due to their age  |
 | 14 | Number Blocked by Carrier | The recipient should ask their carrier to enable SMS on their plan |
 | 15 | Pre-paid Insufficient Funds | The recipient is on a pre-paid plan and does not have enough credit to receive your message |
-| 99 | General Error | Typically refers to an error in the route - contact <mailto://support@nexmo.com> |
+| 99 | General Error | Typically refers to an error in the route - contact <mailto:support@nexmo.com> |
 
 > The other fields in the DLR are explained in the [API Reference](/api/sms#delivery-receipt).
 


### PR DESCRIPTION
## Description

The mailto links in the DLR concept doc had extraneous `//` causing them not to render properly.

## Deploy Notes

Check the `mailto:` links to support in the DLR Error Codes table.
