### PR TITLE
Fix Account/Secret Management redirect

### DIFF
--- a/app/constraints/open_api_constraint.rb
+++ b/app/constraints/open_api_constraint.rb
@@ -26,6 +26,10 @@ class OpenApiConstraint
     { definition: Regexp.new(OPEN_API_PRODUCTS.join('|')) }
   end
 
+  def self.products_with_code_language
+    products.merge(DocumentationConstraint.code_language)
+  end
+
   def self.find_all_versions(name)
     # Remove the .v2 etc if needed
     name = name.gsub(/(\.v\d+)/, '')

--- a/config/redirects.yml
+++ b/config/redirects.yml
@@ -21,7 +21,7 @@
 "/account/api-reference": "/api/account"
 "/voice/voice-api": "/voice/voice-api/overview"
 "/api/voice/ncco": "/voice/voice-api/ncco-reference"
-"/api/account/secret-management": "/api/account"
+"/api/account/secret-management": "/api/account#secret-management"
 "/api/developer": "/api/developer/numbers"
 "/api/developer/account": "/api/account"
 "/api/messages": "/api/developer/messages"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -83,7 +83,7 @@ Rails.application.routes.draw do
     request['definition'] == 'verify' && request['code_language'] == 'templates'
   }
 
-  get '/api/*definition(/:code_language)', to: 'open_api#show', as: 'open_api', constraints: OpenApiConstraint.products
+  get '/api/*definition(/:code_language)', to: 'open_api#show', as: 'open_api', constraints: OpenApiConstraint.products_with_code_language
   get '/api/*document(/:code_language)', to: 'api#show', constraints: DocumentationConstraint.code_language
 
   get '/(:product)/task/(:task_name)(/*task_step)(/:code_language)', to: 'task#index', constraints: DocumentationConstraint.documentation


### PR DESCRIPTION
## Description

https://developer.nexmo.com/api/account/secret-management currently throws an error as `secret-management` is detected as a code language. This PR makes the route stricter by only accepting code languages that we know about

This means that the `code_language` filter succeeds, allowing NDP to get to the redirect filter and redirect as intended

## Deploy Notes

N/A