### PR TITLE
Add deep links to NI OAS responses on each building block

### DIFF
--- a/_documentation/number-insight/building-blocks/number-insight-advanced-async-callback.md
+++ b/_documentation/number-insight/building-blocks/number-insight-advanced-async-callback.md
@@ -53,4 +53,5 @@ The response from the API contains the following data:
 }
 ```
 
+For a description of each returned field and to see all possible values, see the [Number Insights API documentation](/api/number-insight#asyncCallback)
 

--- a/_documentation/number-insight/building-blocks/number-insight-advanced.md
+++ b/_documentation/number-insight/building-blocks/number-insight-advanced.md
@@ -56,3 +56,5 @@ The response from the API contains the following data:
     "roaming": {"status": "not_roaming"}
 }
 ```
+
+For a description of each returned field and to see all possible values, see the [Number Insights API documentation](/api/number-insight?expandResponses=true#response-getNumberInsightAdvanced)

--- a/_documentation/number-insight/building-blocks/number-insight-basic.md
+++ b/_documentation/number-insight/building-blocks/number-insight-basic.md
@@ -33,3 +33,5 @@ The response from the API contains the following data:
     "country_prefix": "44"
 }
 ```
+
+For a description of each returned field and to see all possible values, see the [Number Insights API documentation](/api/number-insight?expandResponses=true#response-getNumberInsightBasic)

--- a/_documentation/number-insight/building-blocks/number-insight-standard.md
+++ b/_documentation/number-insight/building-blocks/number-insight-standard.md
@@ -77,3 +77,5 @@ The response from the API contains the following data:
     "roaming": {"status": "unknown"}
 }
 ```
+
+For a description of each returned field and to see all possible values, see the [Number Insights API documentation](/api/number-insight?expandResponses=true#response-getNumberInsightStandard)


### PR DESCRIPTION
## Description

We had some feedback that requested descriptions of each field in the building block examples. This PR depends on #1201  and adds the required links to the Number Insights building blocks. If we find them useful, we can add links to all products as we revisit the documentation

## Deploy Notes

Depends on #1201  being merged first
