### PR TITLE
Add Pricing API rate limit

### DIFF
--- a/_api/developer/pricing.md
+++ b/_api/developer/pricing.md
@@ -6,6 +6,8 @@ api: Developer API
 
 # Developer - Pricing API Reference
 
+> <strong>Please note that the Pricing API is rate limited to one request per second.</strong>
+
 ## Pricing
 
 ### Pricing by country


### PR DESCRIPTION
## Description

DOCS-270

`/pricing` requests are limited to one request per second

## Deploy Notes

N/A