### PR TITLE
Added Decline Call example for JS

### DIFF
--- a/_examples/client-sdk/in-app-voice/decline-call/javascript.yml
+++ b/_examples/client-sdk/in-app-voice/decline-call/javascript.yml
@@ -1,0 +1,11 @@
+---
+title: JavaScript
+language: javascript
+dependencies:
+    - nexmo-stitch
+code:
+    source: .repos/nexmo/client-sdk-javascript-building-blocks/in-app-voice/decline-call/DeclineCall.js
+    from_line: 1
+    to_line: 2
+run_command: 'Load in your browser'
+file_name: DeclineCall.js


### PR DESCRIPTION
## Description

Added a JavaScript code example for Declining a Call, to address DEVX-782.

## Deploy Notes

Depends on the example code in https://github.com/Nexmo/client-sdk-javascript-building-blocks
