### PR TITLE
Redirect issue from 'building-blocks' to 'code-snippets' solution

### DIFF
--- a/app/controllers/markdown_controller.rb
+++ b/app/controllers/markdown_controller.rb
@@ -5,6 +5,9 @@ class MarkdownController < ApplicationController
   before_action :set_namespace
 
   def show
+    if params['document'].include?('building-blocks')
+      params['document'].sub! 'building-blocks', 'code-snippets'
+    end
     redirect = Redirector.find(request)
     return redirect_to redirect if redirect
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -97,6 +97,7 @@ Rails.application.routes.draw do
 
   get '/:product/*document(/:code_language)', to: 'markdown#show', constraints: DocumentationConstraint.documentation
 
+  get '/:product/building-blocks(/:code_language)', to: redirect('/:product/code-snippets(/:code_language)'), constraints: DocumentationConstraint.documentation
   get '*unmatched_route', to: 'application#not_found'
 
   root 'static#landing'


### PR DESCRIPTION
Check in controller if `building-blocks` is present in the URL parameters, and, if so, replace it with `code-snippets`.
