### PR TITLE
Added testing for ScreenshotFilter

### DIFF
--- a/spec/filters/screenshot_filter_spec.rb
+++ b/spec/filters/screenshot_filter_spec.rb
@@ -4,11 +4,11 @@ RSpec.describe ScreenshotFilter do
   it 'renders image markdown if image location is present in input' do
     input = <<~HEREDOC
       ```screenshot
-      image: public/assets/screenshots/smsInboundWebhook.png
+      image: /a/path/to/an/image.png
       ```
     HEREDOC
 
-    expected_output = '![Screenshot](/assets/screenshots/smsInboundWebhook.png)'
+    expected_output = '![Screenshot](/a/path/to/an/image.png)'
 
     # .chop to remove trailing \n from input
     expect(described_class.call(input.chop)).to eq(expected_output)

--- a/spec/filters/screenshot_filter_spec.rb
+++ b/spec/filters/screenshot_filter_spec.rb
@@ -1,0 +1,44 @@
+require 'rails_helper'
+
+RSpec.describe ScreenshotFilter do
+  it 'renders image markdown if image location is present in input' do
+    input = <<~HEREDOC
+      ```screenshot
+      image: public/assets/screenshots/smsInboundWebhook.png
+      ```
+    HEREDOC
+
+    expected_output = '![Screenshot](/assets/screenshots/smsInboundWebhook.png)'
+
+    # .chop to remove trailing \n from input
+    expect(described_class.call(input.chop)).to eq(expected_output)
+  end
+
+  it 'raises a NoMethodError if no options are provided' do
+    input = <<~HEREDOC
+      ```screenshot
+
+      ```
+    HEREDOC
+
+    expect { described_class.call(input) }.to raise_error(NoMethodError)
+  end
+
+  it 'provides instructions if image location is missing' do
+    input = <<~HEREDOC
+      ```screenshot
+      image:
+      ```
+    HEREDOC
+
+    expected_output = <<~HEREDOC
+      ## Missing image
+      To fix this run:
+      ```
+      $ rake screenshots:update
+      ```
+    HEREDOC
+    # .chop to remove trailing \n from input
+    expect(described_class.call(input.chop)).to eql(expected_output)
+  end
+end


### PR DESCRIPTION
## Description

Added testing for `ScreenshotFilter`:

* It renders image markdown when provided with correct input
* It raises a `NoMethodError` if `image` option is missing
* It provides user instruction if image location is missing

## Deploy Notes

Notes regarding deployment the contained body of work. These should note any db migrations, etc.
