### PR TITLE
Add default Verify timing information

### DIFF
--- a/_documentation/verify/overview.md
+++ b/_documentation/verify/overview.md
@@ -18,6 +18,18 @@ By default, the PIN is first sent via text message (SMS). If there is no reply t
 
 TTS messages are read in the locale that matches the phone number. (For example, the TTS for a 61* phone number is sent using an Australian accent for the English language (`en-au`). You can explicitly control the language, accent and gender in TTS from the Verify Request.)
 
+## Default Timings
+
+Assuming that you make a request with the default `pin_expiry` and `next_event_wait` values, your request will be made using the following timings:
+
+1. Make request to the Verify API
+2. Nexmo immediately send an SMS containing the PIN
+3. Wait 125 seconds for the user to enter the value received
+4. Send 1st Text-To-Speech call to read the PIN to the customer
+5. Wait 180 more seconds
+6. Send 2nd TTS call (with new PIN, as the default `pin_expiry` time is 300s which will have expired)
+7. Wait for the user to enter the new PIN for 300 seconds (the default `pin_expiry`)
+
 ## Concepts
 
 * **Authentication** - Nexmo Verify API is authenticated with your account API Key and Secret. For more information on see the [Authenticating](/api/verify) in the API documentation.


### PR DESCRIPTION
## Description

Add information on the default Verify timings for SMS and TTS voice calls.

Additional information from @peter-nexmo that I didn't include, but may be relevant in the future.

> If you increase the `pin_expiry` to be less than 125 seconds, there will be a new PIN sent for each request, but you would also want to decrease the `next_event_wait` to 120 also. If you increase the `pin_expiry` to cover all 3 scenarios, the same PIN will be used for all 3

Resolves DOCS-338 and DEVX-539

## Deploy Notes

N/A