### PR TITLE
Fix code language replacement for tutorials

### DIFF
--- a/app/controllers/tutorials_controller.rb
+++ b/app/controllers/tutorials_controller.rb
@@ -17,7 +17,7 @@ class TutorialsController < ApplicationController
 
     # We have to strip the last section off if it matches any code languages. Hacky, but it works
     DocumentationConstraint.code_language_list.map(&:downcase).each do |lang|
-      @base_path.gsub!("/#{lang}", '')
+      @base_path.gsub!(%r{/#{lang}$}, '')
     end
 
     render layout: 'page'


### PR DESCRIPTION
## Description

`/client-sdk` was being caught in a search and replace for `cli` which resulted in `/ent-sdk` being rendered (and subsequently not replaced). Yes, this entire thing is held together with string and tape.

## Deploy Notes

N/A
