### PR TITLE
Remove invalid null value from Websockets guide

### DIFF
--- a/_documentation/voice/voice-api/guides/websockets.md
+++ b/_documentation/voice/voice-api/guides/websockets.md
@@ -43,8 +43,7 @@ To instruct Nexmo to connect to a WebSocket your application server must return 
                         "city": "New York City"
                     },
                     "system_roles": [183493, 1038492, 22],
-                    "enable_auditing": false,
-                    "manager_id": null"
+                    "enable_auditing": false
                 }
            }
        ]

--- a/_examples/voice/guides/ncco-reference/connect/websocket-endpoint-connect.md
+++ b/_examples/voice/guides/ncco-reference/connect/websocket-endpoint-connect.md
@@ -29,8 +29,7 @@ menu_weight: 2
                 "city": "New York City"
             },
             "system_roles": [183493, 1038492, 22],
-            "enable_auditing": false,
-            "manager_id": null
+            "enable_auditing": false
         }
       }
     ]


### PR DESCRIPTION
## Description

Removing an invalid null value from the guide for Websockets

## Deploy Notes

Simple change of docs needed
