### PR TITLE
Extract ParameterValuesHelper module

### DIFF
--- a/app/helpers/parameter_values_helper.rb
+++ b/app/helpers/parameter_values_helper.rb
@@ -1,0 +1,5 @@
+module ParameterValuesHelper
+  def parameter_values(enum)
+    to_sentence(enum.map { |value| content_tag(:code, value) }, last_word_connector: ' or ', two_words_connector: ' or ')
+  end
+end

--- a/app/views/open_api/_parameters.html.erb
+++ b/app/views/open_api/_parameters.html.erb
@@ -84,7 +84,7 @@
               <br>
               <small class="Vlt-grey-dark">
                   <%= (callback || model) ? "One of:" : "Must be one of:" %>
-                  <%= parameter.enum.map { |s| "<code>#{s}</code>" }.to_sentence(last_word_connector: ' or ', two_words_connector: ' or ').html_safe %>
+                  <%= parameter_values(parameter.enum) %>
               </small>
             <% end %>
 
@@ -92,7 +92,7 @@
               <br>
               <small class="Vlt-grey-dark">
                   Will be one of:
-                  <%= parameter.raw['x-possible-values'].map { |s| "<code>#{s}</code>" }.to_sentence(last_word_connector: ' or ', two_words_connector: 'or').html_safe %>
+                  <%= parameter_values(parameter.raw['x-possible-values']) %>
               </small>
             <% end %>
 

--- a/app/views/open_api/_response_description_parameters.html.erb
+++ b/app/views/open_api/_response_description_parameters.html.erb
@@ -23,7 +23,7 @@
     <%= value['description'] ? value['description'].render_markdown : '' %>
       <% if value['enum']%>
        <small class="Vlt-grey-dark">
-          One of: <%= value['enum'].map { |s| "<code>#{s}</code>" }.to_sentence(last_word_connector: ' or ', two_words_connector: ' or ').html_safe %>
+          One of: <%= parameter_values(value['enum']) %>
         </small>
       <% end %>
 

--- a/spec/helpers/parameter_values_helper_spec.rb
+++ b/spec/helpers/parameter_values_helper_spec.rb
@@ -1,0 +1,18 @@
+require 'rails_helper'
+
+RSpec.describe ParameterValuesHelper, type: :helper do
+  describe '#parameter_values' do
+    it 'returns a sentence containing the given values wrapped in code tags' do
+      expect(helper.parameter_values(%w[value])).to eq('<code>value</code>')
+    end
+
+    it 'returns a html_safe string' do
+      expect(helper.parameter_values(%w[value])).to be_html_safe
+    end
+
+    it 'uses or to connect the last two values in the sentence' do
+      expect(helper.parameter_values(%w[1 2])).to eq('<code>1</code> or <code>2</code>')
+      expect(helper.parameter_values(%w[1 2 3])).to eq('<code>1</code>, <code>2</code> or <code>3</code>')
+    end
+  end
+end


### PR DESCRIPTION
Using #content_tag and #to_sentence helpers to eliminate html_safe calls and HTML in strings.