### PR TITLE
Replace space between the indicator dot and text

### DIFF
--- a/app/views/tutorials/_index.html.erb
+++ b/app/views/tutorials/_index.html.erb
@@ -16,7 +16,7 @@
 
         <% if tutorial.languages.count > 0 %>
           <% tutorial.languages.each do |language| %>
-            <a href="<%= "#{@base_path}/#{language.downcase}" %>"><small class="Vlt-grey-darker Nxd-tutorials__language Nxd-tutorials__language--<%= language %>"><span>●</span><%= language == "Objective_C" ? "Objective-C" : language %></small></a>
+            <a href="<%= "#{@base_path}/#{language.downcase}" %>"><small class="Vlt-grey-darker Nxd-tutorials__language Nxd-tutorials__language--<%= language %>"><span>●</span> <%= language == "Objective_C" ? "Objective-C" : language %></small></a>
             <% end %>
           <% end %>
 


### PR DESCRIPTION
## Description

Space between indicator dot and text was removed in commit aae18c10ec865abfa6f4bde278570cd01bf1ef44. Relevant to issue #1376 