### PR TITLE
Add operation IDs to improve nav on rendered docs

### DIFF
--- a/_open_api/definitions/reports.yml
+++ b/_open_api/definitions/reports.yml
@@ -24,6 +24,7 @@ paths:
   "/v1/reports/":
     post:
       summary: Create a report
+      operationId: createReport
       description: Request a report on your account activity
       parameters:
         - name: api_key
@@ -86,6 +87,7 @@ paths:
   "/v1/reports/{request_id}":
     get:
       summary: Get status of report
+      operationId: reportStatus
       description: Retrieve status and metadata about a requested report.
       parameters:
         - name: api_key
@@ -131,6 +133,7 @@ paths:
   "/v3/media/{file_id}":
     get:
       summary: Get report data
+      operationId: reportData
       description: Download a zipped archive of the rendered report. The file is available for download for 72 hours.
       parameters:
         - name: api_key


### PR DESCRIPTION
## Description

The navigation links on the left hand side of the documentation weren't working because the paths didn't have `operationId` fields. This PR adds those fields.

## Deploy Notes

Note base branch is `oas/reporting` - this change is for the EA site only.
