### PR TITLE
Add Redact to the homepage and /api page

### DIFF
--- a/app/views/api/index.html.erb
+++ b/app/views/api/index.html.erb
@@ -171,8 +171,12 @@
             <h5>Media API <span class="Vlt-badge Vlt-badge--blue">BETA</span></h5>
             <p>Manage media items such as audio files for use with other Nexmo APIs.</p>
           </a>
+          <a href="/api/redact" class="Nxd-card__link">
+            <h5>Redact API</h5>
+            <p>Redact your personal data in the Nexmo platform</p>
+          </a>
           <a href="/api/account/secret-management" class="Nxd-card__link">
-            <h3>Secret Management API</h3>
+            <h5>Secret Management API</h5>
             <p>Rotate your API secrets</p>
           </a>
         </nav>

--- a/app/views/static/_products.html.erb
+++ b/app/views/static/_products.html.erb
@@ -144,8 +144,10 @@
       <nav>
         <h3 class="Vlt-grey-dark">Global APIs</h3>
         <a href="/api/application">Application</a> |
-        <a href="/api/conversion">Conversion</a> |
+        <a href="/api/conversion">Conversion</a>
+        <br />
         <a href="/api/media">Media</a> |
+        <a href="/api/redact">Redact</a> |
         <a href="/api/account/secret-management">Secret Management</a>
       </nav>
     </div>


### PR DESCRIPTION
## Description

Neither the landing page nor the API reference list had links to the Redact API documentation or API reference pages. Now they do

Resolves #1224

## Deploy Notes

N/A
