### PR TITLE
Support per-path server blocks in OAS rendering

### DIFF
--- a/app/controllers/open_api_controller.rb
+++ b/app/controllers/open_api_controller.rb
@@ -83,6 +83,12 @@ end
 
 # We should fix this in OasParser properly rather than monkeypatching at some point
 module OasParser
+  class Path
+    def servers
+      raw['servers']
+    end
+  end
+
   class Parser
     def self.resolve(path)
       filename = path.split('#/')[0]

--- a/app/views/open_api/_endpoint.html.erb
+++ b/app/views/open_api/_endpoint.html.erb
@@ -9,7 +9,10 @@
       <div class="Vlt-badge-combined">
         <code class="Vlt-badge Vlt-badge--large Nxd-method-badge Nxd-method-badge--<%= endpoint.method %>"><%= endpoint.method.upcase %></code>
         <code class="Vlt-badge Vlt-badge--large Vlt-badge--grey">
-          <span><%= endpoint.definition.servers[0]['url'] %></span><%= endpoint.path.path.gsub(/\{(.+?)\}/, '<span class="api-path-parameter">:\1</span>').html_safe %>
+          <%
+              servers = endpoint.path.servers ? endpoint.path.servers : endpoint.definition.servers
+          %>
+          <span><%= servers[0]['url'] %></span><%= endpoint.path.path.gsub(/\{(.+?)\}/, '<span class="api-path-parameter">:\1</span>').html_safe %>
         </code>
       </div>
 


### PR DESCRIPTION
## Description

It's valid in OpenAPI to have a server endpoint specified at the operation level and we use this in the account API where part of the old developer API hits rest.nexmo.com and the newer secret management API hits api.nexmo.com.

Resolves #1302

## Deploy Notes

N/A