### PR TITLE
Use Volta tabs for oneOf rendering in API responses

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -16,6 +16,7 @@
 //= require jquery-scrolltofixed
 //= require volta/volta.core.js
 //= require volta/components/volta.accordion.js
+//= require volta/components/volta.tab.js
 //= require volta/popper.min.js
 //= require volta/tooltip.min.js
 //= require volta/components/volta.tooltip.js

--- a/app/assets/stylesheets/layout/_api.scss
+++ b/app/assets/stylesheets/layout/_api.scss
@@ -77,11 +77,6 @@
 			}
 		}
 
-		.tabs {
-			// horrible hack but it's how it was working before
-			display: none;
-		}
-
 		&__header {
 			margin: -#{$unit3} -#{$unit2} #{$unit2} -#{$unit2};
 

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -69,7 +69,7 @@ let refresh = () => {
   let rightPane = document.querySelector(".Vlt-main");
   if (rightPane) { rightPane.click(); }
 
-  Volta.init(['accordion', 'tooltip'])
+  Volta.init(['accordion', 'tooltip', 'tab'])
 
   // Fix for Turbolinks scrolling to in-page anchor when navigating to a new page
   if(window.location.hash){

--- a/app/views/open_api/_endpoint.html.erb
+++ b/app/views/open_api/_endpoint.html.erb
@@ -100,19 +100,19 @@
                       response.split_schemas(format).each { schema_tab_ids << SecureRandom.hex }
                     %>
 
-                    <ul class="tabs tabs--schema" data-tabs id="<%= id %>">
+                    <div class="Vlt-tabs">
+                      <div class="Vlt-tabs__header">
+                        <% response.split_schemas(format).each_with_index do |schema, index| %>
+                          <div <%= schema_tab_ids[index] %>" <% if index.zero? %>class="Vlt-tabs__link Vlt-tabs__link_active" aria-selected="true"<% else %>class="Vlt-tabs__link"<% end %>><%= schema['description'] || "Response #{index + 1}" %></div>
+                        <% end %>
+                      </div>
+                      <div class="Vlt-tabs__content">
                       <% response.split_schemas(format).each_with_index do |schema, index| %>
-                        <li class="tabs-title <%= index.zero? ? 'is-active' : '' %>">
-                          <a href="#<%= schema_tab_ids[index] %>" <% if index.zero? %>aria-selected="true"<% end %>><%= schema['description'] || "Response #{index + 1}" %></a>
-                        </li>
-                      <% end %>
-                    </ul>
-                    <div class="tabs-content" data-tabs-content="<%= id %>">
-                      <% response.split_schemas(format).each_with_index do |schema, index| %>
-                        <div class="tabs-panel <%= index.zero? ? 'is-active' : '' %>" id="<%= schema_tab_ids[index] %>">
-                          <%= ResponseParserDecorator.new(schema).html(format, xml_options: schema['xml']) %>
+                         <div class="Vlt-tabs__panel <% if index.zero? %>Vlt-tabs__panel_active<% end %>">
+                           <%= ResponseParserDecorator.new(schema).html(format, xml_options: schema['xml']) %>
                         </div>
-                      <% end %>
+                        <% end %>
+                      </div>
                     </div>
                   <% else %>
                     <% schema = response.schema(format) %>


### PR DESCRIPTION
## Description

In the Volta redesign we lost the ability to show multiple responses for a single HTTP response code. This adds the functionality back using Volta tabs

See the /api/redact 403 response for an example

## Deploy Notes

N/A