### PR TITLE
Force a full page reload for tutorial links

### DIFF
--- a/app/filters/tutorial_link_filter.rb
+++ b/app/filters/tutorial_link_filter.rb
@@ -1,0 +1,19 @@
+class TutorialLinkFilter < Banzai::Filter
+  def call(input)
+    @input = input
+
+    document.css('a').each_with_index do |link, _index|
+      if link['href']&.start_with?('/tutorials/')
+        link['data-turbolinks'] = 'false'
+      end
+    end
+
+    @document.to_html
+  end
+
+  private
+
+  def document
+    @document ||= Nokogiri::HTML::DocumentFragment.parse(@input)
+  end
+end

--- a/app/pipelines/markdown_pipeline.rb
+++ b/app/pipelines/markdown_pipeline.rb
@@ -37,7 +37,8 @@ class MarkdownPipeline < Banzai::Pipeline
       BreakFilter,
       UnfreezeFilter,
       IconFilter,
-      ExternalLinkFilter
+      ExternalLinkFilter,
+      TutorialLinkFilter
     )
   end
 end


### PR DESCRIPTION
## Description

Turbolinks can't find the sidenav (as it doesn't exist) and throws an
error, meaning that the page is not navigated to.

Initial bug report:

> - broken link to tutorial ‘Sending Facebook Messenger messages with the Messages API’ on https://developer.nexmo.com/messages/building-blocks/send-with-facebook-messenger

## Deploy Notes

N/A