### PR TITLE
Update with guidance on failover to SMS with Dispatch API

### DIFF
--- a/_documentation/dispatch/building-blocks/send-an-mms-with-failover.md
+++ b/_documentation/dispatch/building-blocks/send-an-mms-with-failover.md
@@ -18,7 +18,7 @@ Key | Description
 -- | --
 `NEXMO_APPLICATION_ID` | The ID of the application that you created.
 `FROM_NUMBER` | The phone number you are sending the MMS from. (US Short Code and US LVN)
-`TO_NUMBER` | The phone number you are sending the MMS to (T-Mobile is not supported).
+`TO_NUMBER` | The phone number you are sending the MMS to (T-Mobile and Verizon are not currently supported).
 
 > **NOTE:** Don't use a leading `+` or `00` when entering a phone number, start with the country code, for example 447700900000.
 

--- a/_documentation/messages/building-blocks/send-mms.md
+++ b/_documentation/messages/building-blocks/send-mms.md
@@ -30,3 +30,6 @@ application:
 ## Try it out
 
 When you run the code an MMS message is sent to the destination number.
+
+## Sending to unsupported networks
+Sending MMS to the Verizon and T-Mobile networks is not currently supported. In order to ensure your messages get to their recipient successfully use our [Dispatch API to automatically failover to SMS](/dispatch/building-blocks/send-an-mms-with-failover) when MMS cannot be delivered.


### PR DESCRIPTION
## Description

Adding in some guidance on how to failover from MMS to SMS when sending to unsupported networks.

## Deploy Notes

Text updates only.
