### PR TITLE
Fix SMS Demo tool for new allowed message length

### DIFF
--- a/_documentation/messaging/sms/guides/concatenation-and-encoding.md
+++ b/_documentation/messaging/sms/guides/concatenation-and-encoding.md
@@ -24,6 +24,8 @@ If you send a message that contains more than the maximum number of characters p
 
 This segmentation information tells the handset the number of message parts that make up the concatenated SMS and the position of each message part within it. When the handset has received all of the message parts, it presents them to the recipient as a single text.
 
+For more information, the Nexmo Knowledgebase has detailed information about [Multipart SMS](https://help.nexmo.com/hc/en-us/articles/204014833-How-is-a-Multipart-SMS-Constructed-).
+
 ## Encoding
 
 There are two main types of encoding that the Nexmo SMS API supports: `text` and `unicode`.

--- a/app/javascript/packs/Concatenation.jsx
+++ b/app/javascript/packs/Concatenation.jsx
@@ -52,7 +52,7 @@ class Concatenation extends React.Component {
     const shouldEncodeAs16Bit = this.shouldEncodeAs16Bit()
 
     const capacity = shouldEncodeAs16Bit ? 70 : 160
-    const capacityWithMeta = shouldEncodeAs16Bit ? 66 : 153
+    const capacityWithMeta = shouldEncodeAs16Bit ? 67 : 153
 
     var a = [stringArray.slice(0, capacity).join('')]
 


### PR DESCRIPTION
There was a recent change to the allowed length of SMS messages that are both unicode and multipart, gaining us one character. This PR updates the demo to reflect this change.

Fixes #1527 
