### PR TITLE
Fix deep links when navigating via Turbolinks

### DIFF
--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -70,6 +70,14 @@ let refresh = () => {
   if (rightPane) { rightPane.click(); }
 
   Volta.init(['accordion', 'tooltip'])
+
+  // Fix for Turbolinks scrolling to in-page anchor when navigating to a new page
+  if(window.location.hash){
+    const tag = document.getElementById(window.location.hash.slice(1))
+    if(tag){
+      tag.scrollIntoView(true);
+    }
+  }
 }
 
 $(document).on('nexmo:load', function() {


### PR DESCRIPTION
## Description

When you have a link to “voice/voice-api/guides/call-flow#call-states” in the NCCO reference it won’t jump down the page to ‘call-states’ - you have to press enter on the URL again to make the jump.

This PR fixes the issue

## Deploy Notes

N/A