### PR TITLE
Add support for header parameters + collapsible responses

### DIFF
--- a/app/views/open_api/_endpoint.html.erb
+++ b/app/views/open_api/_endpoint.html.erb
@@ -83,15 +83,19 @@
 
       <% endpoint.responses.each do |response| %>
         <% id = SecureRandom.hex %>
+        <%
+          expand_response = response.code[0] == '2' && response.raw['x-expand-response'] != false
+          expand_response = true if response.raw['x-expand-response']
+        %>
 
       <div class="Vlt-accordion">
-        <button tabindex="0" class="Vlt-accordion__trigger <%= response.code[0] == '2' ? 'Vlt-accordion__trigger_active' : '' %>">
+        <button tabindex="0" class="Vlt-accordion__trigger <%= expand_response ? 'Vlt-accordion__trigger_active' : '' %>">
           <h5 class="Vlt-title--nomargin">HTTP response
             <span class="Vlt-badge Vlt-badge--<%= response.code[0] == '2' ? 'green' : response.code[0] == '3' ? 'yellow' : 'red'  %>"><%= response.code %></span>
           </h5>
         </button>
 
-        <div class="Vlt-accordion__content <%= response.code[0] == '2' ? 'Vlt-accordion__content_open' : '' %>">
+        <div class="Vlt-accordion__content <%= expand_response ? 'Vlt-accordion__content_open' : '' %>">
           <div class="tabs-content" data-tabs-content="<%= id %>">
             <% response.formats.each_with_index do |format, index| %>
 

--- a/app/views/open_api/_parameter_groups.html.erb
+++ b/app/views/open_api/_parameter_groups.html.erb
@@ -2,6 +2,11 @@
   callback = false if local_assigns[:callback].nil?
 %>
 
+<% if endpoint.parameters.select {|p| p.in == 'header'}.any? %>
+  <h4>Header Parameters</h4>
+  <%= render 'parameters', parameters: endpoint.parameters.select { |p| p.in == 'header'}, callback: callback %>
+<% end %>
+
 <% if endpoint.path_parameters.any? %>
   <h4>Path Parameters</h4>
   <%= render 'parameters', parameters: endpoint.path_parameters, callback: callback %>


### PR DESCRIPTION
## Description

For the number pools OAS (not part of this PR) we need to support header parameters in addition to path and query params.

We also want to be able to control which responses are shown by default. Our existing logic of anything that starts with a `2` is no longer sufficient. This PR makes that the default behaviour, but allows you to specify `x-expand-response: false` to stop the behaviour

## Deploy Notes

N/A
