### PR TITLE
Fixed GitHub repo URL path error in landing page content block

### DIFF
--- a/app/views/static/default_landing/partials/_github_repo.html.erb
+++ b/app/views/static/default_landing/partials/_github_repo.html.erb
@@ -6,7 +6,7 @@
 
 <div class="Vlt-grid Vlt-grid--center">
   <div class="Vlt-col Vlt-col--M-1of3 Vlt-col--1of3">
-    <a class="Vlt-card Nxd-github-card Vlt-left" href="<%= local_assigns['repo_url'].gsub(%r{https://(www)?github.com/}, '') %>" data-github="Nexmo/<%= local_assigns['repo_url'].split('/').last %>">
+    <a class="Vlt-card Nxd-github-card Vlt-left" href="<%= local_assigns['repo_url'] %>" data-github="Nexmo/<%= local_assigns['repo_url'].split('/').last %>">
       <h3 class="Vlt-blue-dark"><%= local_assigns['repo_url'].split('/').last %></h3>
       <p><%= local_assigns['github_repo_title'] %></p>
       <img src="//badge.fury.io/nu/nexmo.svg" class="Nxd-github-card__badge" height="18">

--- a/spec/views/static/default_landing/partials/_github_repo.html.erb_spec.rb
+++ b/spec/views/static/default_landing/partials/_github_repo.html.erb_spec.rb
@@ -40,4 +40,14 @@ RSpec.describe 'rendering _github_repo landing page partial' do
       }
     end.to raise_error("Missing 'language' key in github_repo landing page block")
   end
+
+  it 'renders the repo URL correctly' do
+    render partial: '/static/default_landing/partials/github_repo.html.erb', locals: {
+        'repo_url' => 'https://example.com/org/repo-name',
+        'github_repo_title' => 'This is a sample title',
+        'language' => 'Ruby',
+    }
+
+    expect(rendered).to include('https://example.com/org/repo-name')
+  end
 end


### PR DESCRIPTION
The `github_repo` content block was applying a `gsub` filter to the URL, which was removing the `https://www.github.com/` part of the URL and making the link a relative path. Since any GitHub repo url should point to `www.github.com/...` there is no reason to apply conditions to the URL in the renderer and I've removed it, fixing the issue.