### PR TITLE
New helper method to address summary title issue

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -207,4 +207,30 @@ module ApplicationHelper
     base_url = Rails.env.production? ? 'https://developer.nexmo.com' : request.base_url
     canonical_path.prepend(base_url)
   end
+
+  def normalize_summary_title(summary, operationID)
+    # define the regex for the matches
+    camelMatch = /^[a-zA-Z]\w+(?:[A-Z]\w+){1,}/x
+    underscoreMatch = /^([^_]*(_[^_])?)*_?$/
+    dashMatch = /^([^-]*(-[^-])?)*-?$/
+
+    # return summary and exit if it is provided
+    if !summary.nil?
+      return summary 
+    end
+
+    if summary.nil?
+      # run through the various possibilities
+      if operationID.match?(camelMatch)
+        revisedSummary = operationID.underscore.split('_').collect{|c| c.capitalize}.join(' ')
+      elsif operationID.match?(underscoreMatch)
+        revisedSummary = operationID.split('_').collect{|c| c.capitalize}.join(' ')
+      elsif operationID.match?(dashMatch)
+        revisedSummary = operationID.split('-').collect{|c| c.capitalize}.join(' ')
+      else # generic string manipulation if it doesn't match any of the above
+        revisedSummary = operationID.humanize.collect{|c| c.capitalize}.join(' ')
+      end
+      return revisedSummary
+    end
+  end
 end

--- a/app/views/open_api/_navigation.html.erb
+++ b/app/views/open_api/_navigation.html.erb
@@ -19,7 +19,7 @@
                     <%= link_to "##{endpoint.operationId}", {:class=>"Vlt-sidemenu__link"} do %>
                       <svg class="Vlt-green"><use xlink:href="/symbol/volta-icons.svg#Vlt-icon-code" /></svg>
 
-                      <span class="Vlt-sidemenu__label"><%= endpoint.summary %> </span><span class="Vlt-badge Vlt-badge--margin-left Nxd-method-badge Nxd-method-badge--<%= endpoint.method %>"><code class="Vlt-white"><%= endpoint.method %></code></span>
+                      <span class="Vlt-sidemenu__label"><%= normalize_summary_title(endpoint.summary, endpoint.operationId) %> </span><span class="Vlt-badge Vlt-badge--margin-left Nxd-method-badge Nxd-method-badge--<%= endpoint.method %>"><code class="Vlt-white"><%= endpoint.method %></code></span>
                     <% end %>
                   </li>
                     <% if endpoint.callbacks.any? %>


### PR DESCRIPTION
I have created a new helper method in `application_helper.rb` to address Issue #1300. The method takes in the `summary` and `operationID`. It either returns the `summary`, if it exists, or runs the `operationID` through some string manipulation to produce a new summary title to be used in the rendering of the navigation, if a `summary` does not already exist.
