### PR TITLE
Fix api-errors page, add smoke test

### DIFF
--- a/app/controllers/api_errors_controller.rb
+++ b/app/controllers/api_errors_controller.rb
@@ -1,5 +1,6 @@
 class ApiErrorsController < ApplicationController
   before_action :error_config
+  before_action :validate_subapi
 
   def index
     @errors_title = 'Generic Errors'
@@ -49,5 +50,19 @@ class ApiErrorsController < ApplicationController
 
   def error_config
     @error_config ||= YAML.load_file("#{Rails.root}/config/api-errors.yml")
+  end
+
+  def validate_subapi
+    # If there is no subapi specified, everything is fine
+    return unless params[:subapi]
+
+    # We used to have some OAS documents that have since been merged in to the top
+    # level OAS documents, but we still need to support the old URLs
+    # e.g. account/secret-management
+    allowed_subapis = {
+      'account' => ['secret-management'],
+    }
+
+    render_not_found unless allowed_subapis[params[:definition]]&.include? params[:subapi]
   end
 end

--- a/config/api-errors.yml
+++ b/config/api-errors.yml
@@ -4,8 +4,8 @@ products:
     hide_rfc7807_header: true
   redact:
     title: Redact API
-  account/secret-management:
-    title: Secret Rotation API
+  account:
+    title: Account API
   messages-olympus:
     title: Messages API
     hide_rfc7807_header: true

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -73,7 +73,7 @@ Rails.application.routes.draw do
 
   get '/api-errors', to: 'api_errors#index'
   get '/api-errors/generic/:id', to: 'api_errors#show'
-  get '/api-errors/*definition', to: 'api_errors#index_scoped', as: 'api_errors_scoped', constraints: OpenApiConstraint.products
+  get '/api-errors/:definition(/*subapi)', to: 'api_errors#index_scoped', as: 'api_errors_scoped', constraints: OpenApiConstraint.products
   get '/api-errors/*definition/:id', to: 'api_errors#show', constraints: OpenApiConstraint.products
 
   get '/api', to: 'api#index'

--- a/spec/smoke_spec.rb
+++ b/spec/smoke_spec.rb
@@ -121,4 +121,9 @@ RSpec.describe 'Smoke Tests', type: :request do
     get '/migrate/tropo/sms'
     expect(response.body).to include('Convert your SMS code from Tropo to Nexmo')
   end
+
+  it '/api-errors contains the expected text' do
+    get '/api-errors'
+    expect(response.body).to include('When a Nexmo API returns an error, for instance, if your account has no credit')
+  end
 end


### PR DESCRIPTION
## Description

The `api-errors` page isn't rendering. This PR fixes the issue and ensures that the old URLs still work for secret management (redirected to `/account`)

## Deploy Notes

N/A
