### PR TITLE
Simplify ApplicationHelper#search_enabled?

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -7,9 +7,7 @@ COLLAPSIBLE = ['Messages API', 'Dispatch API', 'Messaging', 'SMS', 'Conversion A
 
 module ApplicationHelper
   def search_enabled?
-    return false unless defined? ALGOLIA_CONFIG
-    return false unless ENV['ALGOLIA_SEARCH_KEY']
-    true
+    defined?(ALGOLIA_CONFIG) && ENV['ALGOLIA_SEARCH_KEY']
   end
 
   def theme


### PR DESCRIPTION
~~ALGOLIA_CONFIG is only defined if ENV['ALGOLIA_SEARCH_KEY'] is set so the first line is redundant.~~ Double negation simplifies the boolean logic.
