### PR TITLE
Text Content Renderer for Config Driven Landing Pages

### DIFF
--- a/app/views/static/default_landing/partials/_text.html.erb
+++ b/app/views/static/default_landing/partials/_text.html.erb
@@ -1,0 +1,5 @@
+<% 
+    raise "Missing 'content' key in text landing page block" unless local_assigns['content']
+%>
+
+<%= local_assigns['content'].render_markdown %>

--- a/spec/views/static/default_landing/default_landing.html.erb_spec.rb
+++ b/spec/views/static/default_landing/default_landing.html.erb_spec.rb
@@ -32,7 +32,13 @@ RSpec.describe 'static/default_landing' do
           {
               'entries' => [
                 {
-                      'type' => 'contact_support',
+                    'type' => 'contact_support',
+                  },
+                  {
+                    'type' => 'text',
+                    'text' => {
+                      'content' => 'Sample Text Block'
+                    },
                   },
               ],
           },
@@ -148,6 +154,7 @@ RSpec.describe 'static/default_landing' do
     expect(actual).to include("<div class='Vlt-center'>")
     expect(actual).to include('Do you have a question?')
     expect(actual).to include('Sample Title')
+    expect(actual).to include('Sample Text Block')
     expect(actual).to include('Ruby')
     expect(actual).to include('<a class="Vlt-card Nxd-github-card Vlt-left" href="https://www.github.com/Nexmo/repo" data-github="Nexmo/repo">')
     expect(actual).to include('p-large')

--- a/spec/views/static/default_landing/default_landing.html.erb_spec.rb
+++ b/spec/views/static/default_landing/default_landing.html.erb_spec.rb
@@ -34,12 +34,12 @@ RSpec.describe 'static/default_landing' do
                 {
                     'type' => 'contact_support',
                   },
-                  {
-                    'type' => 'text',
-                    'text' => {
-                      'content' => 'Sample Text Block'
-                    },
+                {
+                  'type' => 'text',
+                  'text' => {
+                    'content' => 'Sample Text Block',
                   },
+                },
               ],
           },
           {

--- a/spec/views/static/default_landing/partials/_text.html.erb_spec.rb
+++ b/spec/views/static/default_landing/partials/_text.html.erb_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe 'rendering _text landing page partial' do
     expect { render partial: '/static/default_landing/partials/text.html.erb' }.to raise_error("Missing 'content' key in text landing page block")
   end
 
-  it 'renders markdown correctly' do 
+  it 'renders markdown correctly' do
     render partial: '/static/default_landing/partials/text.html.erb', locals: { 'content' => '__Sample Text__' }
 
     expect(rendered).to include('<p><strong>Sample Text</strong></p>')

--- a/spec/views/static/default_landing/partials/_text.html.erb_spec.rb
+++ b/spec/views/static/default_landing/partials/_text.html.erb_spec.rb
@@ -1,0 +1,13 @@
+require 'rails_helper'
+
+RSpec.describe 'rendering _text landing page partial' do
+  it 'renders correctly with proper data' do
+    render partial: '/static/default_landing/partials/text.html.erb', locals: { 'content' => 'Sample Text' }
+
+    expect(rendered).to include('Sample Text')
+  end
+
+  it 'raises an error if content is not provided' do
+    expect { render partial: '/static/default_landing/partials/text.html.erb' }.to raise_error("Missing 'content' key in text landing page block")
+  end
+end

--- a/spec/views/static/default_landing/partials/_text.html.erb_spec.rb
+++ b/spec/views/static/default_landing/partials/_text.html.erb_spec.rb
@@ -10,4 +10,10 @@ RSpec.describe 'rendering _text landing page partial' do
   it 'raises an error if content is not provided' do
     expect { render partial: '/static/default_landing/partials/text.html.erb' }.to raise_error("Missing 'content' key in text landing page block")
   end
+
+  it 'renders markdown correctly' do 
+    render partial: '/static/default_landing/partials/text.html.erb', locals: { 'content' => '__Sample Text__' }
+
+    expect(rendered).to include('<p><strong>Sample Text</strong></p>')
+  end
 end


### PR DESCRIPTION
## Description

Added last content renderer type to config-driven landing pages: `text`, along with accompanying tests.

