### PR TITLE
Refactored ScreenshotFilter to check if file exists

### DIFF
--- a/app/filters/screenshot_filter.rb
+++ b/app/filters/screenshot_filter.rb
@@ -2,8 +2,7 @@ class ScreenshotFilter < Banzai::Filter
   def call(input)
     input.gsub(/```screenshot(.+?)```/m) do |_s|
       config = YAML.safe_load($1)
-
-      if config['image']
+      if config['image'] && File.file?(config['image'])
         "![Screenshot](#{config['image'].gsub('public', '')})"
       else
         <<~HEREDOC

--- a/spec/filters/screenshot_filter_spec.rb
+++ b/spec/filters/screenshot_filter_spec.rb
@@ -2,9 +2,10 @@ require 'rails_helper'
 
 RSpec.describe ScreenshotFilter do
   it 'renders image markdown if image location is present in input' do
+    expect(File).to receive(:file?).and_return(true)
     input = <<~HEREDOC
       ```screenshot
-      image: /a/path/to/an/image.png
+      image: '/a/path/to/an/image.png'
       ```
     HEREDOC
 
@@ -25,6 +26,26 @@ RSpec.describe ScreenshotFilter do
   end
 
   it 'provides instructions if image location is missing' do
+    input = <<~HEREDOC
+      ```screenshot
+      image:
+      ```
+    HEREDOC
+
+    expected_output = <<~HEREDOC
+      ## Missing image
+      To fix this run:
+      ```
+      $ rake screenshots:update
+      ```
+    HEREDOC
+    # .chop to remove trailing \n from input
+    expect(described_class.call(input.chop)).to eql(expected_output)
+  end
+
+  it 'provides instructions if image cannot be found on disk' do
+    expect(File).not_to receive(:file?)
+
     input = <<~HEREDOC
       ```screenshot
       image:

--- a/spec/filters/screenshot_filter_spec.rb
+++ b/spec/filters/screenshot_filter_spec.rb
@@ -44,11 +44,11 @@ RSpec.describe ScreenshotFilter do
   end
 
   it 'provides instructions if image cannot be found on disk' do
-    expect(File).not_to receive(:file?)
+    expect(File).to receive(:file?).and_return(false)
 
     input = <<~HEREDOC
       ```screenshot
-      image:
+      image: '/a/path/to/an/image.png'
       ```
     HEREDOC
 


### PR DESCRIPTION
Presently, `ScreenshotFilter` does not check if the file provided by the user exists in the file system. In this PR, we add the functionality to check for the presence of the file. Additionally, the spec testing for the filter has been updated to mock both conditions: when the file exists and when it does not.
