### PR TITLE
Remove most required fields from Building Block config

### DIFF
--- a/_examples/number-insight/basic/csharp.yml
+++ b/_examples/number-insight/basic/csharp.yml
@@ -1,8 +1,4 @@
 ---
-title: .NET
-language: dotnet
-dependencies:
-    - Nexmo.Csharp.Client
 client:
     source: .repos/nexmo-community/nexmo-dotnet-quickstart/NexmoDotNetQuickStarts/Controllers/NumberInsightController.cs
     from_line: 12
@@ -11,6 +7,3 @@ code:
     source: .repos/nexmo-community/nexmo-dotnet-quickstart/NexmoDotNetQuickStarts/Controllers/NumberInsightController.cs
     from_line: 34
     to_line: 37
-run_command: '(Run using your IDE)'
-file_name: NumberInsightController.cs
-unindent: true

--- a/_examples/number-insight/basic/curl.yml
+++ b/_examples/number-insight/basic/curl.yml
@@ -1,9 +1,5 @@
 ---
-title: Curl
-language: curl
 code:
     source: .repos/nexmo/curl-building-blocks/number-insight/ni-basic.sh
     from_line: 5
     to_line: 8
-file_name: ni-basic.sh
-run_command: 'sh ni-basic.sh'

--- a/_examples/number-insight/basic/java.yml
+++ b/_examples/number-insight/basic/java.yml
@@ -1,8 +1,4 @@
 ---
-title: Java
-language: java
-dependencies:
-- 'com.nexmo:client:4.0.0'
 code:
   source: .repos/nexmo-community/nexmo-java-quickstart/src/main/java/com/nexmo/quickstart/insight/BasicInsight.java
   from_line: 40
@@ -11,6 +7,3 @@ client:
   source: .repos/nexmo-community/nexmo-java-quickstart/src/main/java/com/nexmo/quickstart/insight/BasicInsight.java
   from_line: 38
   to_line: 38
-file_name: BasicInsight.java
-run_command: java-ide
-unindent: true

--- a/_examples/number-insight/basic/node.yml
+++ b/_examples/number-insight/basic/node.yml
@@ -1,8 +1,4 @@
 ---
-title: Node
-language: node
-dependencies:
-    - nexmo
 code:
     source: .repos/nexmo-community/nexmo-node-quickstart/number_insight/ni-basic.js
     from_line: 16
@@ -11,5 +7,3 @@ client:
     source: .repos/nexmo-community/nexmo-node-quickstart/number_insight/ni-basic.js
     from_line: 9
     to_line: 14
-file_name: ni-basic.js
-run_command: 'node ni-basic.js'

--- a/_examples/number-insight/basic/php.yml
+++ b/_examples/number-insight/basic/php.yml
@@ -1,11 +1,5 @@
 ---
-title: PHP
-language: php
-dependencies:
-    - nexmo/client
 code:
     source: .repos/nexmo-community/nexmo-php-quickstart/number-insights/basic.php
     from_line: 5
     to_line: 8
-file_name: basic.php
-run_command: 'php basic.php'

--- a/_examples/number-insight/basic/python.yml
+++ b/_examples/number-insight/basic/python.yml
@@ -1,6 +1,4 @@
 ---
-title: Python
-language: python
 dependencies:
     - nexmo
     - pprint
@@ -8,5 +6,3 @@ code:
     source: .repos/nexmo-community/nexmo-python-quickstart/number-insight/ni-basic.py
     from_line: 15
     to_line: 18
-file_name: ni-basic.py
-run_command: 'python ni-basic.py'

--- a/_examples/number-insight/basic/ruby.yml
+++ b/_examples/number-insight/basic/ruby.yml
@@ -1,11 +1,5 @@
 ---
-title: Ruby
-language: ruby
-dependencies:
-    - nexmo
 code:
     source: .repos/nexmo-community/nexmo-ruby-quickstart/number-insight/ni-basic.rb
     from_line: 8
     to_line: 19
-file_name: ni-basic.rb
-run_command: 'ruby ni-basic.rb'

--- a/app/filters/building_block_filter.rb
+++ b/app/filters/building_block_filter.rb
@@ -47,7 +47,8 @@ class BuildingBlockFilter < Banzai::Filter
 
       return code_html if config['code_only']
 
-      run_html = @renderer.run_command(config['run_command'], config['file_name'], config['code']['source'])
+      config['run_command'] = config['run_command'].gsub('{filename}', config['file_name']) if config['run_command']
+      run_html = @renderer.run_command(config['run_command'], config['file_name'], config['code']['source']).to_s
 
       prereqs = (application_html + dependency_html + client_html).strip
       prereqs = "<h2>Prerequisites</h2>#{prereqs}" unless prereqs.empty?

--- a/app/models/code_language.rb
+++ b/app/models/code_language.rb
@@ -1,6 +1,6 @@
 class CodeLanguage
   include ActiveModel::Model
-  attr_accessor :key, :label, :type
+  attr_accessor :key, :label, :type, :dependencies, :unindent, :icon, :run_command
   attr_writer :weight, :linkable, :languages, :lexer
 
   def weight

--- a/app/services/building_block_renderer/dotnet.rb
+++ b/app/services/building_block_renderer/dotnet.rb
@@ -4,13 +4,8 @@ module BuildingBlockRenderer
       { 'code' => "$ Install-Package #{deps.join(' ')}" }
     end
 
-    def self.run_command(command, _filename, _file_path)
-      <<~HEREDOC
-        ## Run your code
-         Save this file to your machine and run it:
-         <pre class="highlight bash"><code>$ #{command}</code></pre>
-
-      HEREDOC
+    def self.run_command(_command, _filename, _file_path)
+      nil
     end
 
     def self.create_instructions(filename)

--- a/app/services/building_block_renderer/java.rb
+++ b/app/services/building_block_renderer/java.rb
@@ -3,7 +3,7 @@ module BuildingBlockRenderer
     def self.dependencies(deps)
       {
           'text' => 'Add the following to <code>build.gradle</code>:',
-          'code' => deps.map { |d| "compile '#{d}'" }.join('<br />'),
+          'code' => deps.map { |d| "compile '#{d.gsub('@latest', '4.0.1')}'" }.join('<br />'),
       }
     end
 

--- a/config/code_languages.yml
+++ b/config/code_languages.yml
@@ -3,6 +3,8 @@ terminal_programs:
     weight: 1
     label: cURL
     lexer: sh
+    icon: curl
+    run_command: 'sh {filename}'
   httpie:
     weight: 1
     label: HTTPie
@@ -17,42 +19,85 @@ languages:
     weight: 2
     label: JavaScript
     lexer: javascript
+    icon: javascript
+    dependencies:
+      - 'nexmo'
+
   node:
     weight: 2
     label: Node.js
     lexer: javascript
+    icon: node
+    dependencies:
+      - 'nexmo'
+    run_command: 'node {filename}'
+
   java:
     weight: 3
     label: Java
     lexer: java
+    unindent: true
+    icon: java
+    dependencies:
+      - 'com.nexmo:client:@latest'
+
   dotnet:
     weight: 4
     label: .NET
     lexer: c#
+    unindent: true
+    icon: dotnet
+    dependencies:
+      - 'Nexmo.Csharp.Client'
   csharp:
     weight: 4
-    label: C#
+    label: .NET
     lexer: c#
+    unindent: true
+    icon: dotnet
+    dependencies:
+      - 'Nexmo.Csharp.Client'
+
   php:
     weight: 5
     label: PHP
     lexer: php
+    icon: php
+    dependencies:
+      - 'nexmo/client'
+    run_command: 'php {filename}'
+
   python:
     weight: 6
     label: Python
     lexer: python
+    icon: python
+    dependencies:
+      - 'nexmo'
+    run_command: 'python {filename}'
+
   ruby:
     weight: 7
     label: Ruby
     lexer: ruby
+    icon: ruby
+    dependencies:
+      - 'nexmo'
+    run_command: 'ruby {filename}'
+
   swift:
     weight: 8
     label: Swift
     lexer: swift
+    icon: ios
+    dependencies: []
+
   objective_c:
     weight: 8
     label: Objective-C
     lexer: objective_c
+    icon: ios
+    dependencies: []
 
 platforms:
   ios:


### PR DESCRIPTION
## Description

We were having to add a lot of repeated information (title, language,
run_command etc) to Building Blocks. This PR adds defaults for all
languages, delegates run_command rendering to the per-language renderers
and removes everything except the `code` and `client` sections from
building blocks.

I've updated NI basic as a demo, and once this PR is approved I'll
update all other blocks too

## Deploy Notes

N/A
