### PR TITLE
change exp datetime to add 86400 secs

### DIFF
--- a/_documentation/stitch/concepts/jwt-acl.md
+++ b/_documentation/stitch/concepts/jwt-acl.md
@@ -124,7 +124,7 @@ Nexmo.generateJwt(PRIVATE_KEY, {
             application_id: "aaaaaaaa-bbbb-cccc-dddd-0123456789ab",
             sub: "jamie",
             //expire in 24 hours
-            exp: new Date().getTime() + 86400,
+            exp: Math.round(new Date().getTime()/1000)+86400,
             acl: aclPaths
           })
 ```


### PR DESCRIPTION
## Description

Changed the example `new Date().getTime()` which returns ms not seconds to `Math.round(new Date().getTime()/1000)+86400`.

As `time()` in PHP returns seconds and `new Date().getTime()` in JavaScript return miliseconds for these to be equivalent it should devide `getTime()` by `1000` or `+86400000`.

I opted for this, so the modification was the same.

## Deploy Notes

Just a code example MD change.