### PR TITLE
Fix some Messages API related incorrect links, see #1206

### DIFF
--- a/_documentation/concepts/guides/authentication.md
+++ b/_documentation/concepts/guides/authentication.md
@@ -15,7 +15,7 @@ API | API Key and Secret (Query String) | API Key and Secret (Header) | JSON Web
 [Number Insight](/api/number-insight) | ✅ | ❎ | ❎| ❎
 [Conversion](/api/conversion) | ✅ | ❎ | ❎| ❎
 [Developer](/api/developer) | ✅ | ❎ | ❎| ❎
-[Messages](/api/messages) | ❎ | ✅ | ✅| ❎
+[Messages](/api/messages-olympus) | ❎ | ✅ | ✅| ❎
 [Dispatch](/api/dispatch) | ❎ | ✅ | ✅| ❎
 [Audit](/api/audit) | ❎ | ✅ | ❎ | ❎
 [Redact](/api/redact) | ❎ | ✅ | ❎ | ❎

--- a/_documentation/messages/overview.md
+++ b/_documentation/messages/overview.md
@@ -102,6 +102,6 @@ product: messages
 
 ## Reference
 
-* [Messages API Reference](/api/messages)
+* [Messages API Reference](/api/messages-olympus)
 * [External Accounts API Reference](/api/external-accounts)
 

--- a/_open_api/definitions/messages-olympus.yml
+++ b/_open_api/definitions/messages-olympus.yml
@@ -131,7 +131,7 @@ components:
         text: Check your request parameters against the API documentation.
         link:
           text: See API request format
-          url: /api/messages
+          url: /api/messages-olympus
 
     MessageStatus:
       type: object

--- a/app/views/static/_products.html.erb
+++ b/app/views/static/_products.html.erb
@@ -155,7 +155,7 @@
 <div class="Vlt-grid Vlt-grid--center Vlt-grid--margin4 Nxd-products-banner">
   <div class="Vlt-col">
     <h2>
-      <a href="/stitch/overview">
+      <a href="/messages/overview">
         <svg class="Vlt-icon Vlt-purple Vlt-icon--larger" aria-hidden="true"><use xlink:href="/symbol/volta-icons.svg#Vlt-icon-code"/></svg>
         Messages and Dispatch Beta
       </a>


### PR DESCRIPTION
## Description

A few links to the Messages API reference were incorrect, we've moved this to be `/api/messages-olympus` rather than `/api/messages` and there's a strange redirect on the second option which was causing problem.s

Also fixes a landing page link on the icon and title of "Messages and Dispatch" that was incorrectly pointing to Stitch.