### PR TITLE
Fix API reference links in footer

### DIFF
--- a/app/views/layouts/partials/_footer.html.erb
+++ b/app/views/layouts/partials/_footer.html.erb
@@ -15,8 +15,7 @@
       <a href="/api/voice">Voice</a>
       <a href="/api/verify">Verify</a>
       <a href="/api/number-insight">Number Insight</a>
-      <a href="/api#developer-api">Developer API</a>
-      <a href="/api#global-apis">Global APIs</a>
+      <a href="/api">All APIs</a>
     </div>
 
     <div>


### PR DESCRIPTION
## Description

When we updated the API reference page, we moved away from "developer APIs" and "global APIs" but there are still links in the footer that point to these, but the internal hyperlinks don't exist. Changed to just point to "All APIs" which also makes the footer columns the same length :)