### PR TITLE
Update Java Code Snippets

### DIFF
--- a/_examples/concepts/sample-building-block/java.yml
+++ b/_examples/concepts/sample-building-block/java.yml
@@ -2,7 +2,7 @@
 title: Java
 language: java
 dependencies:
-    - 'com.nexmo:client:4.0.0'
+    - 'com.nexmo:client:4.1.0'
 code:
     source: .repos/nexmo/nexmo-java-code-snippets/src/main/java/com/nexmo/quickstart/voice/DtmfInput.java
     from_line: 35

--- a/_examples/messaging/sms/delivery-receipts/java.yml
+++ b/_examples/messaging/sms/delivery-receipts/java.yml
@@ -2,7 +2,7 @@
 title: Java
 language: java
 dependencies:
-    - 'com.nexmo:client:4.0.0'
+    - 'com.nexmo:client:4.1.0'
     - 'com.sparkjava:spark-core:2.7.2'
 code:
     source: .repos/nexmo/nexmo-java-code-snippets/src/main/java/com/nexmo/quickstart/sms/ReceiveDLR.java

--- a/_examples/messaging/sms/receiving-an-sms/java.yml
+++ b/_examples/messaging/sms/receiving-an-sms/java.yml
@@ -2,7 +2,7 @@
 title: Java
 language: java
 dependencies:
-    - 'com.nexmo:client:4.0.0'
+    - 'com.nexmo:client:4.1.0'
     - 'com.sparkjava:spark-core:2.7.2'
 code:
     source: .repos/nexmo/nexmo-java-code-snippets/src/main/java/com/nexmo/quickstart/sms/ReceiveSMS.java

--- a/_examples/messaging/sms/send-an-sms-with-unicode/java.yml
+++ b/_examples/messaging/sms/send-an-sms-with-unicode/java.yml
@@ -2,7 +2,7 @@
 title: Java
 language: java
 dependencies:
-    - 'com.nexmo:client:4.0.0'
+    - 'com.nexmo:client:4.1.0'
 code:
     source: .repos/nexmo/nexmo-java-code-snippets/src/main/java/com/nexmo/quickstart/sms/SendUnicodeMessage.java
     from_line: 43

--- a/_examples/messaging/sms/send-an-sms/java.yml
+++ b/_examples/messaging/sms/send-an-sms/java.yml
@@ -2,7 +2,7 @@
 title: Java
 language: java
 dependencies:
-    - 'com.nexmo:client:4.0.0'
+    - 'com.nexmo:client:4.1.0'
 code:
     source: .repos/nexmo/nexmo-java-code-snippets/src/main/java/com/nexmo/quickstart/sms/SendMessage.java
     from_line: 43

--- a/_examples/number-insight/advanced/java.yml
+++ b/_examples/number-insight/advanced/java.yml
@@ -2,7 +2,7 @@
 title: Java
 language: java
 dependencies:
-- 'com.nexmo:client:4.0.0'
+- 'com.nexmo:client:4.1.0'
 code:
   source: .repos/nexmo/nexmo-java-code-snippets/src/main/java/com/nexmo/quickstart/insight/AdvancedInsight.java
   from_line: 41

--- a/_examples/number-insight/standard/java.yml
+++ b/_examples/number-insight/standard/java.yml
@@ -2,7 +2,7 @@
 title: Java
 language: java
 dependencies:
-- 'com.nexmo:client:4.0.0'
+- 'com.nexmo:client:4.1.0'
 code:
   source: .repos/nexmo/nexmo-java-code-snippets/src/main/java/com/nexmo/quickstart/insight/StandardInsight.java
   from_line: 40

--- a/_examples/verify/cancel-verification-request/java.yml
+++ b/_examples/verify/cancel-verification-request/java.yml
@@ -2,7 +2,7 @@
 title: Java
 language: java
 dependencies:
-    - 'com.nexmo:client:4.0.0'
+    - 'com.nexmo:client:4.1.0'
 client:
     source: .repos/nexmo/nexmo-java-code-snippets/src/main/java/com/nexmo/quickstart/verify/CancelVerification.java
     from_line: 38

--- a/_examples/verify/send-verification-request/java.yml
+++ b/_examples/verify/send-verification-request/java.yml
@@ -2,7 +2,7 @@
 title: Java
 language: java
 dependencies:
-    - 'com.nexmo:client:4.0.0'
+    - 'com.nexmo:client:4.1.0'
 client:
     source: .repos/nexmo/nexmo-java-code-snippets/src/main/java/com/nexmo/quickstart/verify/StartVerification.java
     from_line: 40

--- a/_examples/verify/trigger-next-verification-process/java.yml
+++ b/_examples/verify/trigger-next-verification-process/java.yml
@@ -2,7 +2,7 @@
 title: Java
 language: java
 dependencies:
-    - 'com.nexmo:client:4.0.0'
+    - 'com.nexmo:client:4.1.0'
 client:
     source: .repos/nexmo/nexmo-java-code-snippets/src/main/java/com/nexmo/quickstart/verify/AdvanceVerification.java
     from_line: 38

--- a/_examples/voice/connect-an-inbound-call/java.yml
+++ b/_examples/voice/connect-an-inbound-call/java.yml
@@ -2,7 +2,7 @@
 title: Java
 language: java
 dependencies:
-    - 'com.nexmo:client:4.0.0'
+    - 'com.nexmo:client:4.1.0'
     - 'com.sparkjava:spark-core:2.7.2'
 code:
     source: .repos/nexmo/nexmo-java-code-snippets/src/main/java/com/nexmo/quickstart/voice/ConnectInboundCall.java

--- a/_examples/voice/connect-callers-to-a-conference/java.yml
+++ b/_examples/voice/connect-callers-to-a-conference/java.yml
@@ -2,7 +2,7 @@
 title: Java
 language: java
 dependencies:
-    - 'com.nexmo:client:4.0.0'
+    - 'com.nexmo:client:4.1.0'
     - 'com.sparkjava:spark-core:2.7.2'
 code:
     source: .repos/nexmo/nexmo-java-code-snippets/src/main/java/com/nexmo/quickstart/voice/ConferenceCall.java

--- a/_examples/voice/download-a-recording/java.yml
+++ b/_examples/voice/download-a-recording/java.yml
@@ -2,7 +2,7 @@
 title: Java
 language: java
 dependencies:
-    - 'com.nexmo:client:4.0.0'
+    - 'com.nexmo:client:4.1.0'
 code:
     source: .repos/nexmo/nexmo-java-code-snippets/src/main/java/com/nexmo/quickstart/voice/DownloadRecording.java
     from_line: 53

--- a/_examples/voice/earmuff-a-call/java.yml
+++ b/_examples/voice/earmuff-a-call/java.yml
@@ -2,7 +2,7 @@
 title: Java
 language: java
 dependencies:
-    - 'com.nexmo:client:4.0.0'
+    - 'com.nexmo:client:4.1.0'
 code:
     source: .repos/nexmo/nexmo-java-code-snippets/src/main/java/com/nexmo/quickstart/voice/EarmuffCall.java
     from_line: 40

--- a/_examples/voice/handle-user-input-with-dtmf/java.yml
+++ b/_examples/voice/handle-user-input-with-dtmf/java.yml
@@ -2,7 +2,7 @@
 title: Java
 language: java
 dependencies:
-    - 'com.nexmo:client:4.0.0'
+    - 'com.nexmo:client:4.1.0'
     - 'com.sparkjava:spark-core:2.7.2'
 code:
     source: .repos/nexmo/nexmo-java-code-snippets/src/main/java/com/nexmo/quickstart/voice/DtmfInput.java

--- a/_examples/voice/make-an-outbound-call-with-ncco/java.yml
+++ b/_examples/voice/make-an-outbound-call-with-ncco/java.yml
@@ -2,7 +2,7 @@
 title: Java
 language: java
 dependencies:
-    - 'com.nexmo:client:4.0.0'
+    - 'com.nexmo:client:4.1.0'
 code:
     source: .repos/nexmo/nexmo-java-code-snippets/src/main/java/com/nexmo/quickstart/voice/OutboundTextToSpeechWithNcco.java
     from_line: 26

--- a/_examples/voice/make-an-outbound-call-with-ncco/java.yml
+++ b/_examples/voice/make-an-outbound-call-with-ncco/java.yml
@@ -1,0 +1,16 @@
+---
+title: Java
+language: java
+dependencies:
+    - 'com.nexmo:client:4.0.0'
+code:
+    source: .repos/nexmo/nexmo-java-code-snippets/src/main/java/com/nexmo/quickstart/voice/OutboundTextToSpeechWithNcco.java
+    from_line: 26
+    to_line: 28
+client:
+    source: .repos/nexmo/nexmo-java-code-snippets/src/main/java/com/nexmo/quickstart/voice/OutboundTextToSpeechWithNcco.java
+    from_line: 18
+    to_line: 21
+run_command: java-ide
+file_name: OutboundTextToSpeechWithNcco.java
+unindent: true

--- a/_examples/voice/make-an-outbound-call/java.yml
+++ b/_examples/voice/make-an-outbound-call/java.yml
@@ -2,7 +2,7 @@
 title: Java
 language: java
 dependencies:
-    - 'com.nexmo:client:4.0.0'
+    - 'com.nexmo:client:4.1.0'
 code:
     source: .repos/nexmo/nexmo-java-code-snippets/src/main/java/com/nexmo/quickstart/voice/OutboundTextToSpeech.java
     from_line: 25

--- a/_examples/voice/mute-a-call/java.yml
+++ b/_examples/voice/mute-a-call/java.yml
@@ -2,7 +2,7 @@
 title: Java
 language: java
 dependencies:
-    - 'com.nexmo:client:4.0.0'
+    - 'com.nexmo:client:4.1.0'
 code:
     source: .repos/nexmo/nexmo-java-code-snippets/src/main/java/com/nexmo/quickstart/voice/MuteCall.java
     from_line: 40

--- a/_examples/voice/play-an-audio-stream-into-a-call/java.yml
+++ b/_examples/voice/play-an-audio-stream-into-a-call/java.yml
@@ -2,7 +2,7 @@
 title: Java
 language: java
 dependencies:
-    - 'com.nexmo:client:4.0.0'
+    - 'com.nexmo:client:4.1.0'
 code:
     source: .repos/nexmo/nexmo-java-code-snippets/src/main/java/com/nexmo/quickstart/voice/StreamAudioToCall.java
     from_line: 57

--- a/_examples/voice/play-dtmf-into-a-call/java.yml
+++ b/_examples/voice/play-dtmf-into-a-call/java.yml
@@ -2,7 +2,7 @@
 title: Java
 language: java
 dependencies:
-    - 'com.nexmo:client:4.0.0'
+    - 'com.nexmo:client:4.1.0'
 code:
     source: .repos/nexmo/nexmo-java-code-snippets/src/main/java/com/nexmo/quickstart/voice/SendDtmfToCall.java
     from_line: 56

--- a/_examples/voice/play-tts-into-a-call/java.yml
+++ b/_examples/voice/play-tts-into-a-call/java.yml
@@ -2,7 +2,7 @@
 title: Java
 language: java
 dependencies:
-    - 'com.nexmo:client:4.0.0'
+    - 'com.nexmo:client:4.1.0'
 code:
     source: .repos/nexmo/nexmo-java-code-snippets/src/main/java/com/nexmo/quickstart/voice/SendTalkToCall.java
     from_line: 33

--- a/_examples/voice/receive-an-inbound-call/java.yml
+++ b/_examples/voice/receive-an-inbound-call/java.yml
@@ -7,7 +7,7 @@ dependencies:
 code:
     source: .repos/nexmo/nexmo-java-code-snippets/src/main/java/com/nexmo/quickstart/voice/InboundCall.java
     from_line: 31
-    to_line: 53
+    to_line: 55
 run_command: java-ide
 file_name: InboundCall.java
 unindent: true

--- a/_examples/voice/receive-an-inbound-call/java.yml
+++ b/_examples/voice/receive-an-inbound-call/java.yml
@@ -2,7 +2,7 @@
 title: Java
 language: java
 dependencies:
-    - 'com.nexmo:client:4.0.0'
+    - 'com.nexmo:client:4.1.0'
     - 'com.sparkjava:spark-core:2.7.2'
 code:
     source: .repos/nexmo/nexmo-java-code-snippets/src/main/java/com/nexmo/quickstart/voice/InboundCall.java

--- a/_examples/voice/record-a-call-with-split-audio/java.yml
+++ b/_examples/voice/record-a-call-with-split-audio/java.yml
@@ -2,7 +2,7 @@
 title: Java
 language: java
 dependencies:
-    - 'com.nexmo:client:4.0.1'
+    - 'com.nexmo:client:4.1.0'
     - 'com.sparkjava:spark-core:2.7.2'
 code:
     source: .repos/nexmo/nexmo-java-code-snippets/src/main/java/com/nexmo/quickstart/voice/RecordCallSplitAudio.java

--- a/_examples/voice/record-a-call/java.yml
+++ b/_examples/voice/record-a-call/java.yml
@@ -2,7 +2,7 @@
 title: Java
 language: java
 dependencies:
-    - 'com.nexmo:client:4.0.0'
+    - 'com.nexmo:client:4.1.0'
     - 'com.sparkjava:spark-core:2.7.2'
 code:
     source: .repos/nexmo/nexmo-java-code-snippets/src/main/java/com/nexmo/quickstart/voice/RecordCall.java

--- a/_examples/voice/record-a-conversation/java.yml
+++ b/_examples/voice/record-a-conversation/java.yml
@@ -2,7 +2,7 @@
 title: Java
 language: java
 dependencies:
-    - 'com.nexmo:client:4.0.0'
+    - 'com.nexmo:client:4.1.0'
     - 'com.sparkjava:spark-core:2.7.2'
 code:
     source: .repos/nexmo/nexmo-java-code-snippets/src/main/java/com/nexmo/quickstart/voice/RecordConversation.java

--- a/_examples/voice/record-a-message/java.yml
+++ b/_examples/voice/record-a-message/java.yml
@@ -2,7 +2,7 @@
 title: Java
 language: java
 dependencies:
-    - 'com.nexmo:client:4.0.0'
+    - 'com.nexmo:client:4.1.0'
     - 'com.sparkjava:spark-core:2.7.2'
 code:
     source: .repos/nexmo/nexmo-java-code-snippets/src/main/java/com/nexmo/quickstart/voice/RecordMessage.java

--- a/_examples/voice/retrieve-info-for-a-call/java.yml
+++ b/_examples/voice/retrieve-info-for-a-call/java.yml
@@ -2,7 +2,7 @@
 title: Java
 language: java
 dependencies:
-    - 'com.nexmo:client:4.0.0'
+    - 'com.nexmo:client:4.1.0'
 code:
     source: .repos/nexmo/nexmo-java-code-snippets/src/main/java/com/nexmo/quickstart/voice/RetrieveCallInfo.java
     from_line: 40

--- a/_examples/voice/retrieve-info-for-all-calls/java.yml
+++ b/_examples/voice/retrieve-info-for-all-calls/java.yml
@@ -2,7 +2,7 @@
 title: Java
 language: java
 dependencies:
-    - 'com.nexmo:client:4.0.0'
+    - 'com.nexmo:client:4.1.0'
 code:
     source: .repos/nexmo/nexmo-java-code-snippets/src/main/java/com/nexmo/quickstart/voice/RetrieveInfoForAllCalls.java
     from_line: 27

--- a/_examples/voice/transfer-a-call/java.yml
+++ b/_examples/voice/transfer-a-call/java.yml
@@ -2,7 +2,7 @@
 title: Java
 language: java
 dependencies:
-    - 'com.nexmo:client:4.0.0'
+    - 'com.nexmo:client:4.1.0'
 code:
     source: .repos/nexmo/nexmo-java-code-snippets/src/main/java/com/nexmo/quickstart/voice/TransferCall.java
     from_line: 41

--- a/app/services/building_block_renderer/java.rb
+++ b/app/services/building_block_renderer/java.rb
@@ -9,7 +9,7 @@ module BuildingBlockRenderer
     end
 
     def self.run_command(_command, filename, file_path)
-      package = file_path.gsub('.repos/nexmo-community/nexmo-java-quickstart/src/main/java/', '').tr('/', '.').gsub(filename, '')
+      package = file_path.gsub('.repos/nexmo/nexmo-java-code-snippets/src/main/java/', '').tr('/', '.').gsub(filename, '')
 
       <<~HEREDOC
         ## Run your code

--- a/app/views/contribute/structure/guides/building-blocks.md
+++ b/app/views/contribute/structure/guides/building-blocks.md
@@ -101,7 +101,7 @@ The options available in these config files combine to a very consistent output 
 title: Java
 language: java
 dependencies:
-    - 'com.nexmo:client:4.0.0'
+    - 'com.nexmo:client:4.1.0'
 code:
     source: .repos/nexmo/nexmo-java-code-snippets/src/main/java/com/nexmo/quickstart/voice/TransferCall.java
     from_line: 42


### PR DESCRIPTION
## Description

- Update Java Client Library from 4.0.0 to 4.1.0
- Update Java Code Snippets Repository
- Update Java Code Snippets to use new static builder method instead of class instantiation.
- Added making call with NCCO example.
- Fixed Java Building Block rendering so that it's removing the correct repository information when showing how to run the code example.

## Deploy Notes

Notes regarding deployment the contained body of work. These should note any db migrations, etc.
