### PR TITLE
Add spec for CodeLanguage model

### DIFF
--- a/app/models/code_language.rb
+++ b/app/models/code_language.rb
@@ -8,7 +8,8 @@ class CodeLanguage
   end
 
   def linkable?
-    @linkable || true
+    return true if @linkable.nil?
+    @linkable
   end
 
   def lexer

--- a/spec/models/code_language_spec.rb
+++ b/spec/models/code_language_spec.rb
@@ -1,0 +1,46 @@
+require 'rails_helper'
+
+RSpec.describe CodeLanguage, type: :model do
+  let(:language) { CodeLanguage.new }
+
+  describe '#weight' do
+    it 'returns a default value' do
+      expect(language.weight).to eq(999)
+    end
+  end
+
+  describe '#linkable?' do
+    it 'returns true' do
+      expect(language.linkable?).to eq(true)
+    end
+
+    context 'with the linkable attribute set to false' do
+      let(:language) { CodeLanguage.new(linkable: false) }
+
+      it 'returns true' do
+        expect(language.linkable?).to eq(true)
+      end
+    end
+  end
+
+  describe '#lexer' do
+    let(:language) { CodeLanguage.new(lexer: 'ruby') }
+
+    it 'returns a rouge lexer' do
+      expect(language.lexer).to eq(Rouge::Lexers::Ruby)
+    end
+  end
+
+  describe '#languages' do
+    let(:language) { CodeLanguage.new(languages: %w[swift objective_c]) }
+    let(:languages) { language.languages }
+
+    it 'returns an array of code languages' do
+      expect(languages).to be_an(Array)
+      expect(languages[0]).to be_a(CodeLanguage)
+      expect(languages[0].key).to eq('swift')
+      expect(languages[1]).to be_a(CodeLanguage)
+      expect(languages[1].key).to eq('objective_c')
+    end
+  end
+end

--- a/spec/models/code_language_spec.rb
+++ b/spec/models/code_language_spec.rb
@@ -17,8 +17,8 @@ RSpec.describe CodeLanguage, type: :model do
     context 'with the linkable attribute set to false' do
       let(:language) { CodeLanguage.new(linkable: false) }
 
-      it 'returns true' do
-        expect(language.linkable?).to eq(true)
+      it 'returns false' do
+        expect(language.linkable?).to eq(false)
       end
     end
   end


### PR DESCRIPTION
Adds specs for the CodeLanguage model (increases coverage from 80% to 100%).

The CodeLanguage#linkable? method is always returning true—if that's correct then the method and the attribute are redundant and could be removed; if not then that's a bug. The `linkable: false` lines in the config suggest the latter but I'm not 100% sure what the correct behaviour is meant to be.