### PR TITLE
Rename #set_header methods

### DIFF
--- a/app/controllers/extend_controller.rb
+++ b/app/controllers/extend_controller.rb
@@ -1,5 +1,5 @@
 class ExtendController < ApplicationController
-  before_action :set_header
+  before_action :set_navigation
 
   def index
     document_paths = Dir.glob("#{Rails.root}/_extend/**/*.md")
@@ -38,7 +38,7 @@ class ExtendController < ApplicationController
 
   private
 
-  def set_header
+  def set_navigation
     @navigation = :extend
   end
 end

--- a/app/controllers/slack_controller.rb
+++ b/app/controllers/slack_controller.rb
@@ -1,5 +1,5 @@
 class SlackController < ApplicationController
-  before_action :set_header
+  before_action :set_navigation
   before_action :set_email, only: [:invite]
   before_action :validate_recapcha, only: [:invite]
   before_action :validate_email, only: [:invite]
@@ -36,7 +36,7 @@ class SlackController < ApplicationController
 
   private
 
-  def set_header
+  def set_navigation
     @navigation = :community
   end
 


### PR DESCRIPTION
This makes it clearer what the methods are doing and matches the set_header methods in other controllers (which makes it easier to look for commonalities to extract).