### PR TITLE
Update to remove MMS LVN language refs on building blocks

### DIFF
--- a/_documentation/dispatch/building-blocks/send-an-mms-with-failover.md
+++ b/_documentation/dispatch/building-blocks/send-an-mms-with-failover.md
@@ -8,7 +8,7 @@ In this example you will send an MMS that can fail over to sending an SMS.
 
 In the Workflow object, message objects can be placed in any order to suit your use case. Each message object must contain a failover object, except for the last message, as there are no more message objects to failover to.
 
-> **NOTE:** MMS only supports US Short Code and US LVNs.
+> **NOTE:** MMS only supports US Short Codes.
 
 ## Example
 
@@ -17,8 +17,8 @@ Ensure the following variables are set to your required values using any conveni
 Key | Description
 -- | --
 `NEXMO_APPLICATION_ID` | The ID of the application that you created.
-`FROM_NUMBER` | The phone number you are sending the MMS from. (US Short Code and US LVN)
-`TO_NUMBER` | The phone number you are sending the MMS to (Recipients on T-Mobile and Verizon networks are currently only supported when sending from US Short codes).
+`FROM_NUMBER` | The phone number you are sending the MMS from (US Short Code only).
+`TO_NUMBER` | The phone number you are sending the MMS to.
 
 > **NOTE:** Don't use a leading `+` or `00` when entering a phone number, start with the country code, for example 447700900000.
 

--- a/_documentation/messages/building-blocks/send-mms.md
+++ b/_documentation/messages/building-blocks/send-mms.md
@@ -6,7 +6,7 @@ title: Send an MMS
 
 In this building block you will see how to send an MMS using the Messages API.
 
-> **IMPORTANT:** Only US Short codes and US LVNs are currently supported for sending MMS. Recipients on T-Mobile and Verizon networks are currently only supported when sending from US Short codes.
+> **IMPORTANT:** Only US Short codes are currently supported for sending MMS.
 
 ## Example
 
@@ -14,7 +14,7 @@ Ensure the following variables are set to your required values using any conveni
 
 | Key           | Description                                                                                                 |
 | ------------- | ----------------------------------------------------------------------------------------------------------- |
-| `FROM_NUMBER` | The phone number you are sending the MMS from. (US Short Code and US LVN only)                              |
+| `FROM_NUMBER` | The phone number you are sending the MMS from. (US Short Code only)                              |
 | `TO_NUMBER`   | The phone number you are sending the message to. |
 | `IMG_URL`     | The URL of the media you want to send                                                                       |
 
@@ -30,6 +30,3 @@ application:
 ## Try it out
 
 When you run the code an MMS message is sent to the destination number.
-
-## Sending to unsupported networks
-Sending MMS to the Verizon and T-Mobile networks is not currently supported. In order to ensure your messages get to their recipient successfully use our [Dispatch API to automatically failover to SMS](/dispatch/building-blocks/send-an-mms-with-failover) when MMS cannot be delivered.


### PR DESCRIPTION
## Description

Removes references to MMS LVN as this may not end up as a public option any more. Back to shortcode only references in the building blocks if needed.

## Deploy Notes

Only merge if the decision comes from Sheri and/or Hugh that the references should be removed.
