### PR TITLE
Scroll active sidebar link in to view on navigation

### DIFF
--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -73,6 +73,13 @@ let refresh = () => {
       tag.scrollIntoView(true);
     }
   }
+
+  setTimeout(function() {
+    const sidebarActive = document.querySelector('.Vlt-sidemenu__link_active')
+    if(sidebarActive){
+      sidebarActive.scrollIntoView(true);
+    }
+  }, 100)
 }
 
 $(document).on('nexmo:load', function() {


### PR DESCRIPTION
## Description

> When clicking on a link in the left navigation the navigation scroll position is reset on page transition. This means I need to scroll back down if I want to browse various links in the same "namespace". For example, if I click on "Inbound Call" building block and now I want to view "Earmuff Call" I need to re-scroll the navigation.

> This is also true when opening new sections in the navigation. The Voice -> Voice API section will collapse when I open the Dispatch API section, but the Dispatch API section gets moved up beyond the visible area so I need to scroll up.

Resolves #1119

## Deploy Notes

N/A