### PR TITLE
Portability is only available in Advanced NI

### DIFF
--- a/_documentation/number-insight/building-blocks/number-insight-advanced.md
+++ b/_documentation/number-insight/building-blocks/number-insight-advanced.md
@@ -8,6 +8,7 @@ navigation_weight: 4
 The Number Insight Advanced API provides all the data from the [Number Insight Standard API](/number-insight/building-blocks/number-insight-standard) together with the following additional information:
 
 * If the number is likely to be valid
+* If the number is ported
 * If the number is reachable
 * If the number is roaming and, if so, the carrier and country
 

--- a/_documentation/number-insight/building-blocks/number-insight-standard.md
+++ b/_documentation/number-insight/building-blocks/number-insight-standard.md
@@ -9,7 +9,6 @@ The Number Insight Standard API provides all the information from the [Number In
 
 * The line type (mobile/landline/virtual number/premium/toll-free)
 * The Mobile Country Code (MCC) and Mobile Network Code (MNC)
-* If the number is ported (not for US numbers)
 * The name of the caller (USA only)
 
 Use this information to determine the best type of communication for a number (SMS or voice) and block virtual numbers.

--- a/_documentation/number-insight/overview.md
+++ b/_documentation/number-insight/overview.md
@@ -35,19 +35,18 @@ Each API level builds upon the capabilities of the previous one. For example, th
 
 ### Feature comparison
 Feature | Basic | Standard | Advanced
---|--|--|--
-Retrieve international and local format | ✅ | ✅ | ✅
-Identify origin country | ✅ | ✅ | ✅
-Detect line type (mobile/landline/virtual number/premium/toll-free) | ❌ | ✅ | ✅
-Determine mobile country code (MCC) and mobile network code (MNC) | ❌ | ✅ | ✅
-Check if number is ported * | ❌ | ✅ | ✅
-Identify caller name (USA only) | ❌ | ✅ | ✅
-Verify that number is reachable | ❌ | ❌ | ✅
-Identify network when roaming | ❌ | ❌ | ✅
-Confirm that user's IP address is in same location as their mobile phone | ❌ | ❌ | ✅
-Access asynchronously | ❌ | ❌ | ✅
+:--|:--:|:--:|:--:
+Number format and origin| ✅ | ✅ | ✅    
+Number type| ❌ | ✅ | ✅
+Carrier and country| ❌ | ✅ | ✅
+Ported| ❌ | ❌ | ✅
+IP match| ❌ | ❌ | ✅
+Validity| ❌ | ❌ | ✅
+Reachability| ❌ | ❌ | ✅
+Roaming status| ❌ | ❌ | ✅
+Roaming carrier and country| ❌ | ❌ | ✅
+**US number** caller name and type| ❌ | ✅ | ✅
 
-\* For US numbers this information is only available in the Advanced API.
 
 > Check the legislation in your country to ensure that you are allowed to save user roaming information.
 


### PR DESCRIPTION
## Description

Arnold Jakstas says that portability info is only available in the Advanced API and that we should reproduce the table from https://www.nexmo.com/products/number-insight/pricing

## Deploy Notes

Check the following pages in [review app](https://nexmo-developer-pr-1250.herokuapp.com):

- Number Insight Overview (comparison table changed)
- Number Insight Standard Building Block (portability removed)
- Number Insight Advanced Building Block (portability added)
