### PR TITLE
Add ogg file format to voice recordings guide

### DIFF
--- a/_documentation/voice/voice-api/guides/recording.md
+++ b/_documentation/voice/voice-api/guides/recording.md
@@ -83,9 +83,9 @@ If you added another `connect` action to this NCCO, the first two participants w
 
 ## File formats
 
-* Nexmo supports recording in MP3 or WAV format, the default is MP3.
+* Nexmo supports recording in MP3, OGG or WAV format, the default is MP3 (or WAV for recording more than 2 channels).
 * MP3 files are recorded with a 16-bit depth and a 16kHz sample rate. They are encoded with a constant bit rate of 32Kbps.
 * WAV files are recorded with a 16-bit depth and a 16kHz sample rate.
 
-Both formats are mono by default. If split recording is enabled, a stereo file with each channel using the previously mentioned bit-depth and sampling rates is created.
+All formats are mono by default. If split recording is enabled, a stereo file with each channel using the previously mentioned bit-depth and sampling rates is created.
 


### PR DESCRIPTION
## Description

We added support for `.ogg` format files when creating recordings, this is shown in the NCCO reference but the recording guide doesn't mention it. This change adds it there.
