### PR TITLE
Render OAS pages at build time

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,3 +26,4 @@ script:
   - bundle exec rubocop
   - bundle exec rake ci:verify_pages
   - bundle exec rake ci:verify_navigation
+  - bundle exec rake ci:verify_oas_reference

--- a/app/constraints/open_api_constraint.rb
+++ b/app/constraints/open_api_constraint.rb
@@ -13,6 +13,10 @@ OPEN_API_PRODUCTS = %w[
 ].freeze
 
 class OpenApiConstraint
+  def self.list
+    OPEN_API_PRODUCTS
+  end
+
   def self.products
     { definition: Regexp.new(OPEN_API_PRODUCTS.join('|')) }
   end

--- a/lib/tasks/ci.rake
+++ b/lib/tasks/ci.rake
@@ -21,4 +21,13 @@ namespace :ci do
     res = session.get '/documentation'
     raise 'Error rendering documentation index page' if res == 500
   end
+
+  desc 'Render all OAS based API references'
+  task 'verify_oas_reference': :environment do
+    session = ActionDispatch::Integration::Session.new(Rails.application)
+    OpenApiConstraint.list.each do |name|
+      res = session.get "/api/#{name}"
+      raise "Error rendering /api/#{name} OAS page" if res == 500
+    end
+  end
 end


### PR DESCRIPTION
## Description

We currently render all markdown pages at build time which prevents `500` errors on production. We don't currently do the same for OAS rendered pages as they're not markdown based.

This PR adds a new CI check that reads the `open_api_constraint` and tries to render all of those pages. This means that any OAS page on NDP will automatically be tested.

## Deploy Notes

N/A