### PR TITLE
Added FREEZESTART and FREEZEEND support in JsSequenceDiagramFilter

### DIFF
--- a/app/filters/js_sequence_diagram_filter.rb
+++ b/app/filters/js_sequence_diagram_filter.rb
@@ -1,11 +1,13 @@
 class JsSequenceDiagramFilter < Banzai::Filter
   def call(input)
     input.gsub(/```js_sequence_diagram(.+?)```/m) do |_s|
-      <<~HEREDOC
+      diagram = <<~HEREDOC
         <div class="js-diagram">
           #{$1}
         </div>
       HEREDOC
+
+      "FREEZESTART#{Base64.urlsafe_encode64(diagram)}FREEZEEND"
     end
   end
 end

--- a/spec/filters/js_sequence_diagram_filter_spec.rb
+++ b/spec/filters/js_sequence_diagram_filter_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe JsSequenceDiagramFilter do
       ```
     HEREDOC
 
-    expected_output = "<div class=\"js-diagram\">\n  \nsome text here\n\n</div>\n\n"
+    expected_output = "FREEZESTARTPGRpdiBjbGFzcz0ianMtZGlhZ3JhbSI-CiAgCnNvbWUgdGV4dCBoZXJlCgo8L2Rpdj4KFREEZEEND\n"
 
     expect(described_class.call(input)).to eq(expected_output)
   end


### PR DESCRIPTION
## Description

In this PR we add `FREEZESTART` and `FREEZEEND` support in `JsSequenceDiagramFilter` and encodes the return value as Base64 binary data. The test for the filter has been updated as well to reflect the new return value.
