### PR TITLE
Add VBC extension endpoint

### DIFF
--- a/_documentation/voice/voice-api/guides/endpoints.md
+++ b/_documentation/voice/voice-api/guides/endpoints.md
@@ -39,3 +39,7 @@ An optional `headers` parameter can be passed containing a JSON object of key va
 ## CallerID
 
 For both `phone` and `sip` endpoint types, the `from` field *must* be a Nexmo Number associated with your account in e.164 format. This will then be used as the caller ID on the receiving phone. For SIP endpoints it will take the format `number@sip.nexmo.com`.
+
+## Vonage Business Cloud
+
+The `vbc` endpoint enables you to connect an inbound call on a Vonage Business Cloud (VBC) programmable number to the VBC extension you specify in the `extension` property of the endpoint.

--- a/_documentation/voice/voice-api/guides/ncco.md
+++ b/_documentation/voice/voice-api/guides/ncco.md
@@ -59,7 +59,7 @@ The actions you can use in an NCCO are:
 
 * [`record`](/voice/voice-api/ncco-reference#record) - all or part of a call
 * [`conversation`](/voice/voice-api/ncco-reference#conversation) - create a standard or hosted conversation
-* [`connect`](/voice/voice-api/ncco-reference#connect) - connect to a connectable endpoint such as a phone number
+* [`connect`](/voice/voice-api/ncco-reference#connect) - connect to a connectable endpoint such as a phone number or Vonage Business Cloud extension
 * [`talk`](/voice/voice-api/ncco-reference#talk) - send synthesized speech to a conversation
 * [`stream`](/voice/voice-api/ncco-reference#stream) - send audio files to a conversation
 * [`input`](/voice/voice-api/ncco-reference#input) - collect digits from the person you are calling, then process them
@@ -80,4 +80,3 @@ You can use these parameters to customize the NCCO you return to Nexmo. The foll
 ```tabbed_examples
 source: '_examples/voice/ncco/creating-a-custom-call-or-conversation-for-each-user'
 ```
-

--- a/_documentation/voice/voice-api/ncco-reference.md
+++ b/_documentation/voice/voice-api/ncco-reference.md
@@ -19,7 +19,7 @@ Action | Description | Synchronous
 -- | -- | --
 [record](#record) | All or part of a Call | No
 [conversation](#conversation) | A standard or hosted conference. | Yes
-[connect](#connect) | To a connectable endpoint such as a phone number. | Yes
+[connect](#connect) | To a connectable endpoint such as a phone number or VBC extension. | Yes
 [talk](#talk) | Send synthesized speech to a Conversation. | Yes, unless *bargeIn=true*
 [stream](#stream) | Send audio files to a Conversation. | Yes, unless *bargeIn=true*
 [input ](#input) | Collect digits from the person you are calling. | Yes
@@ -122,11 +122,11 @@ Option | Description | Required
 
 ## Connect
 
-You can use the `connect` action to connect a call to endpoints such as phone numbers.
+You can use the `connect` action to connect a call to endpoints such as phone numbers or a VBC extension.
 
 This action is synchronous, after a *connect* the next action in the NCCO stack is processed. A connect action ends when the endpoint you are calling is busy or unavailable. You ring endpoints sequentially by nesting connect actions.
 
-The following NCCO examples show how to configure different types of connections. 
+The following NCCO examples show how to configure different types of connections.
 
 ```tabbed_content
 source: '/_examples/voice/guides/ncco-reference/connect'
@@ -169,6 +169,12 @@ Value | Description
 -- | --
 `uri` | the SIP URI to the endpoint you are connecting to in the format `sip:rebekka@sip.example.com`.
 `headers` | `key` => `value` string pairs containing any metadata you need e.g. `{ "location": "New York City", "occupation": "developer" }`
+
+#### vbc - the Vonage Business Cloud (VBC) extension to connect to
+
+Value | Description
+-- | --
+`extension` | the VBC extension to connect the call to.
 
 ## Talk
 

--- a/_examples/voice/guides/ncco-reference/connect/vbc-extension-connect.md
+++ b/_examples/voice/guides/ncco-reference/connect/vbc-extension-connect.md
@@ -1,0 +1,23 @@
+---
+title: VBC Extension
+menu_weight: 6
+---
+
+```json
+[
+  {
+    "action": "talk",
+    "voiceName": "Russell",
+    "text": "Thank you for calling. Connecting you to extension."
+  },
+  {
+    "action": "connect",
+    "endpoint": [
+      {
+        "type": "vbc",
+        "extension": "111"
+      }
+    ]
+  }
+]
+```


### PR DESCRIPTION
## Description

There is a new `vbc` endpoint for the connect action which I have documented here. I need to revisit and add links to the VBC Number Programmability docs when they are merged.

