### PR TITLE
small fixed in setup docs

### DIFF
--- a/_documentation/client-sdk/concepts/jwt-acl.md
+++ b/_documentation/client-sdk/concepts/jwt-acl.md
@@ -9,22 +9,7 @@ description: How to create JWTs and ACLs
 
 ### Overview
 
-The Nexmo Client SDKs use [JWTs](https://jwt.io/) for authentication when a user logs in. These JWTs are generated using the application ID and private key that is provided when a new application is created.
-
-One way to create a new application is from the Nexmo CLI:
-
-```sh
-nexmo app:create "My Nexmo App" https://example.com/answer https://example.com/event --type=rtc --keyfile=private.key
-```
-
-```
-Application created: aaaaaaaa-bbbb-cccc-dddd-0123456789ab
-No existing config found. Writing to a new file.
-Credentials written to /path/to/your/local/folder/.nexmo-app
-Private Key saved to: private.key
-```
-
-You can also create a new application within the [Nexmo Dashboard](https://dashboard.nexmo.com/voice/create-application).
+The Nexmo Client SDKs use [JWTs](https://jwt.io/) for authentication when a user logs in. These JWTs are generated using the application ID and private key that is provided [when a new application is created.](/tutorials/client-sdk-generate-test-credentials#create-a-nexmo-application)
 
 ### Claims
 

--- a/_tutorials/client-sdk-android-make-receive-calls.md
+++ b/_tutorials/client-sdk-android-make-receive-calls.md
@@ -12,7 +12,7 @@ In this tutorial you learn how to use the Nexmo Client SDK for Android, in order
 
 You create a simple app that can make a call and receive a call.
 
-The app has two buttons, to login as two different users: Jane and Joe. After logging in, the user can call the other user, or to call a Public Switched Telephone Network (PSTN) phone number.
+The app will have two buttons, which log in different users: Jane or Joe. After logging in, Jane and Joe are able to place a call and perform actions such as answer, reject or hangup.
 
 ## Prerequisites
 

--- a/_tutorials/client-sdk-generate-test-credentials.md
+++ b/_tutorials/client-sdk-generate-test-credentials.md
@@ -16,7 +16,8 @@ In order to use the Nexmo Client SDK, there are three things you need to set up 
 
 * [JSON Web Tokens, JWTs](https://jwt.io/) - Nexmo Client SDK uses JWTs for authentication. In order for a user to log in and use the SDK functionality, you need to provide a JWT per user. JWTs contain all the information the Nexmo platform needs to authenticate requests, as well as information such as the associated Applications, Users and permissions.
 
-All of these may be created by your backend. If you wish to get started and experience using the SDK without any implementation of your backend, this tutorial will show you how to do so, using the Nexmo CLI.
+All of these may be [created by your backend](/documentation/conversation/overview). 
+If you wish to get started and experience using the SDK without any implementation of your backend, this tutorial will show you how to do so, using the [Nexmo CLI](https://github.com/Nexmo/nexmo-cli).
 
 ## Prerequisites
 
@@ -26,13 +27,15 @@ Make sure you have the following:
 * [Node.JS](https://nodejs.org/en/download/) and NPM installed
 * Install the Nexmo CLI.
 
-To install the Nexmo CLI, run the following in a terminal:
+To install the Nexmo CLI, run the following command in a terminal:
 
 ```bash
-$ npm install -g nexmo-cli@beta
+npm install -g nexmo-cli@beta
 ```
 
 Set up the Nexmo CLI to use your Nexmo API Key and API Secret. You can get these from the [settings page](https://dashboard.nexmo.com/settings) in the Nexmo Dashboard.
+
+Run the following command in a terminal, while replacing `api_key` and `api_secret` with your own:
 
 ```bash
 nexmo setup api_key api_secret
@@ -59,11 +62,11 @@ Private Key saved to: private.key
 
 On the first output line is the Application ID. Take a note of it. It will be later referred to as `MY_APP_ID`.
 
-In addition, a private key is created. It is used to generate JWTs that are used to authenticate your interactions with Nexmo.
+In addition, a private key is created and is saved locally on your machine. It is used to generate JWTs that are used to authenticate your interactions with Nexmo.
 
 ## Create a User
 
-Create a user who will log in to Nexmo Client and participate in the SDK functionality: Conversations, Calls and so on.
+Create a User who will log in to Nexmo Client and participate in the SDK functionality: Conversations, Calls and so on.
 
 Replace `MY_USER_NAME` with your desired user name, and run the following command on a terminal:
 
@@ -77,16 +80,19 @@ The output with the user ID, is similar to:
 User created: USR-aaaaaaaa-bbbb-cccc-dddd-0123456789ab
 ```
 
-Take a note of the `id` attribute as this is the unique identifier for the user that has been created. It will be  referred to as `MY_USER_ID` in the next step.
+The user ID is used to perform tasks by the SDK, such as login, starting a call and more.
 
 ## Generate a User JWT
 
-Generate a JWT for the user. Remember to replace `MY_APP_ID` and `MY_USER_ID` values in the command:
+Generate a JWT for the user. Remember to replace `MY_APP_ID` and `MY_USER_NAME` values in the command:
 
 ```bash
-nexmo jwt:generate ./private.key sub=MY_USER_ID exp=$(($(date +%s)+86400)) acl='/**' application_id=MY_APP_ID
+nexmo jwt:generate ./private.key sub=MY_USER_NAME exp=$(($(date +%s)+86400)) acl='/**' application_id=MY_APP_ID
 ```
 
 > **NOTE**: The above command sets the expiry of the JWT to one day from now, which is the maximum amount of time. You may change the expiration to a shortened amount of time, or re-grenerate a JWT for the user after the current JWT has expired.
+
+
+> **NOTE**: On production apps, it is expected that your backend will expose an endpoint that generates JWT per your client request.
 
 You can read more about the JWT and ACL [in this topic](/client-sdk/concepts/jwt-acl).

--- a/_tutorials/client-sdk-generate-test-credentials.md
+++ b/_tutorials/client-sdk-generate-test-credentials.md
@@ -16,7 +16,7 @@ In order to use the Nexmo Client SDK, there are three things you need to set up 
 
 * [JSON Web Tokens, JWTs](https://jwt.io/) - Nexmo Client SDK uses JWTs for authentication. In order for a user to log in and use the SDK functionality, you need to provide a JWT per user. JWTs contain all the information the Nexmo platform needs to authenticate requests, as well as information such as the associated Applications, Users and permissions.
 
-All of these may be [created by your backend](/documentation/conversation/overview). 
+All of these may be [created by your backend](/conversation/overview). 
 If you wish to get started and experience using the SDK without any implementation of your backend, this tutorial will show you how to do so, using the [Nexmo CLI](https://github.com/Nexmo/nexmo-cli).
 
 ## Prerequisites


### PR DESCRIPTION
## Description

Small fixes on Stitch set up pages

* Removed the creation of a new application part from `jwt-acl.md`, since it's not the focus of this doc, as well as was it had differences from other docs that shows it, which created confusion.

* Fix: generate a jwt should be with username, not user id.

* Some improvements in the explanation on set up pages. 