### PR TITLE
Add spec for Tutorial.by_language method

### DIFF
--- a/spec/models/tutorial_spec.rb
+++ b/spec/models/tutorial_spec.rb
@@ -4,16 +4,16 @@ RSpec.describe Tutorial, type: :model do
   describe '.all' do
     it 'returns an array of Tutorials' do
       tutorials = Tutorial.all
-      expect(tutorials.class).to eq(Array)
-      expect(tutorials[0].class).to eq(Tutorial)
+      expect(tutorials).to be_an(Array)
+      expect(tutorials[0]).to be_a(Tutorial)
     end
   end
 
   describe '.by_product' do
     it 'returns only tutorials for the specified product type' do
       tutorials = Tutorial.by_product('messaging/sms')
-      expect(tutorials.class).to eq(Array)
-      expect(tutorials[0].class).to eq(Tutorial)
+      expect(tutorials).to be_an(Array)
+      expect(tutorials[0]).to be_a(Tutorial)
 
       tutorials.each do |tutorial|
         expect(tutorial.products).to include('messaging/sms')
@@ -40,7 +40,7 @@ RSpec.describe Tutorial, type: :model do
 
   describe '#body' do
     it 'returns a string' do
-      expect(Tutorial.all[0].body.class).to eq(String)
+      expect(Tutorial.all[0].body).to be_a(String)
     end
   end
 

--- a/spec/models/tutorial_spec.rb
+++ b/spec/models/tutorial_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe Tutorial, type: :model do
-  describe '#all' do
+  describe '.all' do
     it 'returns an array of Tutorials' do
       tutorials = Tutorial.all
       expect(tutorials.class).to eq(Array)
@@ -9,7 +9,7 @@ RSpec.describe Tutorial, type: :model do
     end
   end
 
-  describe '#by_product' do
+  describe '.by_product' do
     it 'returns only tutorials for the specified product type' do
       tutorials = Tutorial.by_product('messaging/sms')
       expect(tutorials.class).to eq(Array)

--- a/spec/models/tutorial_spec.rb
+++ b/spec/models/tutorial_spec.rb
@@ -26,6 +26,18 @@ RSpec.describe Tutorial, type: :model do
     end
   end
 
+  describe '.by_language' do
+    it 'returns only tutorials for the specified language' do
+      tutorials = Tutorial.by_language('Ruby')
+      expect(tutorials).to be_a(Array)
+      expect(tutorials).not_to be_empty
+
+      tutorials.each do |tutorial|
+        expect(tutorial.languages).to include('Ruby')
+      end
+    end
+  end
+
   describe '#body' do
     it 'returns a string' do
       expect(Tutorial.all[0].body.class).to eq(String)


### PR DESCRIPTION
Adds a spec for the Tutorial.by_language method to (increases coverage from 90% to 100%).

Fixes spec descriptions for class methods.

Updates existing specs to use be_a/be_an for readability and consistency.