### PR TITLE
Remove links to OAuth page now the page has been removed

### DIFF
--- a/app/views/static/documentation.md
+++ b/app/views/static/documentation.md
@@ -11,8 +11,7 @@ Welcome to the Nexmo Developer Documentation. Get familiar with [concepts](#conc
 There are a number of shared concepts between the various Nexmo APIs:
 
 - [Applications](/concepts/guides/applications) - Security and configuration information you need to connect to Nexmo endpoints
-- [Authentication](/concepts/guides/authentication) – API keys, OAuth, and JSON Web Tokens (JWTs)
-- [OAuth](/concepts/guides/oauth) – How to use OAuth 1.0a with Nexmo's API
+- [Authentication](/concepts/guides/authentication) – API keys and JSON Web Tokens (JWTs)
 - [Signing messages](/concepts/guides/signing-messages) – How to cryptographically sign messages and verify signatures
 - [Webhooks](/concepts/guides/webhooks) – Nexmo's API can send data back to your web server via a webhook
 


### PR DESCRIPTION
## Description

We still had a link to the OAuth docs on the main documentation page. This OAuth page has been removed so the link goes nowhere - this PR removes the link.
