### PR TITLE
Add ability to deep link to a response field description

### DIFF
--- a/app/controllers/open_api_controller.rb
+++ b/app/controllers/open_api_controller.rb
@@ -17,6 +17,8 @@ class OpenApiController < ApplicationController
 
     @definition = OpenApiDefinitionResolver.find(@definition_name)
 
+    @auto_expand_responses = params[:expandResponses]
+
     respond_to do |format|
       format.any(:json, :yaml) { send_file(@definition.path) }
       format.html do

--- a/app/views/open_api/_endpoint.html.erb
+++ b/app/views/open_api/_endpoint.html.erb
@@ -70,7 +70,7 @@
       <% end %>
 
       <%= render 'parameter_groups', endpoint: endpoint %>
-      <%= render 'response_descriptions', endpoint: endpoint, anchor_prefix: "response-#{endpoint.operationId}" %>
+      <%= render 'response_descriptions', endpoint: endpoint, anchor_prefix: "response-#{endpoint.operationId}", auto_expand_responses: @auto_expand_responses %>
 
     </div>
   </div>

--- a/app/views/open_api/_endpoint.html.erb
+++ b/app/views/open_api/_endpoint.html.erb
@@ -70,7 +70,7 @@
       <% end %>
 
       <%= render 'parameter_groups', endpoint: endpoint %>
-      <%= render 'response_descriptions', endpoint: endpoint %>
+      <%= render 'response_descriptions', endpoint: endpoint, anchor_prefix: "response-#{endpoint.operationId}" %>
 
     </div>
   </div>

--- a/app/views/open_api/_response_description_parameters.html.erb
+++ b/app/views/open_api/_response_description_parameters.html.erb
@@ -2,8 +2,9 @@
 <% schema['properties'].each do |key, value| %>
   <% next if key == '_links' %>
   <% next if value['x-skip-response-description'] %>
+  <% anchor_value = "#{anchor_prefix}-#{key}" %>
   <tr<% if value['properties'] %> class=" Vlt-table__row--noline" <% end %>>
-      <td>
+      <td id="<%= anchor_value %>">
           <b><%= key %></b>
           <% if value['items'] %>
               <br />
@@ -34,7 +35,7 @@
           </tr>
           </thead>
           <tbody>
-          <%= render 'response_description_parameters', schema: value %>
+          <%= render 'response_description_parameters', schema: value, anchor_prefix: anchor_value %>
           </tbody>
         </table>
         </div>

--- a/app/views/open_api/_response_descriptions.html.erb
+++ b/app/views/open_api/_response_descriptions.html.erb
@@ -11,7 +11,7 @@
     </p>
 
     <div id="acc<%= id %>" class="Vlt-js-accordion__content">
-        <h4>Response Fields</h4>
+      <h4 id="<%= anchor_prefix %>">Response Fields</h4>
       <% response.formats.each_with_index do |format, index| %>
         <div class="js-format" data-format="<%= format %>">
         <div class="Vlt-table">
@@ -25,11 +25,11 @@
                 <tbody>
                     <% if response.exhibits_one_of_multiple_schemas?(format) %>
                         <% response.split_schemas(format).each_with_index do |schema, index| %>
-                            <%= render 'response_description_parameters', schema: schema %>
+                            <%= render 'response_description_parameters', schema: schema, anchor_prefix: anchor_prefix %>
                        <% end %>
                     <% else %>
                         <% schema = response.schema(format) %>
-                        <%= render 'response_description_parameters', schema: schema %>
+                        <%= render 'response_description_parameters', schema: schema, anchor_prefix: anchor_prefix %>
                     <% end %>
 
                 </tbody>

--- a/app/views/open_api/_response_descriptions.html.erb
+++ b/app/views/open_api/_response_descriptions.html.erb
@@ -10,7 +10,7 @@
     </a>
     </p>
 
-    <div id="acc<%= id %>" class="Vlt-js-accordion__content">
+    <div id="acc<%= id %>" class="Vlt-js-accordion__content <%= auto_expand_responses ? 'Vlt-js-accordion__content_open' : '' %>">
       <h4 id="<%= anchor_prefix %>">Response Fields</h4>
       <% response.formats.each_with_index do |format, index| %>
         <div class="js-format" data-format="<%= format %>">


### PR DESCRIPTION
## Description

This PR adds two things:

* The ability to link to an API specification with the response fields auto-expanded using a query parameter - /api/sms?expandResponses=true
* IDs to all response fields so that you can deep link to a given field e.g. /api/sms?expandResponses=true#response-send-an-sms-messages-message-price

This allows us to link directly to a response field when responding to support requests

## Deploy Notes

N/A