### PR TITLE
Added tests for PartialFilter

### DIFF
--- a/spec/filters/partial_filter_spec.rb
+++ b/spec/filters/partial_filter_spec.rb
@@ -1,0 +1,51 @@
+require 'rails_helper'
+
+RSpec.describe PartialFilter do 
+    it 'renders input as HTML with config["platform"] set to true' do 
+        input = <<~HEREDOC
+        ```partial
+        source: _partials/stitch/guides/calling-users/javascript.md
+        platform: true
+        ```
+        HEREDOC
+
+        expected_output = <<~HEREDOC
+        <div class="js-platform" data-platform="true" data-active="false">
+        HEREDOC
+
+        expect(described_class.call(input)).to include(expected_output)
+    end
+
+    it 'renders input as markdown with config["platform"] not included' do 
+        input = <<~HEREDOC
+        ```partial
+        source: _partials/stitch/guides/calling-users/javascript.md
+        ```
+        HEREDOC
+
+        expected_output = <<~HEREDOC
+        ---
+        title: JavaScript
+        language: javascript
+        ---
+        HEREDOC
+
+        expect(described_class.call(input)).to include(expected_output)
+    end
+
+    it 'returns whitespace with whitespace input' do 
+        input = ' '
+
+        expected_output = ' '
+
+        expect(described_class.call(input)).to eql(expected_output)
+    end
+
+    it 'returns unaltered incorrect input' do 
+        input = 'this is incorrect input'
+
+        expected_output = 'this is incorrect input'
+
+        expect(described_class.call(input)).to eql(expected_output)
+    end
+end

--- a/spec/filters/partial_filter_spec.rb
+++ b/spec/filters/partial_filter_spec.rb
@@ -2,35 +2,35 @@ require 'rails_helper'
 
 RSpec.describe PartialFilter do
   it 'renders input as HTML with config["platform"] set to true' do
+    allow(File).to receive(:read).and_return(mock_partial)
+
     input = <<~HEREDOC
       ```partial
-      source: _partials/stitch/guides/calling-users/javascript.md
+      source: _some_path/to/a/file.md
       platform: true
       ```
     HEREDOC
 
     expected_output = <<~HEREDOC
-      <div class="js-platform" data-platform="true" data-active="false">
+      <div class=\"js-platform\" data-platform=\"true\" data-active=\"false\">\n  <p># Call Convenience methods for Stitch and JavaScript\nSome content here</p>\n\n</div>\n\n
     HEREDOC
 
-    expect(described_class.call(input)).to include(expected_output)
+    # .chop trailing \n from output
+    expect(described_class.call(input)).to eql(expected_output.chop)
   end
 
   it 'renders input as markdown with config["platform"] not included' do
+    allow(File).to receive(:read).and_return(mock_partial)
+
     input = <<~HEREDOC
       ```partial
-      source: _partials/stitch/guides/calling-users/javascript.md
+      source: _some_path/to/a/file.md
       ```
     HEREDOC
 
-    expected_output = <<~HEREDOC
-      ---
-      title: JavaScript
-      language: javascript
-      ---
-    HEREDOC
+    expected_output = "---\ntitle: JavaScript\nlanguage: javascript\n---\n # Call Convenience methods for Stitch and JavaScript\nSome content here\n"
 
-    expect(described_class.call(input)).to include(expected_output)
+    expect(described_class.call(input.chop)).to eql(expected_output)
   end
 
   it 'returns whitespace with whitespace input' do
@@ -47,5 +47,18 @@ RSpec.describe PartialFilter do
     expected_output = 'this is incorrect input'
 
     expect(described_class.call(input)).to eql(expected_output)
+  end
+
+  private
+
+  def mock_partial
+    <<~HEREDOC
+      ---
+      title: JavaScript
+      language: javascript
+      ---
+       # Call Convenience methods for Stitch and JavaScript
+      Some content here
+    HEREDOC
   end
 end

--- a/spec/filters/partial_filter_spec.rb
+++ b/spec/filters/partial_filter_spec.rb
@@ -1,51 +1,51 @@
 require 'rails_helper'
 
-RSpec.describe PartialFilter do 
-    it 'renders input as HTML with config["platform"] set to true' do 
-        input = <<~HEREDOC
-        ```partial
-        source: _partials/stitch/guides/calling-users/javascript.md
-        platform: true
-        ```
-        HEREDOC
+RSpec.describe PartialFilter do
+  it 'renders input as HTML with config["platform"] set to true' do
+    input = <<~HEREDOC
+      ```partial
+      source: _partials/stitch/guides/calling-users/javascript.md
+      platform: true
+      ```
+    HEREDOC
 
-        expected_output = <<~HEREDOC
-        <div class="js-platform" data-platform="true" data-active="false">
-        HEREDOC
+    expected_output = <<~HEREDOC
+      <div class="js-platform" data-platform="true" data-active="false">
+    HEREDOC
 
-        expect(described_class.call(input)).to include(expected_output)
-    end
+    expect(described_class.call(input)).to include(expected_output)
+  end
 
-    it 'renders input as markdown with config["platform"] not included' do 
-        input = <<~HEREDOC
-        ```partial
-        source: _partials/stitch/guides/calling-users/javascript.md
-        ```
-        HEREDOC
+  it 'renders input as markdown with config["platform"] not included' do
+    input = <<~HEREDOC
+      ```partial
+      source: _partials/stitch/guides/calling-users/javascript.md
+      ```
+    HEREDOC
 
-        expected_output = <<~HEREDOC
-        ---
-        title: JavaScript
-        language: javascript
-        ---
-        HEREDOC
+    expected_output = <<~HEREDOC
+      ---
+      title: JavaScript
+      language: javascript
+      ---
+    HEREDOC
 
-        expect(described_class.call(input)).to include(expected_output)
-    end
+    expect(described_class.call(input)).to include(expected_output)
+  end
 
-    it 'returns whitespace with whitespace input' do 
-        input = ' '
+  it 'returns whitespace with whitespace input' do
+    input = ' '
 
-        expected_output = ' '
+    expected_output = ' '
 
-        expect(described_class.call(input)).to eql(expected_output)
-    end
+    expect(described_class.call(input)).to eql(expected_output)
+  end
 
-    it 'returns unaltered incorrect input' do 
-        input = 'this is incorrect input'
+  it 'returns unaltered incorrect input' do
+    input = 'this is incorrect input'
 
-        expected_output = 'this is incorrect input'
+    expected_output = 'this is incorrect input'
 
-        expect(described_class.call(input)).to eql(expected_output)
-    end
+    expect(described_class.call(input)).to eql(expected_output)
+  end
 end


### PR DESCRIPTION
## Description

Added tests for `PartialFilter`:

* Renders content as HTML when `config['platform']` is set to `true`
* Renders content as markdown when `config['platform']` is not present
* Returns whitespace when whitespace is inputted
* Returns any other content when it does not match regex

## Deploy Notes

Notes regarding deployment the contained body of work. These should note any db migrations, etc.
