### PR TITLE
VAPI NCCO in Create Call

### DIFF
--- a/.repos/nexmo/curl-building-blocks/voice/voice-api/make-an-outbound-call-with-ncco.sh
+++ b/.repos/nexmo/curl-building-blocks/voice/voice-api/make-an-outbound-call-with-ncco.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+source "../../config.sh"
+source "../../jwt.sh"
+
+curl -X POST https://api.nexmo.com/v1/calls\
+  -H "Authorization: Bearer "$JWT\
+  -H "Content-Type: application/json"\
+  -d '{"to":[{"type": "phone","number": "'$TO_NUMBER'"}],
+      "from": {"type": "phone","number": "'$NEXMO_NUMBER'"},
+      "ncco": [
+        {
+          "action": "talk",
+          "text": "This is a text to speech call from Nexmo"
+        }
+      ]}'

--- a/_documentation/voice/voice-api/building-blocks/make-an-outbound-call-with-ncco.md
+++ b/_documentation/voice/voice-api/building-blocks/make-an-outbound-call-with-ncco.md
@@ -1,0 +1,33 @@
+---
+title: Make an outbound call with an NCCO
+navigation_weight: 1
+---
+
+# Make an outbound call with an NCCO
+
+This building block makes an outbound call and plays a
+text-to-speech message when the call is answered. You don't need to run a
+server hosting an `answer_url` to run this building block, as you provide your
+NCCO as part of the request
+
+## Example
+
+Replace the following variables in the example code:
+
+Key |	Description
+-- | --
+`NEXMO_NUMBER` |	Your Nexmo number that the call will be made from. For example `447700900000`.
+`TO_NUMBER` |	The number you would like to call to in E.164 format. For example `447700900001`.
+
+```building_blocks
+source: '_examples/voice/make-an-outbound-call-with-ncco'
+application:
+  type: voice
+  name: 'Outbound Call with NCCO Building Block'
+  disable_ngrok: true
+```
+
+## Try it out
+
+When you run the code the `TO_NUMBER` will be called and a text-to-speech message
+will be heard if the call is answered.

--- a/_documentation/voice/voice-api/guides/call-flow.md
+++ b/_documentation/voice/voice-api/guides/call-flow.md
@@ -18,6 +18,8 @@ Both inbound and outbound calls follow the same call flow once answered. This ca
 
 When a call is answered, Nexmo makes a call to the `answer_url` provided. For inbound calls the `answer_url` is fetched from the configuration of the application that the number is linked to. For outbound calls, an `answer_url` is provided in the API request made to create the call.
 
+You may choose to provide your NCCO as part of the request you send to create a call instead of providing an `answer_url`. This is done by providing an NCCO in the `ncco` key of [your request](/api/voice#createCall)
+
 ## Call states
 
 Each call goes through a sequence of states in its lifecycle:

--- a/_examples/voice/make-an-outbound-call-with-ncco/curl.yml
+++ b/_examples/voice/make-an-outbound-call-with-ncco/curl.yml
@@ -1,0 +1,5 @@
+---
+code:
+    source: .repos/nexmo/curl-building-blocks/voice/voice-api/make-an-outbound-call-with-ncco.sh
+    from_line: 5
+    to_line: 100

--- a/app/views/open_api/_parameters.html.erb
+++ b/app/views/open_api/_parameters.html.erb
@@ -64,7 +64,7 @@
                 <% if parameter.array? %>
                   <br>
                   <% if parameter.items && parameter.items['type'] %>
-                    of <%= (parameter.items['type']) %>'s
+                    of <%= (parameter.items['type']) %>s
                   <% end %>
                 <% end %>
               </i>
@@ -113,8 +113,9 @@
           <% unless model %>
             <% if parameter.collection? or parameter.oneOf? %>
               <% if parameter.raw['x-nexmo-developer-collection-description-shown'] %>
-                <!-- Just for spacing -->
-                <td></td>
+                <td>
+                  <%= (parameter.example ? "<code><pre>#{parameter.example}</pre></code>" : '').html_safe %>
+                </td>
               <% end %>
             <% else %>
               <td>


### PR DESCRIPTION
## Description

Add docs for supplying an NCCO in the initial POST body when creating a call. This is mentioned in the call flow page, adds a new building block and updates the OAS document

## Deploy Notes

N/A