### PR TITLE
Fix back button on Building Block pages

### DIFF
--- a/app/filters/building_blocks_filter.rb
+++ b/app/filters/building_blocks_filter.rb
@@ -142,6 +142,7 @@ class BuildingBlocksFilter < Banzai::Filter
     end
 
     @tabs['data-has-initial-tab'] = active_index.present?
+    @tabs['class'] += ' skip-pushstate' if @tabs['data-has-initial-tab']
     active_index ||= 0
 
     contents[active_index][:active] = true

--- a/app/javascript/packs/VoltaTabbedExamples.js
+++ b/app/javascript/packs/VoltaTabbedExamples.js
@@ -89,7 +89,13 @@ export default class VoltaTabbedExamples {
   }
 
   setLanguage(language) {
-      setTimeout(() => { $(`[data-language='${language}']`).click(); }, 0);
+      setTimeout(() => {
+        $(`[data-language='${language}']`).click();
+
+        // Remove skip pushstate after the first load. This is a bit of a hack, but it works to stop breaking
+        // the back button
+        $(".skip-pushstate").removeClass('skip-pushstate');
+      }, 0);
   }
 
   setPlatform(platform) {


### PR DESCRIPTION
## Description

At the moment, adding the language to the URL on building block pages breaks the back button. This PR prevents the initial page load adding the language to the URL to preserve back button behaviour

## Deploy Notes

N/A
