### PR TITLE
For Verify, link to general guides URL and update redirect

### DIFF
--- a/app/views/static/_products.html.erb
+++ b/app/views/static/_products.html.erb
@@ -121,7 +121,7 @@
         <nav>
           <a href="/verify/overview"><svg class="Vlt-icon Vlt-icon--small Vlt-icon--text-bottom Vlt-indigo" aria-hidden="true">
               <use xlink:href="/symbol/volta-icons.svg#Vlt-icon-home" /></svg>Overview</a>
-          <a href="/verify/guides/verify-a-user"><svg class="Vlt-icon Vlt-icon--small Vlt-icon--text-bottom Vlt-indigo"
+          <a href="/verify/guides"><svg class="Vlt-icon Vlt-icon--small Vlt-icon--text-bottom Vlt-indigo"
               aria-hidden="true">
               <use xlink:href="/symbol/volta-icons.svg#Vlt-icon-books" /></svg>Guides</a>
           <a href="/verify/building-blocks"><svg class="Vlt-icon Vlt-icon--small Vlt-icon--text-bottom Vlt-indigo"

--- a/config/redirects.yml
+++ b/config/redirects.yml
@@ -90,7 +90,7 @@
 "/tutorials/smart-local-numbers": "/tutorials/local-numbers"
 "/verify": "/verify/overview"
 "/verify/api-reference": "/api/verify"
-"/verify/guides": "/verify/guides/verify-a-user"
+"/verify/guides": "/verify/guides/verification-events"
 "/verify/tutorial": "/verify/tutorials/passwordless-authentication"
 "/verify/building-blocks": "/verify/building-blocks/send-verify-request"
 "/voice": "/voice/overview"


### PR DESCRIPTION
## Description

Fixes #1501 - on the landing and documentation pages, the Guides link for Verify went to a 404 page. Now it goes to `/verify/guides` and that in turn redirects to the Verification Events guide.
