### PR TITLE
Make icon optional in landing page structured_text partial

### DIFF
--- a/app/views/contribute/guides/landing-pages.md
+++ b/app/views/contribute/guides/landing-pages.md
@@ -298,16 +298,13 @@ The `sessions` content block is a pre-defined set of information that takes no p
 
 <img src="/assets/images/contributing/landing_page_screenshots/structured_text.png" width=400>
 
-The `structured_text` content block provides the styling for a block of text content that features a title with an icon and subsequent paragraps of text. The text `content` can render markdown formatting. It takes the following required parameters:
+The `structured_text` content block provides the styling for a block of text content that features a title and subsequent paragraphs of text. The text `content` can render markdown formatting. It takes the following required parameters:
 
 ```yaml
 
 - type: structured_text
   structured_text:
     header: # Header text (i.e. "Who Owns Your Work?")
-    icon:
-      name: # Icon name (i.e. "icon-merge")
-      color: # Icon color (i.e. "blue")
     text:
       - content: # Text content here, including markdown formatting (i.e. "You do!...")
         type: # "large" or "small"
@@ -315,6 +312,16 @@ The `structured_text` content block provides the styling for a block of text con
 ```
 
 You can specify as many `text` blocks as you would like. Each `text` block consists of `content` and `type`.
+
+There is also an optional icon parameter for the `structured_text` content block. You can include it with the following:
+
+```yaml
+
+icon:
+  name: # Icon name (i.e. "icon-merge")
+  color: # Icon color (i.e. "blue")
+
+```
 
 ### Text
 

--- a/app/views/static/default_landing/partials/_structured_text.html.erb
+++ b/app/views/static/default_landing/partials/_structured_text.html.erb
@@ -1,11 +1,13 @@
 <%
     raise "Missing 'header' key in structured_text landing page block" unless local_assigns['header']
     raise "Missing 'text' key in structured_text landing page block" unless local_assigns['text']
-    raise "Missing icon 'name' key in structured_text landing page block" unless local_assigns['icon']['name']
-    raise "Missing icon 'color' key in structured_text landing page block" unless local_assigns['icon']['color']
+    raise "Missing 'icon color' key in structured_text landing page icon block" if (local_assigns['icon'] && local_assigns['icon']['color'].nil?)
+    raise "Missing 'icon name' key in structured_text landing page icon block" if (local_assigns['icon'] && local_assigns['icon']['name'].nil?)
 %>
 <h2 class="Vlt-title--icon" id="<%= local_assigns['header'].parameterize %>">
-    <svg class="Vlt-<%= local_assigns['icon']['color'] %>"><use xlink:href="/symbol/volta-icons.svg#Vlt-<%= local_assigns['icon']['name'] %>"></use></svg>
+    <% if local_assigns['icon'] %>
+        <svg class="Vlt-<%= local_assigns['icon']['color'] %>"><use xlink:href="/symbol/volta-icons.svg#Vlt-<%= local_assigns['icon']['name'] %>"></use></svg>
+    <% end %>
     <%= local_assigns['header'] %>
 </h2>
 <% local_assigns['text'] ||= [] %>

--- a/spec/views/static/default_landing/partials/_structured_text.html.erb_spec.rb
+++ b/spec/views/static/default_landing/partials/_structured_text.html.erb_spec.rb
@@ -19,7 +19,19 @@ RSpec.describe 'rendering _structured_text landing page partial' do
     expect(rendered).to include('Things here')
   end
 
-  it 'raises an error if icon color is not provided' do
+  it 'renders without an icon if an icon is not provided' do
+    render partial: '/static/default_landing/partials/structured_text.html.erb', locals: {
+      'header' => 'My header',
+      'text' => [
+        { 'type' => 'small', 'content' => 'Things here' },
+        { 'type' => 'large', 'content' => 'Large things here' },
+      ],
+    }
+
+    expect(rendered).to_not include('use xlink:href')
+  end
+
+  it 'raises an error if icon key is provided without icon color' do
     expect do
       render partial: '/static/default_landing/partials/structured_text.html.erb', locals: {
         'icon' => { 'name' => 'nexmo-circle' },
@@ -29,10 +41,10 @@ RSpec.describe 'rendering _structured_text landing page partial' do
           { 'type' => 'large', 'content' => 'Large things here' },
         ],
     }
-    end .to raise_error("Missing icon 'color' key in structured_text landing page block")
+    end .to raise_error("Missing 'icon color' key in structured_text landing page icon block")
   end
 
-  it 'raises an error if an icon name is not provided' do
+  it 'raises an error if icon key is provided without icon name' do
     expect do
       render partial: '/static/default_landing/partials/structured_text.html.erb', locals: {
         'icon' => { 'color' => 'blue' },
@@ -42,7 +54,7 @@ RSpec.describe 'rendering _structured_text landing page partial' do
           { 'type' => 'large', 'content' => 'Large things here' },
         ],
     }
-    end .to raise_error("Missing icon 'name' key in structured_text landing page block")
+    end .to raise_error("Missing 'icon name' key in structured_text landing page icon block")
   end
 
   it 'raises an error if a header is not provided' do


### PR DESCRIPTION
In this PR we refactor the `structured_text` landing page partial to allow for the `icon` parameter as an optional parameter. The reason for doing so is there are many common use cases for only wanting the format of the `structured_text` content block without any icons added. For example, the Migrate to Tropo page (developer.nexmo.com/migrate/tropo) presents us with one example of that. 
