### PR TITLE
Fix for issue #1376: Objective-C and Cross Platform language tags broken

### DIFF
--- a/_tutorials/client-sdk-generate-test-credentials.md
+++ b/_tutorials/client-sdk-generate-test-credentials.md
@@ -3,7 +3,7 @@ title: How to Generate Test Credentials
 products: client-sdk
 description: This tutorial shows you how to create a Nexmo application, users and tokens.
 languages:
-    - Cross platform
+    - Node
 ---
 
 # How to Generate Test Credentials

--- a/_tutorials/client-sdk-ios-add-sdk-to-your-app.md
+++ b/_tutorials/client-sdk-ios-add-sdk-to-your-app.md
@@ -3,7 +3,7 @@ title: How to Add the Nexmo Client SDK to your iOS App
 products: client-sdk
 description: This tutorial shows you how to add the Nexmo Client SDK to your iOS application.
 languages:
-    - Objective-C 
+    - Objective_C 
     - Swift
 ---
 

--- a/_tutorials/client-sdk-ios-in-app-messaging.md
+++ b/_tutorials/client-sdk-ios-in-app-messaging.md
@@ -3,7 +3,7 @@ title: How to Add In-App Messaging to your iOS App
 products: client-sdk
 description: This tutorial shows you how to add in-app messaging to your iOS application using the Nexmo Client SDK.
 languages:
-    - Objective-C 
+    - Objective_C 
     - Swift
 ---
 

--- a/_tutorials/client-sdk-ios-make-receive-calls-objective-c.md
+++ b/_tutorials/client-sdk-ios-make-receive-calls-objective-c.md
@@ -3,7 +3,7 @@ title: How to Make and Receive Voice calls with the Nexmo Client SDK on iOS usin
 products: client-sdk
 description: This tutorial shows you how to create a Nexmo Client SDK application that can make and receive voice calls on iOS using Objective-C.
 languages:
-    - Objective C
+    - Objective_C
 ---
 
 # How to Make and Receive Voice calls with the Nexmo Client SDK on iOS using Objective-C

--- a/_tutorials/client-sdk-ios-set-up-push-notifications.md
+++ b/_tutorials/client-sdk-ios-set-up-push-notifications.md
@@ -3,7 +3,7 @@ title: How to Set Up Nexmo Push Notifications on iOS
 products: client-sdk
 description: This tutorial shows you how to set up push notifications using Firebase.
 languages:
-    - Objective-C
+    - Objective_C
     - Swift
 ---
 

--- a/app/views/tutorials/_index.html.erb
+++ b/app/views/tutorials/_index.html.erb
@@ -16,7 +16,7 @@
 
         <% if tutorial.languages.count > 0 %>
           <% tutorial.languages.each do |language| %>
-            <a href="<%= "#{@base_path}/#{language.downcase}" %>"><small class="Vlt-grey-darker Nxd-tutorials__language Nxd-tutorials__language--<%= language %>"><span>●</span> <%= language %></small></a>
+            <a href="<%= "#{@base_path}/#{language.downcase}" %>"><small class="Vlt-grey-darker Nxd-tutorials__language Nxd-tutorials__language--<%= language %>"><span>●</span><%= language == "Objective_C" ? "Objective-C" : language %></small></a>
             <% end %>
           <% end %>
 


### PR DESCRIPTION
This PR is in response to issue #1376, wherein it was reported by @huijing that the language tags for "Objective-C" and "Cross Platform" were not working in the Tutorials listings. 

I have addressed this by updating all the tutorials markdown files to use the language name designation in conformity with the `code_languages.yml` config file for Objective-C, which is `Objective_C`. I also removed `Cross Platform` from the tutorials markdown language listings, as that is not an accurate language. I updated the one reference for that in the tutorials to `Node` as that tutorial is addressing a Node.JS setup. Lastly, I added conditional logic in the `_index.html.erb` tutorials partial to show `Objective-C` to the visitor when rendered and not the backend text of `Objective_C`.