### PR TITLE
Add a slugified version of the header title to the ID attribute of the HTML tag

### DIFF
--- a/app/views/static/default_landing/partials/_header.html.erb
+++ b/app/views/static/default_landing/partials/_header.html.erb
@@ -3,7 +3,7 @@
     raise "Missing icon 'name' key in header landing page block" unless local_assigns['icon']['name']
     raise "Missing 'title' key in header landing page block" unless local_assigns['title']
 %>
-    <h1 class="Vlt-title--icon <%= "Vlt-title--#{local_assigns['title']['align']}" if local_assigns['title']['align'] %>">
+    <h1 class="Vlt-title--icon <%= "Vlt-title--#{local_assigns['title']['align']}" if local_assigns['title']['align'] %>" id="<%= local_assigns['title']['text'].parameterize %>">
     <svg class="Vlt-<%= local_assigns['icon']['color'] %>"><use xlink:href="/symbol/volta-icons.svg#Vlt-<%= local_assigns['icon']['name'] %>"></use></svg>
     <%= local_assigns['title']['text'] %>
 </h1>

--- a/app/views/static/default_landing/partials/_section_header.html.erb
+++ b/app/views/static/default_landing/partials/_section_header.html.erb
@@ -4,7 +4,7 @@
     raise "Missing icon 'name' key in section_header landing page block" unless local_assigns['icon']['name']
 %>
 
-<h2 class="Vlt-title--icon">
+<h2 class="Vlt-title--icon" id="<%= local_assigns['title'].parameterize %>">
     <svg class="Vlt-<%= local_assigns['icon']['color'] %>"><use xlink:href="/symbol/volta-icons.svg#Vlt-<%= local_assigns['icon']['name'] %>"></use></svg>
     <%= local_assigns['title'] %>
 </h2>

--- a/app/views/static/default_landing/partials/_structured_text.html.erb
+++ b/app/views/static/default_landing/partials/_structured_text.html.erb
@@ -4,7 +4,7 @@
     raise "Missing icon 'name' key in structured_text landing page block" unless local_assigns['icon']['name']
     raise "Missing icon 'color' key in structured_text landing page block" unless local_assigns['icon']['color']
 %>
-<h2 class="Vlt-title--icon">
+<h2 class="Vlt-title--icon" id="<%= local_assigns['header'].parameterize %>">
     <svg class="Vlt-<%= local_assigns['icon']['color'] %>"><use xlink:href="/symbol/volta-icons.svg#Vlt-<%= local_assigns['icon']['name'] %>"></use></svg>
     <%= local_assigns['header'] %>
 </h2>


### PR DESCRIPTION
## Description

The new config-driven landing page rendering had not previously added an `id` attribute to header content, which broke links to page-specific content based on the title. In this pull request, we add the header title slugified to the `id` attribute of header information to restore the link functionality.
