### PR TITLE
Extract ApplicationController#render_not_found method

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -18,7 +18,7 @@ class ApplicationController < ActionController::Base
       redirect_to redirect
     else
       NotFoundNotifier.notify(request)
-      render 'static/404', status: :not_found, formats: [:html]
+      render_not_found
     end
   end
 
@@ -60,5 +60,9 @@ class ApplicationController < ActionController::Base
   def set_feedback_author
     return unless cookies[:feedback_author_id]
     @feedback_author = Feedback::Author.select(:email).find_by(id: cookies[:feedback_author_id])
+  end
+
+  def render_not_found
+    render 'static/404', status: :not_found, formats: [:html]
   end
 end

--- a/app/controllers/careers_controller.rb
+++ b/app/controllers/careers_controller.rb
@@ -1,7 +1,5 @@
 class CareersController < ApplicationController
   def show
     @career = Career.visible_to(current_user).friendly.find(params[:id])
-
-    not_found unless @career
   end
 end

--- a/app/controllers/markdown_controller.rb
+++ b/app/controllers/markdown_controller.rb
@@ -33,7 +33,7 @@ class MarkdownController < ApplicationController
     if redirect
       redirect_to redirect
     else
-      render 'static/404', status: :not_found, formats: [:html]
+      render_not_found
     end
   end
 

--- a/app/controllers/static_controller.rb
+++ b/app/controllers/static_controller.rb
@@ -179,7 +179,7 @@ class StaticController < ApplicationController
         },
       ]
     else
-      return render 'static/404', status: :not_found, formats: [:html]
+      return render_not_found
     end
 
     @building_blocks = @blocks.map do |block|

--- a/app/controllers/task_controller.rb
+++ b/app/controllers/task_controller.rb
@@ -19,10 +19,6 @@ class TaskController < ApplicationController
     render layout: 'documentation'
   end
 
-  def not_found
-    render 'static/404', status: :not_found, formats: [:html]
-  end
-
   private
 
   def set_navigation
@@ -33,7 +29,7 @@ class TaskController < ApplicationController
 
   def set_task
     @task_name = params[:task_name]
-    return not_found unless @task_name
+    render_not_found unless @task_name
   end
 
   def set_task_step


### PR DESCRIPTION
Extracts an ApplicationController#render_not_found method (more DRY) and eliminates TaskController#not_found which isn't / shouldn't be a public action.

Also removes an unreachable call to #not_found in CareersController.