### PR TITLE
Change navigation ordering of SMS concept docs

### DIFF
--- a/_documentation/messaging/sms/guides/SMPP-access.md
+++ b/_documentation/messaging/sms/guides/SMPP-access.md
@@ -1,5 +1,7 @@
 ---
 title: SMPP access
+description: Using SMPP instead of REST to access the SMS API.
+navigation_weight: 7
 ---
 
 # SMPP Access

--- a/_documentation/messaging/sms/guides/concatenation-and-encoding.md
+++ b/_documentation/messaging/sms/guides/concatenation-and-encoding.md
@@ -1,5 +1,7 @@
 ---
-title: Concatenation and Encoding
+title: Concatenation and encoding
+description: Determining whether the byte length of a message results in it being sent as multiple SMS.
+navigation_weight: 2
 ---
 
 # Concatenation and Encoding

--- a/_documentation/messaging/sms/guides/country-specific-features.md
+++ b/_documentation/messaging/sms/guides/country-specific-features.md
@@ -1,10 +1,12 @@
 ---
 title: Country specific features
+description: How different countries' SMS sending rules can affect your campaign.
+navigation_weight: 3
 ---
 
 # Country specific features
 
-Find out how SMS differences in SMS implementation in different markets and territories can affect your campaign
+Find out how different SMS implementations in different markets and territories can affect your campaign.
 
 ## Overview
 

--- a/_documentation/messaging/sms/guides/custom-sender-id.md
+++ b/_documentation/messaging/sms/guides/custom-sender-id.md
@@ -1,5 +1,7 @@
 ---
-title: Sender Identity
+title: Sender identity
+description: How to change where your SMS appears to come from.
+navigation_weight: 1
 ---
 
 # Sender Identity

--- a/_documentation/messaging/sms/guides/delivery-receipts.md
+++ b/_documentation/messaging/sms/guides/delivery-receipts.md
@@ -1,5 +1,7 @@
 ---
 title: Delivery receipts
+description: How to request a delivery receipt (DLR) from the carrier.
+navigation_weight: 4
 ---
 
 # Delivery receipts

--- a/_documentation/messaging/sms/guides/inbound-sms.md
+++ b/_documentation/messaging/sms/guides/inbound-sms.md
@@ -1,5 +1,7 @@
 ---
 title: Inbound SMS
+description: How to receive SMS on your Nexmo virtual numbers.
+navigation_weight: 5
 ---
 
 # Inbound SMS

--- a/_documentation/messaging/sms/guides/troubleshooting-sms.md
+++ b/_documentation/messaging/sms/guides/troubleshooting-sms.md
@@ -1,5 +1,7 @@
 ---
-title: Troubleshooting SMS
+title: Troubleshooting
+description: What to do if your SMS delivery fails.
+navigation_weight: 6
 ---
 
 # Troubleshooting SMS


### PR DESCRIPTION
## Description

Changed the order of SMS concept docs in the left-hand navigation menu. This is to present a more sensible ordering while Lorna works on [DEVX-576](https://nexmoinc.atlassian.net/browse/DEVX-576?atlOrigin=eyJpIjoiNjJkMjljMThkNzg4NGRkMmIxNzRlYTVkMDdhZjBlZDEiLCJwIjoiaiJ9).

## Deploy Notes

Review order of concept guides in [sample app](https://nexmo-developer-pr-1260.herokuapp.com/).
