### PR TITLE
Removed WDC SIP proxies

### DIFF
--- a/_documentation/voice/sip/configure/freepbx.md
+++ b/_documentation/voice/sip/configure/freepbx.md
@@ -10,22 +10,6 @@ Below we provide example configurations for using Nexmo's SIP service with [Free
 ## Inbound configuration
 
 ````
-host=173.193.199.24
-type=friend
-insecure=port,invite
-;Add your codec list here.
-; Note: Use "ulaw" for US only, "alaw" for the rest of the world.
-allow=ulaw,alaw,g729
-dtmfmode=rfc2833
-
-host=174.37.245.34
-type=friend
-insecure=port,invite
-;Add your codec list here.
-; Note: Use "ulaw" for US only, "alaw" for the rest of the world.
-allow=ulaw,alaw,g729
-dtmfmode=rfc2833
-
 host=5.10.112.121
 type=friend
 insecure=port,invite


### PR DESCRIPTION
Removed WDC SIP Proxies, as they are decommissioned from 30th Jan.

## Description

Please describe what the changes are made in this pull request and why the change was necessary.

## Deploy Notes

Notes regarding deployment the contained body of work. These should note any db migrations, etc.
