### PR TITLE
Remove the "nuget package" label from the github_repo landing page content block

### DIFF
--- a/app/views/static/default_landing/partials/_github_repo.html.erb
+++ b/app/views/static/default_landing/partials/_github_repo.html.erb
@@ -9,7 +9,6 @@
     <a class="Vlt-card Nxd-github-card Vlt-left" href="<%= local_assigns['repo_url'] %>" data-github="Nexmo/<%= local_assigns['repo_url'].split('/').last %>">
       <h3 class="Vlt-blue-dark"><%= local_assigns['repo_url'].split('/').last %></h3>
       <p><%= local_assigns['github_repo_title'] %></p>
-      <img src="//badge.fury.io/nu/nexmo.svg" class="Nxd-github-card__badge" height="18">
       <p><small class="Nxd-github-card__meta">
         <span>
           <span class="Vlt-blue-dark">●</span> <%= local_assigns['language'] %>


### PR DESCRIPTION
This pull request removes the `nuget package` label that sits at the top of the `github_repo` content block. 

Before:
<img width="402" alt="screen shot 2019-02-18 at 8 45 39" src="https://user-images.githubusercontent.com/13892277/52932792-a089c480-3359-11e9-8dae-773f72c50757.png">

After:
<img width="399" alt="screen shot 2019-02-18 at 8 46 18" src="https://user-images.githubusercontent.com/13892277/52932809-aed7e080-3359-11e9-8739-79778dde3612.png">

