### PR TITLE
added testing for #inlineescapefilter

### DIFF
--- a/spec/filters/inline_escape_filter_spec.rb
+++ b/spec/filters/inline_escape_filter_spec.rb
@@ -3,34 +3,34 @@ require 'rails_helper'
 RSpec.describe InlineEscapeFilter do
   it 'renders a code block when the code is put in between a set of `` characters' do
     input = <<~HEREDOC
-    ``console.log(variable)``
+      ``console.log(variable)``
     HEREDOC
 
     expected_output = 'FREEZESTARTPGNvZGU-Y29uc29sZS5sb2codmFyaWFibGUpPC9jb2RlPg==FREEZEEND'
-    
+
     # using .chop to remove trailing \n in test input string
     expect(described_class.call(input.chop)).to eq(expected_output)
   end
 
   it 'does not transform the text if it is not put in between a set of `` characters' do
     input = <<~HEREDOC
-    console.log(variable)
+      console.log(variable)
     HEREDOC
 
-    expected_output = input 
+    expected_output = input
 
     expect(described_class.call(input)).to eql(expected_output)
   end
 
   it 'only transforms inline code and leaves code put on multiple lines unaltered' do
     input = <<~HEREDOC
-    ``
-    foo.new
-    console.log(foo)
-    ``
+      ``
+      foo.new
+      console.log(foo)
+      ``
     HEREDOC
 
-    expected_output = input 
+    expected_output = input
 
     expect(described_class.call(input)).to eql(expected_output)
   end

--- a/spec/filters/inline_escape_filter_spec.rb
+++ b/spec/filters/inline_escape_filter_spec.rb
@@ -1,0 +1,37 @@
+require 'rails_helper'
+
+RSpec.describe InlineEscapeFilter do
+  it 'renders a code block when the code is put in between a set of `` characters' do
+    input = <<~HEREDOC
+    ``console.log(variable)``
+    HEREDOC
+
+    expected_output = 'FREEZESTARTPGNvZGU-Y29uc29sZS5sb2codmFyaWFibGUpPC9jb2RlPg==FREEZEEND'
+    
+    # using .chop to remove trailing \n in test input string
+    expect(described_class.call(input.chop)).to eq(expected_output)
+  end
+
+  it 'does not transform the text if it is not put in between a set of `` characters' do
+    input = <<~HEREDOC
+    console.log(variable)
+    HEREDOC
+
+    expected_output = input 
+
+    expect(described_class.call(input)).to eql(expected_output)
+  end
+
+  it 'only transforms inline code and leaves code put on multiple lines unaltered' do
+    input = <<~HEREDOC
+    ``
+    foo.new
+    console.log(foo)
+    ``
+    HEREDOC
+
+    expected_output = input 
+
+    expect(described_class.call(input)).to eql(expected_output)
+  end
+end


### PR DESCRIPTION
## Description

Added testing for `#InlineEscapeFilter` to test the following:

* It transforms text in between a set of `` characters into a code block
* It does not do so for text not in between those characters
* It only does so for inline text and not text that goes on multiple lines

## Deploy Notes

Notes regarding deployment the contained body of work. These should note any db migrations, etc.
