### PR TITLE
Reformat Tutorials to use consistent navigation

### DIFF
--- a/app/assets/stylesheets/objects/_navigation.scss
+++ b/app/assets/stylesheets/objects/_navigation.scss
@@ -85,3 +85,22 @@
     display: none;
   }
 }
+
+.Nxd-tutorial {
+  border-right: 1px solid silver;
+}
+.Nxd-tutorial-sidenav {
+  a {
+    color: black;
+  }
+  padding: 0px;
+
+  li li {
+    margin-left: 10px !important;
+  }
+}
+
+
+.Vlt-sidemenu__link_active {
+  color: white !important;
+}

--- a/app/controllers/tutorials_controller.rb
+++ b/app/controllers/tutorials_controller.rb
@@ -24,18 +24,23 @@ class TutorialsController < ApplicationController
   end
 
   def show
-    @document_path = "_tutorials/#{@document}.md"
-
     # Read document
+    @document_path = "_tutorials/#{@document}.md"
     document = File.read("#{Rails.root}/#{@document_path}")
 
     # Parse frontmatter
     @frontmatter = YAML.safe_load(document)
+
     @document_title = @frontmatter['title']
+    @product = @frontmatter['products']
 
     @content = MarkdownPipeline.new({ code_language: @code_language, disable_label_filter: true }).call(document)
 
-    render layout: 'static'
+    @namespace_path = "_documentation/#{@product}"
+    @namespace_root = '_documentation'
+    @sidenav_root = "#{Rails.root}/_documentation"
+
+    render layout: 'documentation'
   end
 
   private
@@ -46,8 +51,5 @@ class TutorialsController < ApplicationController
 
   def set_navigation
     @navigation = :tutorials
-    @side_navigation_extra_links = {
-      'Tutorials' => '/tutorials',
-    }
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -132,6 +132,11 @@ module ApplicationHelper
         url = (child[:is_file?] ? path_to_url(child[:path]) : first_link_in_directory(child[:children]))
         has_active_class = (active_path == url) || active_path.start_with?("#{url}/")
 
+        # Handle tutorials
+        if @navigation == :tutorials
+          has_active_class = url == "/#{@product}/tutorials"
+        end
+
         if !child[:is_file?]
           if context.first[:children]
             ss << "<a class='Vlt-sidemenu__trigger'>"

--- a/app/helpers/navigation_helper.rb
+++ b/app/helpers/navigation_helper.rb
@@ -11,7 +11,6 @@ HEADING_TAG_DEPTHS = {
 module NavigationHelper
   def navigation_from_content(content:, title: nil)
     content = "<h0 class='injected'>#{title}</h0>\n" + content if title
-
     document = build_document(content)
 
     nodes = ['<ul class="Vlt-sidemenu Vlt-sidemenu--rounded Vlt-sidemenu--flat navigation js-navigation">']

--- a/app/helpers/navigation_helper.rb
+++ b/app/helpers/navigation_helper.rb
@@ -22,6 +22,7 @@ module NavigationHelper
       # If it's a header within tabbed content (including building blocks) we don't want to treat
       # the header as a navigation item in the sidebar
       next unless heading.ancestors('.tabs-content').empty?
+      next unless heading.ancestors('.Vlt-tabs').empty?
 
       # Same with callouts
       next unless heading.ancestors('.Vlt-callout').empty?

--- a/app/views/layouts/static.html.erb
+++ b/app/views/layouts/static.html.erb
@@ -4,6 +4,20 @@
 
   <body class="Nxd-template" data-push-state-root="<%= canonical_path %>">
     <%= render partial: 'layouts/partials/header' %>
+    <div id="Vlt-sidenav" class="Vlt-sidenav Vlt-sidenav--light">
+      <div class="Vlt-sidenav__scroll">
+        <nav class="sidenav" data-turbolinks-permanent tabindex="0" >
+          <% if (@sidebar_nav) %>
+            <%= @sidebar_nav %>
+          <% elsif @custom_navigation %>
+            <%= custom_navigation(@custom_navigation) %>
+          <% else %>
+            <%= sidenav(@sidenav_root, @active_path) %>
+          <% end %>
+        </nav>
+      </div>
+    </div>
+
     <nav class="Vlt-sidenav Vlt-sidenav--light" id="Vlt-sidenav" data-turbolinks-permanent>
       <% if @return_link %>
         <%= link_to @return_link[:path], class: 'sidenav-back', data: { turbolinks: false } do %>
@@ -11,7 +25,6 @@
         <% end %>
         <hr>
       <% end %>
-      <%= navigation_from_content(content: @content, title: @document_title) %>
     </nav>
     <div class="Vlt-main Vlt-main--light Nxd-main" id="primary-content" data-turbolinks="false" tabindex="2">
       <%= render partial: 'layouts/partials/notices' %>

--- a/app/views/tutorials/show.html.erb
+++ b/app/views/tutorials/show.html.erb
@@ -1,1 +1,8 @@
-<%= @content.html_safe %>
+<div class="Vlt-grid ">
+  <div class="Vlt-col Vlt-col--3of4 Nxd-tutorial">
+    <%= @content.html_safe %>
+  </div>
+  <div class="Vlt-col Vlt-col--1of4 Vlt-sidenav Nxd-tutorial-sidenav">
+    <%= navigation_from_content(content: @content) %>
+  </div>
+</div>


### PR DESCRIPTION
## Description

This PR adds our normal left hand side navigation to tutorials, and moves the in-page navigation to the right hand side

<img width="1434" alt="screen shot 2019-02-25 at 11 35 45" src="https://user-images.githubusercontent.com/59130/53363526-946dac00-38f1-11e9-8027-cfc2ff4cd7f1.png">


## Deploy Notes

N/A
