### PR TITLE
JWT Generator

### DIFF
--- a/app/controllers/static_controller.rb
+++ b/app/controllers/static_controller.rb
@@ -18,6 +18,10 @@ class StaticController < ApplicationController
     render layout: 'landing'
   end
 
+  def jwt
+    render layout: 'landing'
+  end
+
   def landing
     render layout: 'landing'
   end

--- a/app/javascript/packs/JWTGenerator.jsx
+++ b/app/javascript/packs/JWTGenerator.jsx
@@ -1,0 +1,262 @@
+import React, { Component } from 'react';
+import { KJUR, KEYUTIL} from 'jsrsasign';
+
+class JWTGenerator extends Component {
+
+    constructor(args) {
+        super(args)
+        var tNow = KJUR.jws.IntDate.get('now');
+        var tEnd = tNow + (3600*6)
+        this.state ={
+            sub: '',
+            acl: '',
+            iat: tNow,
+            exp: tEnd,
+            jti: this.generateJti(12),
+            nbf: tNow,
+            application_id: "",
+            invalidPrivateKey: false
+        };
+    }
+
+    generateJti(jtiLength) {
+        var text = "";
+        var possible = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+
+        for (var i = 0; i < jtiLength; i++) {
+            text += possible.charAt(Math.floor(Math.random() * possible.length));
+        }
+
+        return text;
+    }
+
+    generateJwt(privateKeyString) {
+        this.setState({
+            invalidPrivateKey: false
+        });
+
+        if (!privateKeyString || !this.state.application_id) {
+            this.jwtOutput.value = '';
+            return;
+        }
+
+        // Header
+        var oHeader = {typ: 'JWT', alg: 'RS256'};
+
+        // Payload
+        var oPayload = {};
+        oPayload.iat = this.state.iat;
+        oPayload.exp = this.state.exp;
+        oPayload.jti = this.state.jti;
+        oPayload.nbf = this.state.nbf;
+        oPayload.application_id = this.state.application_id;
+        if (this.state.sub) {
+            oPayload.sub = this.state.sub;
+        }
+        if (this.state.acl) {
+          oPayload.acl = JSON.parse(this.state.acl);
+        }
+
+        var sHeader = JSON.stringify(oHeader);
+        var sPayload = JSON.stringify(oPayload);
+        try {
+            var prvKey = KEYUTIL.getKey(privateKeyString);
+        } catch (e) {
+            this.setState({
+                invalidPrivateKey: true
+            });
+            return;
+        }
+        var sJWT = KJUR.jws.JWS.sign("RS256", sHeader, sPayload, prvKey);
+        this.jwtOutput.value = sJWT;
+    }
+
+    handlePrivateKeyChange() {
+        this.generateJwt(this.privateKeyInput.value)
+    }
+
+    handleApplicationIdChange() {
+        this.setState({
+            "application_id": this.applicationIdInput.value
+        }, () => {
+            this.generateJwt(this.privateKeyInput.value)
+        });
+    }
+
+    handleValidForChange() {
+        // Calculate exp as iat + valid for
+        let validFor = this.validForInput.value;
+        if (!validFor) {
+            validFor = 6;
+        }
+        let exp = this.state.iat + (validFor * this.validForDropdown.value);
+        this.setState({
+            "exp": exp,
+        }, () => {
+            this.generateJwt(this.privateKeyInput.value)
+        });
+    }
+
+    handleSubChange() {
+        this.setState({
+            "sub": this.subInput.value
+        }, () => {
+            this.generateJwt(this.privateKeyInput.value)
+        });
+    }
+
+    handleAclChange() {
+        this.setState({
+            "acl": this.aclInput.value
+        }, () => {
+            this.generateJwt(this.privateKeyInput.value)
+        });
+    }
+
+    renderCallout() {
+
+        let message = `<h4>Use your <code>private key</code> and <code>application_id</code> to create a JWT for your Nexmo Application</h4>The JWT is generated on the client-side so your private key <strong>never leaves your browser</strong>.`;
+        let calloutType = 'tip';
+
+        // If they've provided an invalid private key, tell them that
+        if (this.state.invalidPrivateKey) {
+            return this.generateCallout('critical', 'Invalid private key provided');
+        }
+
+        if (!this.privateKeyInput) {
+            return this.generateCallout('tip', message);
+        }
+
+        if (this.state.acl) {
+            try {
+                JSON.parse(this.state.acl);
+            } catch (e) {
+                return this.generateCallout('critical', 'Invalid ACL provided. Must be JSON');
+            }
+        }
+
+        if (this.privateKeyInput.value && this.applicationIdInput.value) {
+            return '';
+        }
+
+        if (!this.privateKeyInput.value && !this.applicationIdInput.value) {
+            return this.generateCallout('tip', message);
+        }
+
+        if (!this.privateKeyInput.value) {
+            return this.generateCallout('warning', 'Next, provide a Private Key');
+        }
+
+        if (!this.applicationIdInput.value) {
+            return this.generateCallout('warning', 'Next, provide an Application ID');
+        }
+
+        return callout;
+
+    }
+
+    generateCallout(type, text) {
+       return ( <div className={'Vlt-callout Vlt-callout--' + type}>
+                <i></i>
+                <div className="Vlt-callout__content" dangerouslySetInnerHTML={{__html: text}}>
+                </div>
+            </div>
+        );
+    }
+
+    render() {
+        return (
+            <div>
+                <h1>JWT Generator</h1>
+                {this.renderCallout()}
+                <div className="Vlt-grid">
+
+                    <div className="Vlt-col">
+                        <h2>Parameters</h2>
+                        <div className="Vlt-form__element">
+                            <label className="Vlt-label">Private Key</label>
+                            <div className="Vlt-textarea">
+                                <textarea rows="8" cols="50" ref={(e) => this.privateKeyInput = e} onChange={this.handlePrivateKeyChange.bind(this)}></textarea>
+                            </div>
+                        </div>
+                        <div className="Vlt-form__element">
+                            <label className="Vlt-label">Application ID</label>
+                            <div className="Vlt-input">
+                                <input ref={(e) => this.applicationIdInput = e} onChange={this.handleApplicationIdChange.bind(this)} />
+                            </div>
+                        </div>
+                        <div className="Vlt-form__element">
+                            <label htmlFor="example-input-icon-button" className="Vlt-label">Valid For</label>
+                            <div className="Vlt-composite">
+                                <div className="Vlt-input">
+                                    <input type="number" ref={(e) => this.validForInput = e} onChange={this.handleValidForChange.bind(this)} placeholder="6" />
+                                </div>
+
+                                <div className="Vlt-composite__append">
+                                    <div className="Vlt-native-dropdown">
+                                        <select ref={(e) => this.validForDropdown = e} onChange={this.handleValidForChange.bind(this)} defaultValue="3600">
+                                            <option value="1">Seconds</option>
+                                            <option value="60">Minutes</option>
+                                            <option value="3600">Hours</option>
+                                            <option value="86400">Days</option>
+                                        </select>
+                                    </div>
+                                </div>
+
+                            </div>
+                        </div>
+                         <div className="Vlt-form__element">
+                            <label className="Vlt-label">Sub (optional)</label>
+                            <div className="Vlt-input">
+                                <input ref={(e) => this.subInput = e} onChange={this.handleSubChange.bind(this)} />
+                            </div>
+                        </div>
+                        <div className="Vlt-form__element">
+                            <label className="Vlt-label">ACL (optional)</label>
+                            <div className="Vlt-textarea">
+                                <textarea rows="4" cols="50" ref={(e) => this.aclInput = e} onChange={this.handleAclChange.bind(this)}></textarea>
+                            </div>
+                        </div>
+                    </div>
+                   <div className="Vlt-col">
+                        <h2>Encoded</h2>
+                        <div className="Vlt-form__element">
+                            <label className="Vlt-label">Your JWT</label>
+                            <div className="Vlt-textarea">
+                                <textarea rows="29" cols="50" ref={(e) => this.jwtOutput = e}></textarea>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <div className="Vlt-grid">
+                    <div className="Vlt-col">
+                        <h2>Decoded</h2>
+                        <div className="Vlt-table Vlt-table--data">
+                            <table>
+                                <thead>
+                                <tr>
+                                    <th>Name</th>
+                                    <th>Value</th>
+                                    <th>Meaning</th>
+                                </tr>
+                                </thead>
+                                <tbody>
+                                <tr><td><code>application_id</code></td><td>{this.state.application_id}</td><td>The application ID this JWT uses for authentication</td></tr>
+                                <tr><td><code>iat</code></td><td>{this.state.iat}</td><td>The time at which the token was issued</td></tr>
+                                <tr><td><code>nbf</code></td><td>{this.state.nbf}</td><td>The time at which the token should become valid</td></tr>
+                                <tr><td><code>exp</code></td><td>{this.state.exp}</td><td>The time at which the token should expire</td></tr>
+                                <tr><td><code>sub</code></td><td>{this.state.sub}</td><td>The subject identified by the JWT (only used for the Client SDKs)</td></tr>
+                                <tr><td><code>acl</code></td><td>{this.state.acl}</td><td>A list of permissions that this token will have</td></tr>
+                                <tr><td><code>jti</code></td><td>{this.state.jti}</td><td>A unique identifier for the JWT</td></tr>
+                                </tbody>
+                            </table>
+                        </div>
+                    </div>
+
+                </div>
+            </div>
+        );
+    }
+}
+
+export default JWTGenerator;

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -25,6 +25,7 @@ import Feedback from './Feedback'
 import Concatenation from './Concatenation'
 import APIStatus from './APIStatus'
 import BuildingBlockEvents from './BuildingBlockEvents'
+import JWTGenerator from './JWTGenerator'
 
 import {
   preventSamePage as turbolinksPreventSamePage,
@@ -47,6 +48,10 @@ let refresh = () => {
   Scroll()
   Navigation()
   BuildingBlockEvents()
+
+  if (document.getElementById('jwtGenerator')) {
+    ReactDOM.render(<JWTGenerator/>, document.getElementById('jwtGenerator'))
+  }
 
   if (document.getElementById('SearchComponent')) {
     ReactDOM.render(<Search/>, document.getElementById('SearchComponent'))

--- a/app/views/static/jwt.html.erb
+++ b/app/views/static/jwt.html.erb
@@ -1,0 +1,4 @@
+<div class="container">
+  <div id="jwtGenerator" class="Vlt-card">
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,6 +16,7 @@ Rails.application.routes.draw do
   end
 
   get '/robots.txt', to: 'static#robots'
+  get '/jwt', to: 'static#jwt'
 
   get '/*landing_page', to: 'static#default_landing', constraints: LandingPageConstraint.matches?
 

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "gsap": "^1.20.2",
     "js-sequence-diagrams": "https://github.com/adambutler/js-sequence-diagrams.git#modularity",
     "js-yaml": "^3.9.0",
+    "jsrsasign": "^8.0.12",
     "lodash": "^4.17.4",
     "node-sass": "^4.5.3",
     "path-complete-extname": "^0.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3538,6 +3538,11 @@ jsprim@^1.2.2:
     json-schema "0.2.3"
     verror "1.10.0"
 
+jsrsasign@^8.0.12:
+  version "8.0.12"
+  resolved "https://registry.yarnpkg.com/jsrsasign/-/jsrsasign-8.0.12.tgz#22abb9656d34a30b9530436720835e89c2e5c316"
+  integrity sha1-Iqu5ZW00owuVMENnIINeicLlwxY=
+
 kind-of@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-2.0.1.tgz#018ec7a4ce7e3a86cb9141be519d24c8faa981b5"


### PR DESCRIPTION
## Description

This PR adds a JWT generator at `/jwt` that takes a private key, application ID and optional `sub` and creates a JWT that's valid for 6 hours (customisable in the interface). It's all done client side, so the private key never leaves your browser.

It definitely needs refactoring, but what we have here is useful so I'm in favour of shipping and fixing later

## Deploy Notes

N/A