### PR TITLE
MMS LVN update clarity on Short Codes

### DIFF
--- a/_documentation/dispatch/building-blocks/send-an-mms-with-failover.md
+++ b/_documentation/dispatch/building-blocks/send-an-mms-with-failover.md
@@ -18,7 +18,7 @@ Key | Description
 -- | --
 `NEXMO_APPLICATION_ID` | The ID of the application that you created.
 `FROM_NUMBER` | The phone number you are sending the MMS from. (US Short Code and US LVN)
-`TO_NUMBER` | The phone number you are sending the MMS to (T-Mobile and Verizon are not currently supported when sending using US LVNs).
+`TO_NUMBER` | The phone number you are sending the MMS to (Recipients on T-Mobile and Verizon networks are currently only supported when sending from US Short codes).
 
 > **NOTE:** Don't use a leading `+` or `00` when entering a phone number, start with the country code, for example 447700900000.
 

--- a/_documentation/dispatch/building-blocks/send-an-mms-with-failover.md
+++ b/_documentation/dispatch/building-blocks/send-an-mms-with-failover.md
@@ -18,7 +18,7 @@ Key | Description
 -- | --
 `NEXMO_APPLICATION_ID` | The ID of the application that you created.
 `FROM_NUMBER` | The phone number you are sending the MMS from. (US Short Code and US LVN)
-`TO_NUMBER` | The phone number you are sending the MMS to (T-Mobile and Verizon are not currently supported).
+`TO_NUMBER` | The phone number you are sending the MMS to (T-Mobile and Verizon are not currently supported when sending using US LVNs).
 
 > **NOTE:** Don't use a leading `+` or `00` when entering a phone number, start with the country code, for example 447700900000.
 

--- a/_documentation/messages/building-blocks/send-mms.md
+++ b/_documentation/messages/building-blocks/send-mms.md
@@ -6,7 +6,7 @@ title: Send an MMS
 
 In this building block you will see how to send an MMS using the Messages API.
 
-> **IMPORTANT:** Only US Short codes and US LVNs are currently supported for sending MMS. Recipients on T-Mobile and Verizon networks are not currently supported.
+> **IMPORTANT:** Only US Short codes and US LVNs are currently supported for sending MMS. Recipients on T-Mobile and Verizon networks are not currently supported on US LVNs.
 
 ## Example
 
@@ -15,7 +15,7 @@ Ensure the following variables are set to your required values using any conveni
 | Key           | Description                                                                                                 |
 | ------------- | ----------------------------------------------------------------------------------------------------------- |
 | `FROM_NUMBER` | The phone number you are sending the MMS from. (US Short Code and US LVN only)                              |
-| `TO_NUMBER`   | The phone number you are sending the message to. T-Mobile and Verizon networks are not currently supported. |
+| `TO_NUMBER`   | The phone number you are sending the message to. T-Mobile and Verizon networks are not currently supported for US LVN. |
 | `IMG_URL`     | The URL of the media you want to send                                                                       |
 
 > **NOTE:** Don't use a leading `+` or `00` when entering a phone number, start with the country code, for example 14155550105.

--- a/_documentation/messages/building-blocks/send-mms.md
+++ b/_documentation/messages/building-blocks/send-mms.md
@@ -6,7 +6,7 @@ title: Send an MMS
 
 In this building block you will see how to send an MMS using the Messages API.
 
-> **IMPORTANT:** Only US Short codes and US LVNs are currently supported for sending MMS. Recipients on T-Mobile and Verizon networks are not currently supported on US LVNs.
+> **IMPORTANT:** Only US Short codes and US LVNs are currently supported for sending MMS. Recipients on T-Mobile and Verizon networks are currently only supported when sending from US Short codes.
 
 ## Example
 
@@ -15,7 +15,7 @@ Ensure the following variables are set to your required values using any conveni
 | Key           | Description                                                                                                 |
 | ------------- | ----------------------------------------------------------------------------------------------------------- |
 | `FROM_NUMBER` | The phone number you are sending the MMS from. (US Short Code and US LVN only)                              |
-| `TO_NUMBER`   | The phone number you are sending the message to. T-Mobile and Verizon networks are not currently supported for US LVN. |
+| `TO_NUMBER`   | The phone number you are sending the message to. |
 | `IMG_URL`     | The URL of the media you want to send                                                                       |
 
 > **NOTE:** Don't use a leading `+` or `00` when entering a phone number, start with the country code, for example 14155550105.


### PR DESCRIPTION
## Description

Text change to clarify that T-Mobile and Verizon can be sent to on US Short Code but not US LVN.

## Deploy Notes

Text only change.
