### PR TITLE
Reordered the tutorials feedback icons to present the yes icon first

### DIFF
--- a/app/javascript/packs/Feedback.jsx
+++ b/app/javascript/packs/Feedback.jsx
@@ -239,8 +239,8 @@ class Feedback extends React.Component {
     } else {
       return(
         <div>
-          <span onClick={ () => this.setSentiment('negative') } className={ "Vlt-btn Vlt-btn--large Vlt-btn--tertiary Vlt-btn--icon" + (this.state.sentiment == 'negative' ? ' Vlt-btn_active' : '') }><svg className="Vlt-red" dangerouslySetInnerHTML={{__html: unhappyIcon }} /></span>
           <span onClick={ () => this.setSentiment('positive') } className={ "Vlt-btn Vlt-btn--large Vlt-btn--tertiary Vlt-btn--icon" + (this.state.sentiment == 'positive' ? ' Vlt-btn_active' : '') }><svg className="Vlt-green" dangerouslySetInnerHTML={{__html: happyIcon }} /></span>
+          <span onClick={ () => this.setSentiment('negative') } className={ "Vlt-btn Vlt-btn--large Vlt-btn--tertiary Vlt-btn--icon" + (this.state.sentiment == 'negative' ? ' Vlt-btn_active' : '') }><svg className="Vlt-red" dangerouslySetInnerHTML={{__html: unhappyIcon }} /></span>
         </div>
       )
     }


### PR DESCRIPTION
## Description

In response to issue #996, I've reordered the feedback icons to present the "yes" icon first to the user.

## Deploy Notes

Notes regarding deployment the contained body of work. These should note any db migrations, etc.
