### PR TITLE
Add button to exclude non-GA products from coverage

### DIFF
--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -96,6 +96,16 @@ class DashboardController < ApplicationController
       end
     end
 
+    # Remove non-GA features
+    if params[:show_ga_only]
+      params[:ignore_products] = 'conversation,messages,dispatch,audit'
+    end
+    params[:ignore_products]&.split(',')&.each do |key|
+      @complete_coverage.delete(key)
+      @toplevel_summary.delete(key)
+    end
+
+    # Calculate the overall summary
     @overall_summary = { 'blocks' => 0, 'langs' => {} }
     @supported_languages.each do |lang|
       @overall_summary['langs'][lang] = 0
@@ -168,9 +178,9 @@ class DashboardController < ApplicationController
       language = language.downcase
       language = 'dotnet' if language == 'csharp'
       x[language] = {
-          'source' =>  items['source'],
-          'source_path' =>  'config: ' + source_path,
-          'type' => 'config',
+        'source' =>  items['source'],
+        'source_path' =>  'config: ' + source_path,
+        'type' => 'config',
       }
     else
       stack = stack.clone

--- a/app/views/dashboard/coverage.html.erb
+++ b/app/views/dashboard/coverage.html.erb
@@ -38,6 +38,9 @@
         <br>
         <p><label>Ignore Languages:</label> <input type="text" name="ignore" placeholder="curl,php" value="<%=params[:ignore]%>" /></p>
         <p><label>Hide json/xml entries:</label> <input type="checkbox" name="hide_response" value="1" <%= params[:hide_response] ? 'checked' : '' %> /></p>
+        <br />
+        <p><label>Ignore Products:</label> <input type="text" name="ignore_products" placeholder="conversation,messages,dispatch,audit" value="<%=params[:ignore_products]%>" /></p>
+        <p><label>Show only GA products:</label> <input type="checkbox" name="show_ga_only" value="1" <%= params[:show_ga_only] ? 'checked' : '' %> /></p>
         <br>
     <%= link_to 'Reset', '/coverage' %> &nbsp;
     <%= submit_tag 'Update', class: 'button' %>


### PR DESCRIPTION
## Description

Adds the ability to exclude products from the building block coverage report

## Deploy Notes

N/A
