### PR TITLE
updated the filter specs to call described_class instead of the expli…

### DIFF
--- a/spec/filters/anchor_filter_spec.rb
+++ b/spec/filters/anchor_filter_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe AnchorFilter do
       <a name="this-is-a-test"></a>
     HEREDOC
 
-    expect(AnchorFilter.call(input)).to eq(expected_output)
+    expect(described_class.call(input)).to eq(expected_output)
   end
   it 'returns input if input already is an explicit anchor link' do
     input = <<~HEREDOC
@@ -21,6 +21,6 @@ RSpec.describe AnchorFilter do
       <a name="this-is-a-test"></a>
     HEREDOC
 
-    expect(AnchorFilter.call(input)).to eq(expected_output)
+    expect(described_class.call(input)).to eq(expected_output)
   end
 end

--- a/spec/filters/audio_filter_spec.rb
+++ b/spec/filters/audio_filter_spec.rb
@@ -14,6 +14,6 @@ RSpec.describe AudioFilter do
 
     expected_output = "FREEZESTART#{Base64.urlsafe_encode64(audio)}FREEZEEND\n"
 
-    expect(AudioFilter.call(input)).to eq(expected_output)
+    expect(described_class.call(input)).to eq(expected_output)
   end
 end

--- a/spec/filters/break_filter_spec.rb
+++ b/spec/filters/break_filter_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe BreakFilter do
       <br>
     HEREDOC
 
-    expect(BreakFilter.call(input)).to eq(expected_output)
+    expect(described_class.call(input)).to eq(expected_output)
   end
   it 'turns more than one instance of § into an equal number of break HTML tags' do
     input = <<~HEREDOC
@@ -21,7 +21,7 @@ RSpec.describe BreakFilter do
       <br><br>
     HEREDOC
 
-    expect(BreakFilter.call(input)). to eq(expected_output)
+    expect(described_class.call(input)). to eq(expected_output)
   end
   it 'only transforms the § symbol and does not turn anything else into a break HTML tag' do
     input = <<~HEREDOC
@@ -32,6 +32,6 @@ RSpec.describe BreakFilter do
       not a symbol
     HEREDOC
 
-    expect(BreakFilter.call(input)). to eq(expected_output)
+    expect(described_class.call(input)). to eq(expected_output)
   end
 end

--- a/spec/filters/columns_filter_spec.rb
+++ b/spec/filters/columns_filter_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe ColumnsFilter do
       {end}
     HEREDOC
 
-    output = ColumnsFilter.call(input)
+    output = described_class.call(input)
 
     expect(output).to eq(
       <<~HEREDOC

--- a/spec/filters/icon_filter_spec.rb
+++ b/spec/filters/icon_filter_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe IconFilter do
       <svg class="Vlt-green Vlt-icon Vlt-icon--small"><use xlink:href="/symbol/volta-icons.svg#Vlt-icon-check" /></svg>
     HEREDOC
 
-    expect(IconFilter.call(input)).to eq(expected_output)
+    expect(described_class.call(input)).to eq(expected_output)
   end
   it 'turns ❌ symbol into HTML' do
     input = <<~HEREDOC
@@ -21,7 +21,7 @@ RSpec.describe IconFilter do
       <svg class="Vlt-red Vlt-icon Vlt-icon--small"><use xlink:href="/symbol/volta-icons.svg#Vlt-icon-cross" /></svg>
     HEREDOC
 
-    expect(IconFilter.call(input)). to eq(expected_output)
+    expect(described_class.call(input)). to eq(expected_output)
   end
   it 'turns an icon text reference into the appropriate HTML tag' do
     input = <<~HEREDOC
@@ -32,6 +32,6 @@ RSpec.describe IconFilter do
       <svg class="Vlt-green Vlt-icon Vlt-icon--small"><use xlink:href="/symbol/volta-icons.svg#Vlt-icon-heart" /></svg>\n
     HEREDOC
 
-    expect(IconFilter.call(input)). to eq(expected_output)
+    expect(described_class.call(input)). to eq(expected_output)
   end
 end

--- a/spec/filters/tab_filter_spec.rb
+++ b/spec/filters/tab_filter_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe TabFilter do
       HEREDOC
 
       expect do
-        TabFilter.new.call(input)
+        described_class.new.call(input)
       end.to raise_error('A source, tabs or config key must be present in this tabbed_example config')
     end
   end
@@ -23,7 +23,7 @@ RSpec.describe TabFilter do
       HEREDOC
 
       expect do
-        TabFilter.new.call(input)
+        described_class.new.call(input)
       end.to raise_error('A source, tabs or config key must be present in this tabbed_example config')
     end
   end


### PR DESCRIPTION
## Description

This pull request updates the `filter` specs currently in `master` to use the `described_class` keyword to refer to the object being tested. This enables us to have more durable tests, in the event we change the name of a method or class, it does not break the test.

## Deploy Notes

Notes regarding deployment the contained body of work. These should note any db migrations, etc.
