### PR TITLE
Move Building Blocks to Volta tabs

### DIFF
--- a/app/assets/stylesheets/objects/_tabs.scss
+++ b/app/assets/stylesheets/objects/_tabs.scss
@@ -95,3 +95,26 @@ ul.tabs {
     }
   }
 }
+
+.Vlt-tabs__link_active {
+  background: #f8fafc;
+}
+
+.Vlt-tabs__content {
+  background: #f8fafc;
+  border-bottom-left-radius: 8px;
+  border-bottom-right-radius: 8px;
+  border-bottom: 1px solid #e7ebee;
+  border-left: 1px solid #e7ebee;
+  border-right: 1px solid #e7ebee;
+  margin-bottom: 32px;
+  padding: 24px;
+  margin-top: 0px;
+}
+
+
+.Vlt-tabs__header--bordered {
+  .Vlt-tabs__link:first-child {
+    margin-left: 0;
+  }
+}

--- a/app/filters/building_blocks_filter.rb
+++ b/app/filters/building_blocks_filter.rb
@@ -12,8 +12,9 @@ class BuildingBlocksFilter < Banzai::Filter
 
   def create_tabs(content)
     tab = Nokogiri::XML::Element.new 'li', @document
-    tab['class'] = 'tabs-title'
-    tab['class'] += ' is-active' if content[:active]
+    tab['class'] = 'Vlt-tabs__link'
+    tab['class'] += ' Vlt-tabs__link_active' if content[:active]
+    tab['aria-selected'] = 'true' if content[:active]
 
     if content['language']
       tab['data-language'] = content['language']
@@ -23,7 +24,7 @@ class BuildingBlocksFilter < Banzai::Filter
 
     tab_link = Nokogiri::XML::Element.new 'a', @document
     tab_link.inner_html = "<svg><use xlink:href=\"/assets/images/brands/#{content['icon']}.svg##{content['icon']}\" /></svg><span>" + content['title'] + '</span>'
-    tab_link['href'] = "##{content['id']}"
+    tab_link['class'] = 'tab-link'
 
     tab.add_child(tab_link)
     @tabs.add_child(tab)
@@ -32,26 +33,24 @@ class BuildingBlocksFilter < Banzai::Filter
   def create_content(content)
     element = Nokogiri::XML::Element.new 'div', @document
     element['id'] = content['id']
-    element['class'] = 'tabs-panel'
-    element['class'] += ' is-active' if content[:active]
+    element['class'] = 'Vlt-tabs__panel'
+    element['class'] += ' Vlt-tabs__panel_active' if content[:active]
     element.inner_html = content[:body]
 
     @tabs_content.add_child(element)
   end
 
   def html
-    id = SecureRandom.hex
-
     html = <<~HEREDOC
-      <div>
-        <ul class="tabs" data-tabs id="#{id}"></ul>
-        <div class="tabs-content" data-tabs-content="#{id}"></div>
+      <div class="Vlt-tabs">
+        <div class="Vlt-tabs__header--bordered"></div>
+        <div class="Vlt-tabs__content"></div>
       </div>
     HEREDOC
 
     @document = Nokogiri::HTML::DocumentFragment.parse(html)
-    @tabs = @document.at_css('.tabs')
-    @tabs_content = @document.at_css('.tabs-content')
+    @tabs = @document.at_css('.Vlt-tabs__header--bordered')
+    @tabs_content = @document.at_css('.Vlt-tabs__content')
 
     contents.each do |content|
       create_tabs(content)

--- a/app/javascript/packs/UserPreference.js
+++ b/app/javascript/packs/UserPreference.js
@@ -1,7 +1,8 @@
 import intersection from 'lodash/intersection'
 
 export default class UserPreference {
-  constructor() {
+  constructor(useSingleStore) {
+    this.useSingleStore = useSingleStore;
     this.platformPreference = this.platforms()
     this.terminalProgramsPreference = this.terminalPrograms()
     this.frameworkPreference = this.frameworks()
@@ -25,13 +26,16 @@ export default class UserPreference {
 
   all() {
     return this.platforms().concat(
-      this.languages(),
       this.terminalPrograms(),
+      this.languages(),
       this.frameworks()
     )
   }
 
   getKeyFromType(type) {
+    if (this.useSingleStore) {
+        return 'preferences.all';
+    }
     switch (type) {
       case 'languages': return 'preferences.languages'
       case 'platforms': return 'preferences.platforms'

--- a/app/javascript/packs/VoltaTabbedExamples.js
+++ b/app/javascript/packs/VoltaTabbedExamples.js
@@ -1,0 +1,98 @@
+import UserPreference from './UserPreference'
+
+export default class VoltaTabbedExamples {
+  constructor() {
+    this.userPreference = new UserPreference(true);
+
+    if ($('.Vlt-tabs').length) {
+      this.context = $('.Vlt-tabs');
+      this.restoreTabs = this.restoreTabs.bind(this)
+      this.setupEvents = this.setupEvents.bind(this)
+      this.onTabClick = this.onTabClick.bind(this)
+      this.onPopState = this.onPopState.bind(this)
+      this.persistLanguage = this.persistLanguage.bind(this)
+      this.restoreTabs()
+      this.setupEvents()
+    }
+  }
+
+  shouldRestoreTabs() {
+    return !this.context.data('has-initial-tab')
+  }
+
+  doesTabLanguageExist(language) {
+    return $(this.context).find(`[data-language='${language}']`).length > 0
+  }
+
+  languages() {
+    let obj = {}
+
+    $(this.context).find(`[data-language]`).each(function(index, el) {
+      $(el).data('language').split(',').forEach(function(language) {
+        obj[language] = {
+          platform: $(el).data('platform') || false
+        }
+      })
+    })
+
+    return obj
+  }
+
+  restoreTabs() {
+      if (this.shouldRestoreTabs()) {
+        let languages = this.languages()
+        const language = this.userPreference.topMatch(Object.keys(languages))
+
+        if (language) {
+          if (languages[language]['platform']) {
+            this.setPlatform(languages[language]['platform'], this.context)
+          } else {
+            this.setLanguage(language, this.context)
+          }
+        }
+      }
+  }
+
+  setupEvents() {
+    $('.Vlt-tabs__link').click(this.onTabClick)
+    $(window).on('popstate', this.onPopState)
+  }
+
+  onPopState(event) {
+    if (window.history.state && window.history.state.language) {
+      this.setLanguage(window.history.state.language)
+    }
+  }
+
+  onTabClick(event) {
+    const language = $(event.currentTarget).data('language')
+    const languageType = $(event.currentTarget).data('language-type')
+    const linkable = $(event.currentTarget).data('language-linkable')
+
+    if (language) {
+      if (linkable) {
+        $(document).trigger('codeLanguageChange', { language });
+        if ($(".skip-pushstate").length == 0) {
+            const rootPath = $('body').data('push-state-root')
+            window.history.pushState({language}, 'language', `${rootPath}/${language}`)
+        }
+      }
+
+      this.persistLanguage(language, languageType, linkable)
+    }
+  }
+
+  persistLanguage(language, languageType) {
+    if (language) {
+      this.userPreference.promote(languageType, language)
+    }
+  }
+
+  setLanguage(language) {
+      setTimeout(() => { $(`[data-language='${language}']`).click(); }, 0);
+  }
+
+  setPlatform(platform) {
+      setTimeout(() => { $(`[data-platform='${platform}']`).click(); }, 0);
+  }
+}

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -14,6 +14,7 @@ import React from 'react'
 import ReactDOM from 'react-dom'
 import GithubCards from './GithubCards'
 import TabbedExamples from './TabbedExamples'
+import VoltaTabbedExamples from './VoltaTabbedExamples'
 import Format from './Format'
 import JsSequenceDiagrams from './JsSequenceDiagrams'
 import Navigation from './Navigation'
@@ -41,6 +42,7 @@ let refresh = () => {
   GithubCards()
   JsSequenceDiagrams()
   new TabbedExamples
+  new VoltaTabbedExamples
   new Format
   Modals()
   APIStatus()

--- a/spec/smoke_spec.rb
+++ b/spec/smoke_spec.rb
@@ -93,13 +93,13 @@ RSpec.describe 'Smoke Tests', type: :request do
 
   it 'markdown page has default code_language' do
     get '/voice/voice-api/building-blocks/connect-an-inbound-call'
-    expect(response.body).to include('li class="tabs-title is-active" data-language="node" data-language-type="languages"')
+    expect(response.body).to include('li class="Vlt-tabs__link Vlt-tabs__link_active" aria-selected="true" data-language="node" data-language-type="languages" data-language-linkable="true"')
   end
 
   it 'markdown page respects code_language' do
     get '/voice/voice-api/building-blocks/connect-an-inbound-call/php'
-    expect(response.body).to include('li class="tabs-title is-active" data-language="php" data-language-type="languages"')
-    expect(response.body).not_to include('li class="tabs-title is-active" data-language="node" data-language-type="languages"')
+    expect(response.body).to include('li class="Vlt-tabs__link Vlt-tabs__link_active" aria-selected="true" data-language="php" data-language-type="languages" data-language-linkable="true"')
+    expect(response.body).not_to include('li class="Vlt-tabs__link Vlt-tabs__link_active" aria-selected="true" data-language="node" data-language-type="languages" data-language-linkable="true"')
   end
 
   it '/hansel contains the expected text' do


### PR DESCRIPTION
## Description

Migrate building blocks to use Volta tabs rather than foundation tabs. There is one change, in that if you visit a Building Block without a language in the URL it will now be appended. Everything else should be identical

## Deploy Notes

N/A
