### PR TITLE
Extract VideoHelper module

### DIFF
--- a/app/helpers/video_helper.rb
+++ b/app/helpers/video_helper.rb
@@ -1,0 +1,15 @@
+module VideoHelper
+  def video_embed_url(video_url)
+    if video_url.include? 'youtube'
+      video_id = video_url.match(/v=(.{11})/)[1]
+      return "https://www.youtube.com/embed/#{video_id}?showinfo=0"
+    end
+
+    if video_url.include? 'vimeo'
+      video_id = video_url.match(/(\d{7,})/)[1]
+      return "https://player.vimeo.com/video/#{video_id}"
+    end
+
+    video_url
+  end
+end

--- a/app/models/session.rb
+++ b/app/models/session.rb
@@ -6,28 +6,4 @@ class Session < ApplicationRecord
   validates :video_url, presence: true
 
   scope :published, -> { where(published: true) }
-
-  def video_content
-    <<~HEREDOC
-      <div class="video">
-        <iframe src="#{embed_url}" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>
-      </div>
-    HEREDOC
-  end
-
-  private
-
-  def embed_url
-    if video_url.include? 'youtube'
-      video_id = video_url.match(/v=(.{11})/)[1]
-      return "https://www.youtube.com/embed/#{video_id}?showinfo=0"
-    end
-
-    if video_url.include? 'vimeo'
-      video_id = video_url.match(/(\d{7})/)[1]
-      return "https://player.vimeo.com/video/#{video_id}"
-    end
-
-    video_url
-  end
 end

--- a/app/views/static/community.html.erb
+++ b/app/views/static/community.html.erb
@@ -32,7 +32,9 @@
       <% @sessions.each do |session| %>
         <div class="Vlt-col Vlt-col--1of3">
           <h4><%= session.title %></h4>
-          <%= session.video_content.html_safe %>
+          <div class="video">
+            <iframe src="<%= video_embed_url(session.video_url) %>" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>
+          </div>
           <p><%= session.description %></p>
           <br>
         </div>

--- a/spec/helpers/video_helper_spec.rb
+++ b/spec/helpers/video_helper_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+RSpec.describe VideoHelper, type: :helper do
+  describe '#video_embed_url' do
+    context 'with a youtube video url' do
+      let(:video_url) { 'https://www.youtube.com/watch?v=i7EZDYYfFmc' }
+
+      it 'returns a youtube embed url' do
+        expect(helper.video_embed_url(video_url)).to eq('https://www.youtube.com/embed/i7EZDYYfFmc?showinfo=0')
+      end
+    end
+
+    context 'with a vimeo video url' do
+      let(:video_url) { 'https://vimeo.com/205296677' }
+
+      it 'returns a vimeo embed url' do
+        expect(helper.video_embed_url(video_url)).to eq('https://player.vimeo.com/video/205296677')
+      end
+    end
+  end
+end


### PR DESCRIPTION
Avoids presentation logic, markup, and html_safe call in model; easier to re-use; easier to test.

Vimeo regexp adjusted to match longer ids.