### PR TITLE
Redesigned the Config File for Config-Driven Landing Pages

### DIFF
--- a/app/controllers/static_controller.rb
+++ b/app/controllers/static_controller.rb
@@ -4,14 +4,14 @@ class StaticController < ApplicationController
 
     @landing_config = YAML.load_file("#{Rails.root}/config/landing_pages/#{yaml_name}.yml")
 
-    @landing_config['rows'].each do |row|
-      some_columns_have_widths = row['columns'].select { |c| c['width'] }.count.positive?
+    @landing_config['page'].each do |row|
+      some_columns_have_widths = row['row'].select { |c| c['width'] }.count.positive?
       if some_columns_have_widths
-        row['columns'] = row['columns'].map do |c|
+        row['row'] = row['row'].map do |c|
           c['width'] ||= 1
           c
         end
-        row['column_count'] = row['columns'].map { |c| c['width'] }.sum
+        row['column_count'] = row['row'].map { |c| c['width'] }.sum
       end
     end
 

--- a/app/views/static/default_landing.html.erb
+++ b/app/views/static/default_landing.html.erb
@@ -1,13 +1,13 @@
 <div class="<%= @landing_config['container_classes'] ? @landing_config['container_classes'].join(' ') : '' %> container Nxd-landing-page">
-    <% @landing_config["rows"].each do |row| %>
+    <% @landing_config["page"].each do |row| %>
     <div class="Vlt-grid Nxd-landing-row">
-      <% row["columns"].each do |info| %>
+      <% row["row"].each do |info| %>
         <% if row['column_count']%>
           <div class="Vlt-col Vlt-col--<%= info["width"] %>of<%= row['column_count'] %> Nxd-landing-col">
         <% else %>
           <div class="Vlt-col Nxd-landing-col">
         <% end %>
-        <% info["entries"].each do |data| %>
+        <% info["column"].each do |data| %>
         <%
           unless lookup_context.exists?(data['type'], "static/default_landing/partials", true)
           raise "Could not find the #{data['type']} partial file."

--- a/config/landing_pages/default.yml
+++ b/config/landing_pages/default.yml
@@ -19,9 +19,9 @@
 title: "Welcome to Nexmo, Residents of Jupiter"
 meta_title: "A longer title goes here."
 
-rows:
-  - columns:
-    - entries: 
+page:
+  - row:
+    - column: 
       - type: header
         header:
           title: "Thanks for joining us!"
@@ -32,9 +32,9 @@ rows:
           image:
           url:
           alt_text:  
-  - columns:
+  - row:
     - width: 2
-      entries:
+      column:
       - type: building_block
         building_block:
           name: messaging/sms
@@ -42,69 +42,69 @@ rows:
           pre_text:
           post_text:
     - width: 2
-      entries:
+      column:
       - type: building_block
         building_block:
           name: messaging/send-an-sms
           language: python
           pre_text:
           post_text:
-  - columns:
+  - row:
     - width: 1 
-      entries:
+      column:
       - type: call_to_action
         call_to_action:
           header: "Sign Up"
           icon: "sign-up"
           subheader: "Try it for free"
     - width: 1
-      entries: 
+      column: 
       - type: join_slack
     - width: 1
-      entries: 
+      column: 
       - type: github_org
         github_org:
           name: nexmo
     - width: 1
-      entries:
+      column:
       - type: github_repo
         github_repo:
           org: nexmo
           name: nexmo-php
-  - columns: 
+  - row: 
     - width: 1
-      entries:
+      column:
       - type: tutorial
         tutorial:
           name: call-tracking
     - width: 1
-      entries:
+      column:
       - type: tutorial
         tutorial:
           name: receive-sms-with-ruby
     - width: 2 
-      entries:
+      column:
       - type: sdk
         sdk:
           name: ruby
-  - columns: 
+  - row: 
     - width: 1
-      entries: 
+      column: 
       - type: text
         text:
           content: Your awesome content
     - width: 1
-      entries:
+      column:
       - type: text
         text:
           content: More awesome content
     - width: 1
-      entries:
+      column:
       - type: html
         html:
           content: <a href="/find/me/here">Amazing things</a>
     - width: 1
-      entries:
+      column:
       - type: structured_text
         structured_text:
           header: "This is the header text"

--- a/config/landing_pages/e/smallbizhack.yml
+++ b/config/landing_pages/e/smallbizhack.yml
@@ -1,8 +1,8 @@
 title: "Use our APIs & SDK or or make the API calls yourself to integrate with our calling, messaging and mobile platforms"
 
-rows:
-  - columns:
-    - entries:
+page:
+  - row:
+    - column:
       - type: header
         header:
           title:
@@ -14,26 +14,26 @@ rows:
           icon:
             name: "icon-star"
             color: "yellow"
-  - columns:
-    - entries:
+  - row:
+    - column:
       - type: action_button
         action_button:
           text: "Sign Up For Free"
           url: "https://dashboard.nexmo.com/sign-up?utm_source=nexmo-developer&utm_medium=smallbizhack&utm_campaign=landing"
           center_button: true
 
-  - columns:
-    - entries:
+  - row:
+    - column:
         - type: line_divider
 
 
-  - columns:
-    - entries:
+  - row:
+    - column:
       - type: text
         text:
           content: "# Hack with Nexmo"
-  - columns:
-    - entries:
+  - row:
+    - column:
       - type: structured_text
         structured_text:
           header: "The Challenge"
@@ -45,7 +45,7 @@ rows:
             type: large
 
 
-    - entries:
+    - column:
       - type: structured_text
         structured_text:
           header: "Prizes"
@@ -58,12 +58,12 @@ rows:
           - content: Each team will be judged based on their **idea**, **presentation**, **technical execution** and **use of Nexmo**.
             type: large
 
-  - columns:
-    - entries:
+  - row:
+    - column:
         - type: line_divider
 
-  - columns:
-    - entries:
+  - row:
+    - column:
       - type: action_button
         action_button:
           text: "View Nexmo docs"
@@ -73,13 +73,13 @@ rows:
           large: true
 
 
-  - columns:
-    - entries:
+  - row:
+    - column:
         - type: line_divider
 
 
-  - columns:
-    - entries:
+  - row:
+    - column:
       - type: call_to_action
         call_to_action:
           title: "Voice"
@@ -89,7 +89,7 @@ rows:
             color: "green"
           url: "/voice"
 
-    - entries:
+    - column:
       - type: call_to_action
         call_to_action:
           title: "Messages"
@@ -99,7 +99,7 @@ rows:
             color: "purple"
           url: "/messages/overview"
 
-    - entries:
+    - column:
       - type: call_to_action
         call_to_action:
           title: "Conversation"
@@ -109,8 +109,8 @@ rows:
             color: "indigo"
           url: "/conversation"
 
-  - columns:
-    - entries:
+  - row:
+    - column:
       - type: text
         text:
           content: |
@@ -122,12 +122,12 @@ rows:
             	</div>
             </div>
 
-  - columns:
-    - entries:
+  - row:
+    - column:
         - type: line_divider
 
-  - columns:
-    - entries:
+  - row:
+    - column:
         - type: header
           header:
             title:
@@ -155,7 +155,7 @@ rows:
               npm install nexmo-client --save
               ```
 
-    - entries:
+    - column:
         - type: header
           header:
             title:
@@ -178,12 +178,12 @@ rows:
               <a class="Vlt-btn Vlt-btn--secondary" href="/voice/voice-api/building-blocks/make-an-outbound-call">View the complete code &raquo;</a>
               </div>
 
-  - columns:
-    - entries:
+  - row:
+    - column:
         - type: line_divider
 
-  - columns:
-    - entries:
+  - row:
+    - column:
       - type: section_header
         section_header:
           title: "Handy links and further reading"
@@ -192,8 +192,8 @@ rows:
             color: "blue-dark"
 
 
-  - columns:
-    - entries:
+  - row:
+    - column:
       - type: text
         text:
           content: >
@@ -204,8 +204,8 @@ rows:
                 Come and say hello at the Nexmo booth! We'd love to hear what you're having issues with to help you out (and improve the docs at the same time!)
             	</div>
             </div>
-  - columns:
-    - entries:
+  - row:
+    - column:
       - type: unordered_list
         unordered_list:
             bullet_shape: simple
@@ -215,7 +215,7 @@ rows:
               - item: "[How to Make and Receive Voice calls with the Nexmo Client SDK on Android](/tutorials/client-sdk-android-make-receive-calls)"
               - item: "[How to Add the Nexmo Client SDK to your JavaScript App](/tutorials/client-sdk-js-add-sdk-to-your-app)"
               - item: "[How to Make and Receive Voice Calls with the Nexmo Client SDK on iOS using Objective-C](/tutorials/client-sdk-ios-make-receive-calls-objective-c)"
-    - entries:
+    - column:
       - type: unordered_list
         unordered_list:
             bullet_shape: simple
@@ -225,12 +225,12 @@ rows:
               - item: "[Record a Call](/voice/voice-api/building-blocks/record-a-call/node)"
               - item: "[Connect Callers into a Conference](/voice/voice-api/building-blocks/connect-callers-into-a-conference/node)"
               - item: "[Transfer a Call](/voice/voice-api/building-blocks/transfer-a-call/node)"
-  - columns:
-    - entries:
+  - row:
+    - column:
         - type: line_divider
-  - columns:
-    - entries:
+  - row:
+    - column:
       - type: join_slack
-  - columns:
-    - entries:
+  - row:
+    - column:
         - type: line_divider

--- a/config/landing_pages/hansel.yml
+++ b/config/landing_pages/hansel.yml
@@ -3,9 +3,9 @@
 title: "Nexmo APIs provide all you need to get up and running with your .NET applications"
 meta_title: ".NET Tutorials, SDK, code samples and more for a full suite of cloud communications APIs"
 
-rows:
-  - columns:
-    - entries: 
+page:
+  - row:
+    - column: 
       - type: header
         header:
           title: 
@@ -25,12 +25,12 @@ rows:
           type: "secondary"
           large: true
           center_button: true
-  - columns:
-    - entries:
+  - row:
+    - column:
         - type: line_divider
-  - columns:
+  - row:
     - width: 2
-      entries:
+      column:
       - type: call_to_action
         call_to_action:
           title: "SDKs & Tools"
@@ -40,7 +40,7 @@ rows:
             color: "blue-dark"
           url: "/tools"
     - width: 2
-      entries:
+      column:
       - type: call_to_action
         call_to_action:
           title: "Community"
@@ -49,17 +49,17 @@ rows:
             name: "icon-group"
             color: "blue-dark"
           url: "/community"
-  - columns:
-    - entries:
+  - row:
+    - column:
         - type: line_divider
-  - columns:
-    - entries:
+  - row:
+    - column:
       - type: join_slack
-  - columns:
-    - entries:
+  - row:
+    - column:
         - type: line_divider
-  - columns:
-    - entries:
+  - row:
+    - column:
       - type: call_to_action
         call_to_action:
           title: "Nexmo & .NET in action"
@@ -71,33 +71,33 @@ rows:
             name: "Brand-icon-dotnet"
             color: "blue-dark"
           url: "https://www.nexmo.com/blog/category/developer?ref=hansel-dr"
-  - columns:
+  - row:
     - width: 2
-      entries:
+      column:
       - type: tutorial
         tutorial:
           name: two-factor-authentication-dotnet-verify-api
     - width: 2
-      entries:
+      column:
       - type: tutorial
         tutorial:
           name: number-insight-api-aspnet
-  - columns: 
-    - entries:
+  - row: 
+    - column:
       - type: github_repo
         github_repo:
           repo_url: https://github.com/Nexmo/nexmo-dotnet
           github_repo_title: "Nexmo REST API client for .NET"
           language: "C#"
-  - columns:
-    - entries:
+  - row:
+    - column:
       - type: line_divider
-  - columns:
-    - entries:
+  - row:
+    - column:
       - type: products
-  - columns:
-    - entries: 
+  - row:
+    - column: 
       - type: line_divider
-  - columns:
-    - entries:
+  - row:
+    - column:
       - type: contact_support

--- a/config/landing_pages/phpuk19.yml
+++ b/config/landing_pages/phpuk19.yml
@@ -1,8 +1,8 @@
 title: "Nexmo loves PHP! Use our SDKs or make the API calls yourself to integrate with our calling, messaging and mobile platforms"
 
-rows:
-  - columns:
-    - entries:
+page:
+  - row:
+    - column:
       - type: header
         header:
           title:
@@ -14,26 +14,26 @@ rows:
           icon:
             name: "icon-star"
             color: "yellow"
-  - columns:
-    - entries:
+  - row:
+    - column:
       - type: action_button
         action_button:
           text: "Sign Up For Free"
           url: "https://dashboard.nexmo.com/sign-up?utm_source=nexmo-developer&utm_medium=phpuk19&utm_campaign=landing"
           center_button: true
 
-  - columns:
-    - entries:
+  - row:
+    - column:
         - type: line_divider
 
 
-  - columns:
-    - entries:
+  - row:
+    - column:
       - type: text
         text:
           content: "# The Nexmo Hackathon"
-  - columns:
-    - entries:
+  - row:
+    - column:
       - type: structured_text
         structured_text:
           header: "The Challenge"
@@ -46,7 +46,7 @@ rows:
           - content: Otherwise, you’re welcome to hang out in the Nexmo Hackathon Lounge, build anything you want using our APIs and still present your project.
             type: large
 
-    - entries:
+    - column:
       - type: structured_text
         structured_text:
           header: "Prizes & Judging"
@@ -59,7 +59,7 @@ rows:
           - content: Each team will be judged based on their **idea**, **presentation**, **technical execution** and **use of Nexmo**.
             type: large
 
-    - entries:
+    - column:
       - type: structured_text
         structured_text:
           header: "The Rules"
@@ -72,7 +72,7 @@ rows:
           - content: You’ll need to <a href="https://docs.google.com/forms/d/e/1FAIpQLSfZ6lfH15AX5HkANMf-Wot4u8IuSB5Leov6Sfr_O595NeNmeg/viewform">submit your project</a> the latest by 12:30pm on Friday and be ready to present in the Nexmo Hackathon Lounge.
             type: large
 
-    - entries:
+    - column:
       - type: structured_text
         structured_text:
           header: "The Timeline"
@@ -95,12 +95,12 @@ rows:
               * 12:40pm - Presentations start in the Hackathon Lounge<br />
               * 4:45pm - Winners announced and prizes awarded in the main track/Porter Tun room
 
-  - columns:
-    - entries:
+  - row:
+    - column:
         - type: line_divider
 
-  - columns:
-    - entries:
+  - row:
+    - column:
       - type: action_button
         action_button:
           text: "View Nexmo docs"
@@ -108,7 +108,7 @@ rows:
           center_button: true
           type: primary
           large: true
-    - entries:
+    - column:
       - type: action_button
         action_button:
           text: "Get the schedule data"
@@ -116,7 +116,7 @@ rows:
           center_button: true
           type: primary
           large: true
-    - entries:
+    - column:
       - type: action_button
         action_button:
           text: "Submit your hack"
@@ -126,13 +126,13 @@ rows:
           large: true
 
 
-  - columns:
-    - entries:
+  - row:
+    - column:
         - type: line_divider
 
 
-  - columns:
-    - entries:
+  - row:
+    - column:
       - type: call_to_action
         call_to_action:
           title: "Voice"
@@ -142,7 +142,7 @@ rows:
             color: "green"
           url: "/voice"
 
-    - entries:
+    - column:
       - type: call_to_action
         call_to_action:
           title: "Messages"
@@ -152,7 +152,7 @@ rows:
             color: "purple"
           url: "/messages/overview"
 
-    - entries:
+    - column:
       - type: call_to_action
         call_to_action:
           title: "Verify"
@@ -162,8 +162,8 @@ rows:
             color: "indigo"
           url: "/verify"
 
-  - columns:
-    - entries:
+  - row:
+    - column:
       - type: text
         text:
           content: |
@@ -175,12 +175,12 @@ rows:
             	</div>
             </div>
 
-  - columns:
-    - entries:
+  - row:
+    - column:
         - type: line_divider
 
-  - columns:
-    - entries:
+  - row:
+    - column:
         - type: header
           header:
             title:
@@ -208,7 +208,7 @@ rows:
               composer require nexmo/laravel
               ```
 
-    - entries:
+    - column:
         - type: header
           header:
             title:
@@ -237,12 +237,12 @@ rows:
               <a class="Vlt-btn Vlt-btn--secondary" href="/voice/voice-api/building-blocks/make-an-outbound-call">View the complete code &raquo;</a>
               </div>
 
-  - columns:
-    - entries:
+  - row:
+    - column:
         - type: line_divider
 
-  - columns:
-    - entries:
+  - row:
+    - column:
       - type: section_header
         section_header:
           title: "Handy PHP-related links and further reading"
@@ -251,8 +251,8 @@ rows:
             color: "blue-dark"
 
 
-  - columns:
-    - entries:
+  - row:
+    - column:
       - type: text
         text:
           content: >
@@ -263,8 +263,8 @@ rows:
                 Come and say hello at the Nexmo booth! We'd love to hear what you're having issues with to help you out (and improve the docs at the same time!)
             	</div>
             </div>
-  - columns:
-    - entries:
+  - row:
+    - column:
       - type: unordered_list
         unordered_list:
             bullet_shape: simple
@@ -274,7 +274,7 @@ rows:
               - item: "[Receive an Incoming Call with PHP](https://www.nexmo.com/blog/2018/06/28/receive-an-inbound-voice-call-with-php-dr/)"
               - item: "[Handle Keypad Input (DTMF) with PHP](https://www.nexmo.com/blog/2018/08/10/handle-user-input-with-php-dr/)"
               - item: "[Interactive Voice Response](/tutorials/interactive-voice-response)"
-    - entries:
+    - column:
       - type: unordered_list
         unordered_list:
             bullet_shape: simple
@@ -284,12 +284,12 @@ rows:
               - item: "[Record a Call](/voice/voice-api/building-blocks/record-a-call/php)"
               - item: "[Connect Callers into a Conference](/voice/voice-api/building-blocks/connect-callers-into-a-conference/php)"
               - item: "[Transfer a Call](/voice/voice-api/building-blocks/transfer-a-call/php)"
-  - columns:
-    - entries:
+  - row:
+    - column:
         - type: line_divider
-  - columns:
-    - entries:
+  - row:
+    - column:
       - type: join_slack
-  - columns:
-    - entries:
+  - row:
+    - column:
         - type: line_divider

--- a/config/landing_pages/spotlight.yml
+++ b/config/landing_pages/spotlight.yml
@@ -4,9 +4,9 @@ title: "Write for Nexmo"
 meta_title: "Developer Spotlight - Teach others, grow as a writer, and help us build the next go-to destination for developers"
 container_classes:
   - Vlt-article
-rows:
-  - columns:
-    - entries:
+page:
+  - row:
+    - column:
       - type: header
         header:
           title: 
@@ -22,16 +22,16 @@ rows:
           text: "Apply Now"
           url: "#submit-your-idea"
     - width: 2
-      entries:
+      column:
       - type: html
         html:
           content: '<img src="/assets/images/developer_spotlight.png" />'
-  - columns:
-    - entries:
+  - row:
+    - column:
         - type: line_divider
-  - columns:
+  - row:
     - width: 2
-      entries:
+      column:
       - type: section_header
         section_header:
           title: "Examples"
@@ -59,7 +59,7 @@ rows:
           url: "https://www.nexmo.com/blog/2018/03/14/speech-voice-translation-microsoft-dr/"
           alt_text: "speech voice translation tutorial"
     - width: 2
-      entries:
+      column:
       - type: structured_text
         structured_text:
           header: "What We're Looking For"

--- a/spec/controllers/static_controller_spec.rb
+++ b/spec/controllers/static_controller_spec.rb
@@ -13,11 +13,11 @@ RSpec.describe StaticController, type: :request do
   describe 'GET default_landing' do
     it 'renders single column with 100% width' do
       landing_config = {
-          'rows' => [
+          'page' => [
             {
-                'columns' => [
+                'row' => [
                   {
-                        'entries' => [
+                        'column' => [
                           {
                                 'type' => 'text',
                                 'text' => {
@@ -41,12 +41,12 @@ RSpec.describe StaticController, type: :request do
 
     it 'renders two columns with 50% width each' do
       landing_config = {
-        'rows' => [
+        'page' => [
           {
-                  'columns' => [
+                  'row' => [
                     {
                           'width' => 1,
-                          'entries' => [
+                          'column' => [
                             {
                                   'type' => 'text',
                                   'text' => {
@@ -57,7 +57,7 @@ RSpec.describe StaticController, type: :request do
                       },
                     {
                           'width' => 1,
-                          'entries' => [
+                          'column' => [
                             {
                                   'type' => 'text',
                                   'text' => {
@@ -81,11 +81,11 @@ RSpec.describe StaticController, type: :request do
 
     it 'renders three columns, no width specified' do
       landing_config = {
-          'rows' => [
+          'page' => [
             {
-                  'columns' => [
+                  'row' => [
                     {
-                          'entries' => [
+                          'column' => [
                             {
                                   'type' => 'text',
                                   'text' => {
@@ -95,7 +95,7 @@ RSpec.describe StaticController, type: :request do
                           ],
                       },
                     {
-                          'entries' => [
+                          'column' => [
                             {
                                   'type' => 'text',
                                   'text' => {
@@ -106,7 +106,7 @@ RSpec.describe StaticController, type: :request do
 
                     },
                     {
-                      'entries' => [
+                      'column' => [
                         {
                               'type' => 'text',
                               'text' => {
@@ -130,12 +130,12 @@ RSpec.describe StaticController, type: :request do
 
     it 'renders two columns in three-column grid (1:2 and 1:1)' do
       landing_config = {
-          'rows' => [
+          'page' => [
             {
-                  'columns' => [
+                  'row' => [
                     {
                           'width' => 2,
-                          'entries' => [
+                          'column' => [
                             {
                                   'type' => 'text',
                                   'text' => {
@@ -146,7 +146,7 @@ RSpec.describe StaticController, type: :request do
                       },
                     {
                       'width' => 1,
-                      'entries' => [
+                      'column' => [
                         {
                               'type' => 'text',
                               'text' => {
@@ -171,12 +171,12 @@ RSpec.describe StaticController, type: :request do
 
     it 'renders two columns in three-column grid (1:1 and 1:2)' do
       landing_config = {
-          'rows' => [
+          'page' => [
             {
-                  'columns' => [
+                  'row' => [
                     {
                           'width' => 1,
-                          'entries' => [
+                          'column' => [
                             {
                                   'type' => 'text',
                                   'text' => {
@@ -187,7 +187,7 @@ RSpec.describe StaticController, type: :request do
                       },
                     {
                       'width' => 2,
-                      'entries' => [
+                      'column' => [
                         {
                               'type' => 'text',
                               'text' => {
@@ -211,32 +211,32 @@ RSpec.describe StaticController, type: :request do
 
     it 'renders two rows, one with two columns (1:1) and one with three (1:1:1)' do
       landing_config = {
-          'rows' => [
+          'page' => [
             {
-              'columns' => [
+              'row' => [
                 {
                   'width' => 1,
-                  'entries' => [],
+                  'column' => [],
                 },
                 {
                   'width' => 1,
-                  'entries' => [],
+                  'column' => [],
                 },
               ],
             },
             {
-              'columns' => [
+              'row' => [
                 {
                   'width' => 1,
-                  'entries' => [],
+                  'column' => [],
                 },
                 {
                   'width' => 1,
-                  'entries' => [],
+                  'column' => [],
                 },
                 {
                   'width' => 1,
-                  'entries' => [],
+                  'column' => [],
                 },
               ],
             },
@@ -253,15 +253,15 @@ RSpec.describe StaticController, type: :request do
 
     it 'renders the correct grid size when the last item in the grid has no explicit width' do
       landing_config = {
-        'rows' => [
+        'page' => [
           {
-            'columns' => [
+            'row' => [
               {
                 'width' => 1,
-                'entries' => [],
+                'column' => [],
               },
               {
-                'entries' => [],
+                'column' => [],
               },
             ],
           },
@@ -277,15 +277,15 @@ RSpec.describe StaticController, type: :request do
 
     it 'renders the correct grid size when the first item in the grid has no explicit width' do
       landing_config = {
-        'rows' => [
+        'page' => [
           {
-            'columns' => [
+            'row' => [
               {
-                'entries' => [],
+                'column' => [],
               },
               {
                 'width' => 1,
-                'entries' => [],
+                'column' => [],
               },
             ],
           },

--- a/spec/views/static/default_landing/default_landing.html.erb_spec.rb
+++ b/spec/views/static/default_landing/default_landing.html.erb_spec.rb
@@ -3,11 +3,11 @@ require 'rails_helper'
 RSpec.describe 'static/default_landing' do
   it 'renders all partials' do
     @landing_config = {
-    'rows' => [
+    'page' => [
       {
-        'columns' => [
+        'row' => [
           {
-                'entries' => [
+                'column' => [
                   {
                         'type' => 'header',
                         'header' => {
@@ -30,7 +30,7 @@ RSpec.describe 'static/default_landing' do
                 ],
             },
           {
-              'entries' => [
+              'column' => [
                 {
                     'type' => 'contact_support',
                   },
@@ -44,7 +44,7 @@ RSpec.describe 'static/default_landing' do
           },
           {
                 'width' => 2,
-                'entries' => [
+                'column' => [
                   {
                         'type' => 'html',
                         'html' => {
@@ -56,16 +56,16 @@ RSpec.describe 'static/default_landing' do
         ],
       },
       {
-        'columns' => [
+        'row' => [
           {
-                'entries' => [
+                'column' => [
                   {
                         'type' => 'line_divider',
                     },
                 ],
             },
           {
-              'entries' => [
+              'column' => [
                 {
                       'type' => 'call_to_action',
                       'call_to_action' => {
@@ -80,10 +80,10 @@ RSpec.describe 'static/default_landing' do
         ],
       },
       {
-        'columns' => [
+        'row' => [
           {
                 'width' => 2,
-                'entries' => [
+                'column' => [
                   {
                         'type' => 'section_header',
                         'section_header' => {
@@ -115,9 +115,9 @@ RSpec.describe 'static/default_landing' do
         ],
       },
       {
-        'columns' => [
+        'row' => [
           {
-                'entries' => [
+                'column' => [
                   {
                         'type' => 'unordered_list',
                         'unordered_list' => {


### PR DESCRIPTION
In this pull request, we introduce a redesigned config file for the config-driven landing pages. The naming of the objects have been changed from:

```yaml

rows:
  - columns:
    - entries:

```

to:

```yaml

page:
  - row:
    - column:

```

This has been done to simplify the creation of future config files by landing page creators.