### PR TITLE
Document Websocket/SIP header formats

### DIFF
--- a/_documentation/voice/voice-api/guides/websockets.md
+++ b/_documentation/voice/voice-api/guides/websockets.md
@@ -35,8 +35,16 @@ To instruct Nexmo to connect to a WebSocket your application server must return 
                 "uri": "wss://example.com/socket",
                 "content-type": "audio/l16;rate=16000",
                 "headers": {
-                    "prop1": "value1",
-                    "prop2": "value2"
+                    "name": "J Doe",
+                    "age": 40,
+                    "address": {
+                        "line_1": "Apartment 14",
+                        "line_2": "123 Example Street",
+                        "city": "New York City"
+                    },
+                    "system_roles": [183493, 1038492, 22],
+                    "enable_auditing": false,
+                    "manager_id": null"
                 }
            }
        ]

--- a/_documentation/voice/voice-api/ncco-reference.md
+++ b/_documentation/voice/voice-api/ncco-reference.md
@@ -161,13 +161,14 @@ Value | Description
 -- | --
 `uri` | the URI to the websocket you are streaming to.
 `content-type` | the internet media type for the audio you are streaming. Possible values are: `audio/l16;rate=16000`
-`headers` | a JSON object containing any metadata you want.
+`headers` | a JSON object containing any metadata you want. See [connecting to a websocket](/voice/voice-api/guides/websockets#connecting-to-a-websocket) for example headers
 
 #### sip - the sip endpoint to connect to
 
 Value | Description
 -- | --
-`uri` | the SIP URI to the endpoint you are connecting to in the format sip:rebekka@sip.example.com.
+`uri` | the SIP URI to the endpoint you are connecting to in the format `sip:rebekka@sip.example.com`.
+`headers` | `key` => `value` string pairs containing any metadata you need e.g. `{ "location": "New York City", "occupation": "developer" }`
 
 ## Talk
 

--- a/_examples/voice/guides/ncco-reference/connect/sip-endpoint-connect.md
+++ b/_examples/voice/guides/ncco-reference/connect/sip-endpoint-connect.md
@@ -18,7 +18,8 @@ menu_weight: 3
     "endpoint": [
       {
         "type": "sip",
-        "uri": "sip:rebekka@sip.mcrussell.com"
+        "uri": "sip:rebekka@sip.mcrussell.com",
+        "headers": { "location": "New York City", "occupation": "developer" }
       }
     ]
   }

--- a/_examples/voice/guides/ncco-reference/connect/websocket-endpoint-connect.md
+++ b/_examples/voice/guides/ncco-reference/connect/websocket-endpoint-connect.md
@@ -16,14 +16,24 @@ menu_weight: 2
     ],
     "from": "447700900000",
     "endpoint": [
-    {
-      "type": "websocket",
-      "uri": "ws://example.com/socket",
-      "content-type": "audio/l16;rate=16000",
-      "headers": {
-        "whatever": "metadata_you_want"
+      {
+        "type": "websocket",
+        "uri": "ws://example.com/socket",
+        "content-type": "audio/l16;rate=16000",
+        "headers": {
+            "name": "J Doe",
+            "age": 40,
+            "address": {
+                "line_1": "Apartment 14",
+                "line_2": "123 Example Street",
+                "city": "New York City"
+            },
+            "system_roles": [183493, 1038492, 22],
+            "enable_auditing": false,
+            "manager_id": null
+        }
       }
-      }
-    ]}
+    ]
+  }
 ]
 ```


### PR DESCRIPTION
## Description

Document header format types for websocket/sip. Websockets can have any JSON data, SIP can use string key/value pairs

## Deploy Notes

N/A
