### PR TITLE
Language filter testing

### DIFF
--- a/spec/filters/language_filter_spec.rb
+++ b/spec/filters/language_filter_spec.rb
@@ -9,12 +9,12 @@ RSpec.describe LanguageFilter do
     expect(described_class.call(input)).to eql(expected_output)
   end
 
-  it 'raises an error if input is whitespace' do
+  it 'returns whitespace unaltered' do
     input = ' '
 
-    expected_output = ' ' # rubocop:disable UselessAssignment
+    expected_output = ' '
 
-    expect { described_class(input) }.to raise_error(ArgumentError)
+    expect(described_class.call(input)).to eql(expected_output)
   end
 
   it 'wraps matching input in a span tag and assigns "lang" to the tag' do

--- a/spec/filters/language_filter_spec.rb
+++ b/spec/filters/language_filter_spec.rb
@@ -1,35 +1,35 @@
 require 'rails_helper'
 
 RSpec.describe LanguageFilter do
-    it 'does nothing to text that does not match the regex' do 
-        input = 'some text'
+  it 'does nothing to text that does not match the regex' do
+    input = 'some text'
 
-        expected_output = 'some text'
-        
-        expect(described_class.call(input)).to eql(expected_output)
-    end
+    expected_output = 'some text'
 
-    it 'raises an error if input is whitespace' do 
-        input = ' '
+    expect(described_class.call(input)).to eql(expected_output)
+  end
 
-        expected_output = ' '
+  it 'raises an error if input is whitespace' do
+    input = ' '
 
-        expect{described_class(input)}.to raise_error(ArgumentError)
-    end
+    expected_output = ' ' # rubocop:disable UselessAssignment
 
-    it 'wraps matching input in a span tag and assigns "lang" to the tag' do 
-        input = "[נצמו](lang: 'il')"
+    expect { described_class(input) }.to raise_error(ArgumentError)
+  end
 
-        expected_output = "<span lang='il'>נצמו</span>"
+  it 'wraps matching input in a span tag and assigns "lang" to the tag' do
+    input = "[נצמו](lang: 'il')"
 
-        expect(described_class.call(input)).to eql(expected_output)
-    end
+    expected_output = "<span lang='il'>נצמו</span>"
 
-    it 'does nothing if the text is in correct format but it is missing the correct formatting' do 
-        input = "Bonjour(lang: 'fr')"
+    expect(described_class.call(input)).to eql(expected_output)
+  end
 
-        expected_output = "Bonjour(lang: 'fr')"
+  it 'does nothing if the text is in correct format but it is missing the correct formatting' do
+    input = "Bonjour(lang: 'fr')"
 
-        expect(described_class.call(input)).to eql(expected_output)
-    end
+    expected_output = "Bonjour(lang: 'fr')"
+
+    expect(described_class.call(input)).to eql(expected_output)
+  end
 end

--- a/spec/filters/language_filter_spec.rb
+++ b/spec/filters/language_filter_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe LanguageFilter do
     expect(described_class.call(input)).to eql(expected_output)
   end
 
-  it 'does nothing if the text is in correct format but it is missing the correct formatting' do
+  it 'does nothing if the text is correct but the word is not within brackets' do
     input = "Bonjour(lang: 'fr')"
 
     expected_output = "Bonjour(lang: 'fr')"

--- a/spec/filters/language_filter_spec.rb
+++ b/spec/filters/language_filter_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+
+RSpec.describe LanguageFilter do
+    it 'does nothing to text that does not match the regex' do 
+        input = 'some text'
+
+        expected_output = 'some text'
+        
+        expect(described_class.call(input)).to eql(expected_output)
+    end
+
+    it 'raises an error if input is whitespace' do 
+        input = ' '
+
+        expected_output = ' '
+
+        expect{described_class(input)}.to raise_error(ArgumentError)
+    end
+
+    it 'wraps matching input in a span tag and assigns "lang" to the tag' do 
+        input = "[נצמו](lang: 'il')"
+
+        expected_output = "<span lang='il'>נצמו</span>"
+
+        expect(described_class.call(input)).to eql(expected_output)
+    end
+
+    it 'does nothing if the text is in correct format but it is missing the correct formatting' do 
+        input = "Bonjour(lang: 'fr')"
+
+        expected_output = "Bonjour(lang: 'fr')"
+
+        expect(described_class.call(input)).to eql(expected_output)
+    end
+end


### PR DESCRIPTION
## Description

Added testing for `LanguageFilter`, specifically:

* It does nothing with non-matching text
* It raises an error if the input is only whitespace
* It correctly transforms matching input
* It does nothing if the input is correct except for the formatting

## Deploy Notes

Notes regarding deployment the contained body of work. These should note any db migrations, etc.
