### PR TITLE
Fix incorrect formatting of array elements as labels

### DIFF
--- a/app/filters/label_filter.rb
+++ b/app/filters/label_filter.rb
@@ -1,7 +1,7 @@
 class LabelFilter < Banzai::Filter
   def call(input)
     return input if options[:disable_label_filter]
-    input.gsub(/\[([a-zA-Z0-9\s:\-\.]+)\]/) do |_s|
+    input.gsub(/\s\[([a-zA-Z0-9\s:\-\.]+)\]/) do |_s|
       "<span class='Vlt-badge #{class_name($1)}'>#{$1}</span> "
     end
   end

--- a/app/filters/label_filter.rb
+++ b/app/filters/label_filter.rb
@@ -1,7 +1,7 @@
 class LabelFilter < Banzai::Filter
   def call(input)
     return input if options[:disable_label_filter]
-    input.gsub(/\s\[([a-zA-Z0-9\s:\-\.]+)\]/) do |_s|
+    input.gsub(/\[([a-zA-Z0-9\s:\-\.]{2,})\]/) do |_s|
       "<span class='Vlt-badge #{class_name($1)}'>#{$1}</span> "
     end
   end


### PR DESCRIPTION
## Description

This is an attempt to fix the issue shown [here](https://files.slack.com/files-pri/T02NNHD8S-FH0UAHUD6/send-sms-python-bad-label.png) (in the as-yet uncommitted [PR 1565](https://github.com/Nexmo/nexmo-developer/pull/1565)), where array elements are being rendered as labels. I'm just checking for the presence of a whitespace character before the square bracket before it is considered to be a label.

## Deploy Notes

I've checked for `[POST]`, `[GET}`, `[200]` etc and all appears to be okay, but till need further testing in the [review app](https://nexmo-developer-pr-1566.herokuapp.com/).
