### PR TITLE
Fix package name error in java code snippets

### DIFF
--- a/app/services/building_block_renderer/java.rb
+++ b/app/services/building_block_renderer/java.rb
@@ -9,7 +9,7 @@ module BuildingBlockRenderer
     end
 
     def self.run_command(_command, filename, file_path)
-      package = file_path.gsub('.repos/nexmo-community/nexmo-java-quickstart/src/main/java/', '').tr('/', '.').gsub(filename, '')
+      package = file_path.gsub('.repos/nexmo/nexmo-java-code-snippets/src/main/java/', '').tr('/', '.').gsub(filename, '')
 
       <<~HEREDOC
         ## Run your code


### PR DESCRIPTION
## Description

After the building block repo name changes the java examples don't render the "Run your code" package/file names correctly:

[Example](https://files.slack.com/files-pri/T02NNHD8S-FH42V12UE/image.png)

## Deploy Notes

Test [in sample app](https://nexmo-developer-pr-1563.herokuapp.com/): select a couple of java code snippets and check that each renders the package name correctly in both the text and `gradle` command.
