### PR TITLE
Positive feedback button should not link to negative feedback form

### DIFF
--- a/app/javascript/packs/Feedback.jsx
+++ b/app/javascript/packs/Feedback.jsx
@@ -151,7 +151,7 @@ class Feedback extends React.Component {
     return (
       <div>
         <hr/>
-        <p>Great! Thanks for letting us know.</p>
+        <p>Great! Thanks for the feedback.</p>
       </div>
     )
   }

--- a/app/javascript/packs/Feedback.jsx
+++ b/app/javascript/packs/Feedback.jsx
@@ -151,7 +151,7 @@ class Feedback extends React.Component {
     return (
       <div>
         <hr/>
-        <p>Great! <a onClick={ () => this.setState({ showExtendedFields: true }) }>Give us some feedback</a></p>
+        <p>Great! Thanks for letting us know.</p>
       </div>
     )
   }


### PR DESCRIPTION
## Description

When a user clicks on the positive feedback button, a message appears with a link to the negative feedback form. This is wrong!

For now I've just removed the link and thank the user for their feedback instead.

## Deploy Notes

Test in sample app: https://nexmo-developer-pr-1491.herokuapp.com/
