### PR TITLE
Printable version: remove left hand nav when printing tutorials

### DIFF
--- a/app/assets/stylesheets/layout/_print.scss
+++ b/app/assets/stylesheets/layout/_print.scss
@@ -4,7 +4,7 @@
     overflow: hidden;
   }
 
-  #footer, .Nxd-header, #Vlt-sidenav, #FeedbackComponent {
+  #footer, .Nxd-header, .Vlt-sidenav, #FeedbackComponent {
     display: none;
   }
 }


### PR DESCRIPTION
## Description

I think this was a typo, not sure! But I don't need the menu when I print (the font is too big as well but I've got no idea how to fix that)