### PR TITLE
[WIP] Grouping and Sorting by Tags Feature

### DIFF
--- a/app/controllers/open_api_controller.rb
+++ b/app/controllers/open_api_controller.rb
@@ -42,7 +42,7 @@ class OpenApiController < ApplicationController
     @groups = @definition.endpoints.group_by { |endpoint| endpoint.raw['tags'] }
     @groups = @groups.sort_by do |name, _|
       next 999 if name.nil?
-      @definition.raw['tags'][name]['order'] || 999
+      @definition.raw['tags'][name]['x-order'] || 999
     end
   end
 

--- a/app/controllers/open_api_controller.rb
+++ b/app/controllers/open_api_controller.rb
@@ -39,19 +39,24 @@ class OpenApiController < ApplicationController
   end
 
   def set_groups
+    tags = @definition.raw['tags']
     # For now we only use the first tag in the list as an equivalent for the old x-group functionality
-    @groups = @definition.endpoints.group_by { |endpoint| endpoint.raw['tags'].first }
+    @groups = @definition.endpoints.group_by do |endpoint|
+      next nil unless tags
+      endpoint.raw['tags'].first
+    end
 
     # We want to use the order in which the tags are defined in the definition, so iterate over the tags
     # and store the index against the tag name. We'll use this later for sorting
     ordering = {}
-    @definition.raw['tags'].each_with_index do |tag, index|
+    tags&.each_with_index do |tag, index|
       ordering[tag['name'].capitalize] = index
     end
 
     # Sort by the order in which they're defined in the definition
     @groups = @groups.sort_by do |name, _|
-      ordering[name.capitalize]
+      return 999 if name.nil?
+      ordering[name.capitalize] || 999
     end
   end
 

--- a/app/controllers/open_api_controller.rb
+++ b/app/controllers/open_api_controller.rb
@@ -39,16 +39,10 @@ class OpenApiController < ApplicationController
   end
 
   def set_groups
-    @groups = @definition.endpoints.group_by do |endpoint| 
-      !endpoint.raw['tags'].nil? ? endpoint.raw['tags'].first : endpoint.raw['x-group']
-      #endpoint.raw['x-group'] 
-    end
+    @groups = @definition.endpoints.group_by { |endpoint| endpoint.raw['tags'] }
     @groups = @groups.sort_by do |name, _|
-      if !name.nil? 
-        name
-      else 
-        @definition.raw['x-groups'][name]['order']
-      end
+      next 999 if name.nil?
+      @definition.raw['tags'][name]['order'] || 999
     end
   end
 

--- a/app/controllers/open_api_controller.rb
+++ b/app/controllers/open_api_controller.rb
@@ -40,8 +40,10 @@ class OpenApiController < ApplicationController
 
   def set_groups
     @groups = @definition.endpoints.group_by { |endpoint| endpoint.raw['tag'] }
-    @groups = @groups.sort_by do |name|
-      @definition.raw['tags'][name]
+    @groups = @groups.sort_by do |name, _|
+      @definition.raw['tags'].each do |tag|
+        tag[name.capitalize]
+      end
     end
   end
 

--- a/app/controllers/open_api_controller.rb
+++ b/app/controllers/open_api_controller.rb
@@ -39,10 +39,9 @@ class OpenApiController < ApplicationController
   end
 
   def set_groups
-    @groups = @definition.endpoints.group_by { |endpoint| endpoint.raw['tags'] }
-    @groups = @groups.sort_by do |name, _|
-      next 999 if name.nil?
-      @definition.raw['tags'][name]['x-order'] || 999
+    @groups = @definition.endpoints.group_by { |endpoint| endpoint.raw['tag'] }
+    @groups = @groups.sort_by do |name|
+      @definition.raw['tags'][name]
     end
   end
 

--- a/app/controllers/open_api_controller.rb
+++ b/app/controllers/open_api_controller.rb
@@ -39,10 +39,16 @@ class OpenApiController < ApplicationController
   end
 
   def set_groups
-    @groups = @definition.endpoints.group_by { |endpoint| endpoint.raw['x-group'] }
+    @groups = @definition.endpoints.group_by do |endpoint| 
+      !endpoint.raw['tags'].nil? ? endpoint.raw['tags'].first : endpoint.raw['x-group']
+      #endpoint.raw['x-group'] 
+    end
     @groups = @groups.sort_by do |name, _|
-      next 999 if name.nil?
-      @definition.raw['x-groups'][name]['order'] || 999
+      if !name.nil? 
+        name
+      else 
+        @definition.raw['x-groups'][name]['order']
+      end
     end
   end
 

--- a/app/controllers/open_api_controller.rb
+++ b/app/controllers/open_api_controller.rb
@@ -39,11 +39,19 @@ class OpenApiController < ApplicationController
   end
 
   def set_groups
-    @groups = @definition.endpoints.group_by { |endpoint| endpoint.raw['tag'] }
+    # For now we only use the first tag in the list as an equivalent for the old x-group functionality
+    @groups = @definition.endpoints.group_by { |endpoint| endpoint.raw['tags'].first }
+
+    # We want to use the order in which the tags are defined in the definition, so iterate over the tags
+    # and store the index against the tag name. We'll use this later for sorting
+    ordering = {}
+    @definition.raw['tags'].each_with_index do |tag, index|
+      ordering[tag['name'].capitalize] = index
+    end
+
+    # Sort by the order in which they're defined in the definition
     @groups = @groups.sort_by do |name, _|
-      @definition.raw['tags'].each do |tag|
-        tag[name.capitalize]
-      end
+      ordering[name.capitalize]
     end
   end
 

--- a/app/views/open_api/_navigation.html.erb
+++ b/app/views/open_api/_navigation.html.erb
@@ -8,7 +8,7 @@
 
           <% @groups.each do |name, endpoints| %>
             <% if name %>
-              <% group = @definition.raw['tags'] != '' ? @definition.raw['tags'] : @definition.raw['x-groups'][name] %>
+              <% group = @definition.raw['tags'][name] %>
               <li>
                 <h5 class="Vlt-sidemenu__title Vlt-sidemenu__title--border"><%= group['name'] %></h5>
               </li>

--- a/app/views/open_api/_navigation.html.erb
+++ b/app/views/open_api/_navigation.html.erb
@@ -8,10 +8,10 @@
 
           <% @groups.each do |name, endpoints| %>
             <% if name %>
-              <% group = @definition.raw['tags'][name] %>
-              <li>
-                <h5 class="Vlt-sidemenu__title Vlt-sidemenu__title--border"><%= group['name'] %></h5>
-              </li>
+              <% group = @definition.raw['tags'].select { |tag| tag['name'].capitalize == name.capitalize }.first %>
+                <li>
+                  <h5 class="Vlt-sidemenu__title Vlt-sidemenu__title--border"><%= group['name'] %></h5>
+                </li>
             <% end %>
 
                 <% endpoints.each do |endpoint| %>

--- a/app/views/open_api/_navigation.html.erb
+++ b/app/views/open_api/_navigation.html.erb
@@ -8,7 +8,10 @@
 
           <% @groups.each do |name, endpoints| %>
             <% if name %>
-              <% group = @definition.raw['tags'].select { |tag| tag['name'].capitalize == name.capitalize }.first %>
+              <%
+                group = @definition.raw['tags'].select { |tag| tag['name'].capitalize == name.capitalize }.first
+                raise "Could not find 'tags' entry for #{name.capitalize}" unless group
+              %>
                 <li>
                   <h5 class="Vlt-sidemenu__title Vlt-sidemenu__title--border"><%= group['name'] %></h5>
                 </li>

--- a/app/views/open_api/_navigation.html.erb
+++ b/app/views/open_api/_navigation.html.erb
@@ -8,7 +8,7 @@
 
           <% @groups.each do |name, endpoints| %>
             <% if name %>
-              <% group = @definition.raw['x-groups'][name] %>
+              <% group = @definition.raw['tags'] != '' ? @definition.raw['tags'] : @definition.raw['x-groups'][name] %>
               <li>
                 <h5 class="Vlt-sidemenu__title Vlt-sidemenu__title--border"><%= group['name'] %></h5>
               </li>

--- a/app/views/open_api/show.html.erb
+++ b/app/views/open_api/show.html.erb
@@ -66,7 +66,7 @@
 
     <% @groups.each do |name, endpoints| %>
       <% if name %>
-        <%= render partial: 'model', locals: { group: @definition.raw['x-groups'][name] } %>
+        <%= render partial: 'model', locals: { group: @definition.raw['tags'][name] } %>
       <% end %>
 
       <% endpoints.each do |endpoint| %>

--- a/app/views/open_api/show.html.erb
+++ b/app/views/open_api/show.html.erb
@@ -66,7 +66,8 @@
 
     <% @groups.each do |name, endpoints| %>
       <% if name %>
-        <%= render partial: 'model', locals: { group: @definition.raw['tags'][name] } %>
+        <% group = @definition.raw['tags'].select { |tag| tag['name'].capitalize == name.capitalize }.first %>
+          <%= render partial: 'model', locals: { group: group } %>
       <% end %>
 
       <% endpoints.each do |endpoint| %>


### PR DESCRIPTION
As a first stab at modifying the `sort_groups` private method in the `open_api_controller` I've introduced logic to first `group_by` and then `sort_by` tags, if they are present. As a next step, the logic in `app/views/open_api/_navigation.html.erb` also needs to change, specifically at around line 13, to adjust based on whether the text is coming from the tag or from the `x-group`. 

