### PR TITLE
Created a dynamic route for config-driven landing pages

### DIFF
--- a/app/constraints/landing_page_constraint.rb
+++ b/app/constraints/landing_page_constraint.rb
@@ -1,7 +1,15 @@
 class LandingPageConstraint
-  def self.filename?(params)
-    if File.exists?("/config/landing_pages/#{params}")
-      params 
+  def self.matches?
+    # This is the base path to our config files, that we'll be stripping off
+    root = "#{Rails.root}/config/landing_pages/"
+
+    # Format the landing page list as required, removing the base path and config folder
+    available_pages = Dir["#{root}/**/*.yml"].map do |filename|
+      name = File.join(File.dirname(filename), File.basename(filename, '.yml')).gsub(root, '')
+      name[0] = '' if name[0] == '/' # Remove leading slash for subdirectories
+      name
     end
+
+    { landing_page: Regexp.new(available_pages.join('|')) }
   end
 end

--- a/app/constraints/landing_page_constraint.rb
+++ b/app/constraints/landing_page_constraint.rb
@@ -1,0 +1,7 @@
+class LandingPageConstraint
+  def self.filename?(params)
+    if File.exists?("/config/landing_pages/#{params}")
+      params 
+    end
+  end
+end

--- a/app/controllers/static_controller.rb
+++ b/app/controllers/static_controller.rb
@@ -1,7 +1,6 @@
 class StaticController < ApplicationController
   def default_landing
-    # Get URL and split the / to retrieve the landing page name
-    yaml_name = request.fullpath.split('/')[1]
+    yaml_name = request[:landing_page]
 
     @landing_config = YAML.load_file("#{Rails.root}/config/landing_pages/#{yaml_name}.yml")
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,8 +17,7 @@ Rails.application.routes.draw do
 
   get '/robots.txt', to: 'static#robots'
 
-  get '/*landing_page/', to: 'static#default_landing', constraints: LandingPageConstraint.filename?(:landing_page)
-
+  get '/*landing_page', to: 'static#default_landing', constraints: LandingPageConstraint.matches?
 
   get 'markdown/show'
 
@@ -49,10 +48,6 @@ Rails.application.routes.draw do
   }
 
   get '/documentation', to: 'static#documentation'
-
-  # get '/hansel', to: 'static#default_landing'
-
-  # get '/spotlight', to: 'static#default_landing'
 
   get '/migrate/tropo', to: 'static#migrate'
   get '/migrate/tropo/(/*guide)', to: 'static#migrate_details'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,6 +17,9 @@ Rails.application.routes.draw do
 
   get '/robots.txt', to: 'static#robots'
 
+  get '/*landing_page/', to: 'static#default_landing', constraints: LandingPageConstraint.filename?(:landing_page)
+
+
   get 'markdown/show'
 
   get '/signout', to: 'sessions#destroy'
@@ -47,9 +50,9 @@ Rails.application.routes.draw do
 
   get '/documentation', to: 'static#documentation'
 
-  get '/hansel', to: 'static#default_landing'
+  # get '/hansel', to: 'static#default_landing'
 
-  get '/spotlight', to: 'static#default_landing'
+  # get '/spotlight', to: 'static#default_landing'
 
   get '/migrate/tropo', to: 'static#migrate'
   get '/migrate/tropo/(/*guide)', to: 'static#migrate_details'

--- a/spec/controllers/static_controller_spec.rb
+++ b/spec/controllers/static_controller_spec.rb
@@ -1,9 +1,9 @@
 require 'rails_helper'
 
-RSpec.describe StaticController, type: :controller do
+RSpec.describe StaticController, type: :request do
   before do
     Rails.application.routes.draw do
-      get '/default_landing' => 'static#default_landing'
+      get '/:landing_page' => 'static#default_landing'
     end
   end
   after do
@@ -11,8 +11,6 @@ RSpec.describe StaticController, type: :controller do
   end
 
   describe 'GET default_landing' do
-    render_views
-
     it 'renders single column with 100% width' do
       landing_config = {
           'rows' => [
@@ -307,7 +305,7 @@ def assert_rows_and_columns(config, matches)
   expect(YAML).to receive(:load_file).with("#{Rails.root}/config/landing_pages/default_landing.yml") .and_return(config)
   allow(YAML).to receive(:load_file)
 
-  get :default_landing
+  get '/default_landing'
 
   assert_select '.Nxd-landing-page' do |elements|
     assert_select elements[0], '.Nxd-landing-row', matches.count do |rows|


### PR DESCRIPTION
## Description

In this PR, we introduce dynamic routing for config-driven landing pages. Namely, we introduce a `LandingPageConstraint` model with a class method `filename?` that checks if the path matches a file in the `/config/landing_pages`. If it does, it returns that path back to the route and accesses the `static#default_landing` controller method.