### PR TITLE
Add Background Color to Search Results Tab Focus

### DIFF
--- a/app/assets/stylesheets/layout/_search.scss
+++ b/app/assets/stylesheets/layout/_search.scss
@@ -61,7 +61,7 @@ $quick-search-width: 800px;
     }
 
     &:focus {
-      background-color: rgba(0,0,0.1);
+      background-color: rgba(0,0,0,0.1);
     }
 
     h6 {

--- a/app/assets/stylesheets/layout/_search.scss
+++ b/app/assets/stylesheets/layout/_search.scss
@@ -60,6 +60,10 @@ $quick-search-width: 800px;
       background: $grey-lighter;
     }
 
+    &:focus {
+      background-color: rgba(0,0,0.1);
+    }
+
     h6 {
       font-weight: 900;
     }


### PR DESCRIPTION
This PR responds to issue #1485. The highlighted search result is not readily apparent right now when using the tab key to move between them. This adds a more prominent highlighting to the result that is currently in focus.
