### PR TITLE
Add blog content as external tutorials for SMS

### DIFF
--- a/_tutorials/ifttt-to-sms.md
+++ b/_tutorials/ifttt-to-sms.md
@@ -1,0 +1,9 @@
+---
+title: Anything-to-SMS with IFTTT and Nexmo
+external_link: https://www.nexmo.com/blog/2018/09/18/anything-to-sms-ifttt-nexmo-dr/
+description: Send an SMS in response to any trigger by creating a serverless action in PHP that sends an SMS. Use IFTTT to send a webhook to the serverless action when your chosen event occurs
+products: messaging/sms
+languages:
+ - PHP
+---
+

--- a/_tutorials/receive-sms-dotnet.md
+++ b/_tutorials/receive-sms-dotnet.md
@@ -1,0 +1,8 @@
+---
+title: Receive SMS Messages with ASP.NET MVC Framework
+external_link: https://www.nexmo.com/blog/2017/03/31/recieve-sms-messages-with-asp-net-mvc-framework-dr/
+products: messaging/sms
+description: A tutorial to show how your ASP .NET MVC application can use the Nexmo c# library to receive SMS messages from your users and display them in your output window.
+languages:
+ - dotnet
+---

--- a/_tutorials/receive-sms-with-java.md
+++ b/_tutorials/receive-sms-with-java.md
@@ -1,0 +1,8 @@
+---
+title: Receive SMS Messages with Java
+external_link: https://www.nexmo.com/blog/2017/05/31/receive-sms-messages-java-dr/
+products: messaging/sms
+description: This tutorial walks you through creating a servlet to receive incoming SMS messages from your users. You'll learn how to configure your Nexmo number and account, set up the servlet, and have the incoming messages logged to the console.
+languages:
+  - Java
+---

--- a/_tutorials/receive-sms-with-php.md
+++ b/_tutorials/receive-sms-with-php.md
@@ -1,0 +1,9 @@
+---
+title: Receiving an SMS with PHP
+external_link: https://www.nexmo.com/blog/2018/06/19/receiving-an-sms-with-php-dr/
+products: messaging/sms
+description: Walk through of how to receive an SMS in your PHP project
+languages:
+  - PHP
+---
+

--- a/_tutorials/receive-sms-with-ruby.md
+++ b/_tutorials/receive-sms-with-ruby.md
@@ -1,0 +1,8 @@
+---
+title: How to Receive SMS Messages with Ruby on Rails
+external_link: https://www.nexmo.com/blog/2017/10/23/receive-sms-messages-ruby-on-rails-dr/
+products: messaging/sms
+description: Handle incoming SMS from users in your Ruby on Rails application.
+languages:
+  - Ruby
+---

--- a/_tutorials/send-sms-with-dotnet.md
+++ b/_tutorials/send-sms-with-dotnet.md
@@ -1,0 +1,8 @@
+---
+title: How to Send SMS Messages with ASP.NET MVC Framework
+external_link: https://www.nexmo.com/blog/2017/03/23/send-sms-messages-asp-net-mvc-framework-dr/
+products: messaging/sms
+description: Enhance your .NET application by adding the ability to send SMS messages to users. This tutorial walks you through adding a simple form to your web application, and sending an SMS message to the number provided.
+languages:
+  - dotnet
+---

--- a/_tutorials/send-sms-with-flask.md
+++ b/_tutorials/send-sms-with-flask.md
@@ -1,0 +1,8 @@
+---
+title: How to Send SMS Messages with Python, Flask and Nexmo
+external_link: https://www.nexmo.com/blog/2017/06/22/send-sms-messages-python-flask-dr/
+products: messaging/sms
+description: This tutorial introduces you to sending SMS with Python, making use of the Nexmo Python library. It starts by showing how to send SMS from the REPL, then goes on to show you how to build a simple flask app with SMS capabilities.
+languages:
+  - Python
+---

--- a/_tutorials/send-sms-with-java.md
+++ b/_tutorials/send-sms-with-java.md
@@ -1,0 +1,8 @@
+---
+title: How to Send SMS Messages with Java
+external_link: https://www.nexmo.com/blog/2017/05/03/send-sms-messages-with-java-dr/
+products: messaging/sms
+description: Learn how to add the ability to send SMS messages from your Java application. This tutorial also shows how you can create a web service and use that to send the SMS messages.
+languages:
+ - Java
+---

--- a/_tutorials/send-sms-with-php.md
+++ b/_tutorials/send-sms-with-php.md
@@ -1,0 +1,8 @@
+---
+title: Sending SMS Messages with PHP
+external_link: https://www.nexmo.com/blog/2017/09/20/sending-sms-messages-with-php-dr/
+products: messaging/sms
+description: This short but detailed tutorial shows you how you can send SMS messages from your PHP application.
+languages:
+  - PHP
+---

--- a/_tutorials/send-sms-with-ruby.md
+++ b/_tutorials/send-sms-with-ruby.md
@@ -1,0 +1,8 @@
+---
+title: How to Send SMS Messages with Ruby on Rails
+external_link: https://www.nexmo.com/blog/2017/10/16/send-sms-ruby-on-rails-dr/
+products: messaging/sms
+description: Detailed tutorial on how you can send SMS from your Ruby on Rails application using the Nexmo SMS API
+languages:
+ - Ruby
+---

--- a/_tutorials/sms-browser-notifications.md
+++ b/_tutorials/sms-browser-notifications.md
@@ -1,0 +1,9 @@
+---
+title: Show SMS Notifications in the Browser with Angular, Node.JS, and Ably
+external_link: https://www.nexmo.com/blog/2018/08/07/sms-notifications-browser-with-angular-node-ably-dr/
+products: messaging/sms
+description: Use Node.js and Express to receive an SMS, send it via Ably to a web browser, and then use Angular to display it as a notification in a Single Page Application.
+languages:
+  - Node
+---
+

--- a/_tutorials/sms-dlr-with-dotnet.md
+++ b/_tutorials/sms-dlr-with-dotnet.md
@@ -1,0 +1,8 @@
+---
+title: How to Get an SMS Delivery Receipt in ASP .NET MVC
+external_link: https://www.nexmo.com/blog/2017/07/21/get-sms-delivery-receipt-asp-net-mvc-dr/
+products: messaging/sms
+description: Delivery receipts allow you to get information about when an SMS is delivered to a user's handset. This tutorial shows how you can recieve these delivery receipt notifications in your ASP .NET application.
+languages:
+ - dotnet
+---

--- a/_tutorials/sms-dlr-with-php.md
+++ b/_tutorials/sms-dlr-with-php.md
@@ -1,0 +1,8 @@
+---
+title: Receiving SMS Delivery Receipts with PHP
+external_link: https://www.nexmo.com/blog/2018/06/25/receiving-sms-delivery-receipts-with-php-dr/
+products: messaging/sms
+description: Get notifications when your SMS is actually delivered to the handset of the user. This tutorial uses Slim framework to log the delivery receipts of your sent messages.
+languages:
+  - PHP
+---

--- a/_tutorials/sms-dlr-with-ruby.md
+++ b/_tutorials/sms-dlr-with-ruby.md
@@ -1,0 +1,8 @@
+---
+title: Receive an SMS Delivery Receipt from a Mobile Carrier with Ruby on Rails
+external_link: https://www.nexmo.com/blog/2017/10/19/receive-sms-delivery-receipt-ruby-on-rails-dr/
+products: messaging/sms
+description: By enabling delivery receipts on the SMS messages that you send, you can get a notification when the message is successfully delivered. This tutorial show you how you can implement this in your Rails application.
+languages:
+  - Ruby
+---

--- a/_tutorials/sms-fortune-cookies-with-ibm-cloud.md
+++ b/_tutorials/sms-fortune-cookies-with-ibm-cloud.md
@@ -1,0 +1,9 @@
+---
+title: Serverless SMS Fortune Cookies with Nexmo and IBM
+external_link: https://www.nexmo.com/blog/2018/08/14/serverless-sms-nexmo-ibm-dr/
+description: Receive SMS from a user, and respond using a serverless function. This example uses IBM Cloud Functions to receive the webhook notification of the incoming SMS request, and respond by sending an SMS (containing a fortune cookie as a very simple example) back to the user. An ideal model for low-traffic use cases where users need up-to-date information by SMS.
+products: messaging/sms
+languages:
+  - PHP
+---
+


### PR DESCRIPTION
## Description

Now we can add external resources as tutorials, I've pulled in the X with Y posts about SMS from 2017 and 2018 and added them as tutorials, plus a couple of other SMS-related posts that I saw along the way. This content already exists but isn't very easy to surface for developers, so hopefully this helps.