### PR TITLE
Create Nexmo application with VBC capability

### DIFF
--- a/_documentation/vonage-business-cloud/number-programmability/guides/create-voice-application.md
+++ b/_documentation/vonage-business-cloud/number-programmability/guides/create-voice-application.md
@@ -10,13 +10,17 @@ Every Number Programmability service application that you build must be associat
 
 > **Note**: To avoid confusion, `Application` here refers to the Nexmo Application. The application you are building will be referred to as "application".
 
-A Nexmo Application stores configuration information such as details of the programmable numbers and webhook callback URLs that your application uses. To make your VBC programmability service calls zero-rated in Nexmo, you must create an Application with the `vbc` capability.
+A Nexmo Application stores configuration information such as details of the programmable numbers and webhook callback URLs that your application uses. To make your VBC programmability service calls zero-rated in Nexmo, you must create an Application with the `vbc` and `voice` capabilities, using the [Nexmo Application API](https://developer.nexmo.com/api/application.v2).
 
-## Creating a Nexmo Voice Application with the Application API
+## Using the Application API
 
-> **Note**: The `vbc` capability is only available in [version 2 of the Nexmo Application API](https://developer.nexmo.com/api/application.v2). The [Nexmo CLI](https://github.com/Nexmo/nexmo-cli) utility and [Developer Dashboard](https://dashboard.nexmo.com/voice/create-application) use version 1, therefore you cannot use them for this purpose.
+To create a Nexmo Application for working with the Number Programmability service, issue the `curl` command shown below, replacing `NEXMO_API_KEY` and `NEXMO_API_SECRET` with your Nexmo API key and secret respectively. You can find this information in the [Nexmo Developer dashboard](https://dashboard.nexmo.com/getting-started-guide).
 
-To create a Nexmo Application with the `vbc` capability, issue the following `curl` command, replacing `NEXMO_API_KEY` and `NEXMO_API_SECRET` with your Nexmo API key and secret respectively. You can find this information in the [Nexmo Developer dashboard](https://dashboard.nexmo.com/getting-started-guide).
+The two URLs you provide refer to the webhook endpoints that your application will expose to Nexmo's servers:
+
+* The first is the webhook that Nexmo's APIs will make a request to when a call is received on your VBC programmable number.
+* The second is where Nexmo's APIs will post details about events that your application might be interested in - such as a call being answered or terminated.
+
 
 ```
 curl -X POST \
@@ -25,7 +29,21 @@ curl -X POST \
   -H 'Content-Type: application/json' \
   -d '{
     "name": "My Nexmo VBC Application",
-    "capabilities": {"vbc": {} }
+    "capabilities": {
+      "vbc": {},
+      "voice": {
+        "webhooks": {
+          "answer_url": {
+            "address": "https://example.com/webhooks/answer",
+            "http_method": "POST"
+          },
+          "event_url": {
+            "address": "https://example.com/webhooks/event",
+            "http_method": "POST"
+          }
+        }
+      } 
+	  }
   }'
 ```
 
@@ -33,22 +51,34 @@ The response is a JSON object containing the Nexmo Application `id` that you wil
 
 ```
 {
-    "id": "27aa0583-7246-4822-aabb-17b03c25d52e",
-    "name": "My Nexmo VBC Application",
-    "keys": {
-        "private_key": "-----BEGIN PRIVATE KEY-----\nMIIEvAIBADANBgkq...
-        -----END PRIVATE KEY-----\n",
-        "public_key": "-----BEGIN PUBLIC_KEY-----\nMIIBIjANBgkqh...
-        -----END PUBLIC KEY-----\n"
-    },
-    "capabilities": {
-        "vbc": {}
-    },
-    "_links": {
-        "self": {
-            "href": "/v2/applications/27aa0583-7246-4822-aabb-17b03c25d52e"
+  "id": "27aa0583-7246-4822-aabb-17b03c25d52e",
+  "name": "My Nexmo VBC Application",
+  "keys": {
+    "private_key": "-----BEGIN PRIVATE KEY-----\nMIIEvAIBADANBgkq...
+    -----END PRIVATE KEY-----\n",
+    "public_key": "-----BEGIN PUBLIC_KEY-----\nMIIBIjANBgkqh...
+    -----END PUBLIC KEY-----\n"
+  },
+  "capabilities": {
+    "voice": {
+      "webhooks": {
+        "event_url": {
+            "address": "https://example.com/webhooks/event",
+            "http_method": "POST"
+        },
+        "answer_url": {
+            "address": "https://example.com/webhooks/answer",
+            "http_method": "POST"
         }
+      }
+    },
+    "vbc": {}
+  },
+  "_links": {
+    "self": {
+      "href": "/v2/applications/27aa0583-7246-4822-aabb-17b03c25d52e"
     }
+  }
 }
 ```
 

--- a/_documentation/vonage-business-cloud/number-programmability/guides/create-voice-application.md
+++ b/_documentation/vonage-business-cloud/number-programmability/guides/create-voice-application.md
@@ -1,48 +1,55 @@
 ---
-title: Create a Voice API application
-description: The application stores security and configuration information for your interaction with the API.
+title: Create a Nexmo Voice application
+description: The application stores security and configuration information for your interaction with the Voice API.
 navigation_weight: 2
 ---
 
-# Create a Nexmo Voice API Application
+# Create a Nexmo Application
 
 Every Number Programmability service application that you build must be associated with a Nexmo Voice Application.
 
-> **Note**: To avoid confusion, `Application` here refers to the Nexmo Voice Application. The application you are building will be referred to as "application".
+> **Note**: To avoid confusion, `Application` here refers to the Nexmo Application. The application you are building will be referred to as "application".
 
-A Nexmo Voice Application stores configuration information such as details of the programmable numbers and webhook callback URLs that your application uses.
+A Nexmo Application stores configuration information such as details of the programmable numbers and webhook callback URLs that your application uses. To make your VBC programmability service calls zero-rated in Nexmo, you must create an Application with the `vbc` capability.
 
-You can create Nexmo Voice Applications by any of the following methods:
+## Creating a Nexmo Voice Application with the Application API
 
-* Using the [Nexmo Developer Dashboard](https://dashboard.nexmo.com/voice/create-application).
-* Using the [Nexmo CLI](https://github.com/Nexmo/nexmo-cli).
-* Programmatically, using the [Nexmo Application API](/api/application.v2).
+> **Note**: The `vbc` capability is only available in [version 2 of the Nexmo Application API](https://developer.nexmo.com/api/application.v2). The [Nexmo CLI](https://github.com/Nexmo/nexmo-cli) utility and [Developer Dashboard](https://dashboard.nexmo.com/voice/create-application) use version 1, therefore you cannot use them for this purpose.
 
-## Using the Nexmo CLI
+To create a Nexmo Application with the `vbc` capability, issue the following `curl` command, replacing `NEXMO_API_KEY` and `NEXMO_API_SECRET` with your Nexmo API key and secret respectively. You can find this information in the [Nexmo Developer dashboard](https://dashboard.nexmo.com/getting-started-guide).
 
-In this example, we'll create a Voice Application using the Nexmo CLI:
+```
+curl -X POST \
+  https://api.nexmo.com/v2/applications \
+  -H 'Authorization: Basic base64($NEXMO_API_KEY:$NEXMO_API_SECRET' \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "name": "My Nexmo VBC Application",
+    "capabilities": {"vbc": {} }
+  }'
+```
 
-1. If you don't already have one, [create a Nexmo account](https://dashboard.nexmo.com/sign-up).
+The response is a JSON object containing the Nexmo Application `id` that you will use to interact with the Nexmo Voice API.
 
-2. Use [npm](https://www.npmjs.com/) to install and setup the Nexmo CLI, using the API key and secret from your [Nexmo Developer Dashboard](https://dashboard.nexmo.com/getting-started-guide):
+```
+{
+    "id": "27aa0583-7246-4822-aabb-17b03c25d52e",
+    "name": "My Nexmo VBC Application",
+    "keys": {
+        "private_key": "-----BEGIN PRIVATE KEY-----\nMIIEvAIBADANBgkq...
+        -----END PRIVATE KEY-----\n",
+        "public_key": "-----BEGIN PUBLIC_KEY-----\nMIIBIjANBgkqh...
+        -----END PUBLIC KEY-----\n"
+    },
+    "capabilities": {
+        "vbc": {}
+    },
+    "_links": {
+        "self": {
+            "href": "/v2/applications/27aa0583-7246-4822-aabb-17b03c25d52e"
+        }
+    }
+}
+```
 
-    ```sh
-    $ npm install nexmo-cli -g
-    $ nexmo setup <api_key> <api_secret>
-    ```
-3. Execute the following command in your application directory:
-
-    ```sh
-    $ nexmo app:create "NumberProgrammabilityApp" http://example.com/webhooks/answer http://example.com/webhooks/event  --keyfile private.key
-    ```
-    The two URLs you provide refer to the webhook endpoints that your application will expose to Nexmo's servers:
-    * The first is the webhook that Nexmo's APIs will make a request to when a call is received on your VBC programmable number.
-    * The second is where Nexmo's APIs will post details about events that your application might be interested in - such as a call being answered or terminated.
-
-    You can [change the webhook URLs](https://github.com/Nexmo/nexmo-cli#update-an-application) when you know the exact endpoints, so if you don't have this information yet leave them as `http://example.com`.
-
-    The above command also stores your private key in the file named `private.key` in the directory that you executed it in.
-
-    Make a note of the `application_id` that this command creates. You can also find this in your [Nexmo Developer Dashboard](https://dashboard.nexmo.com/voice/your-applications).
-
-> The next step is to [provision the Number Programmability service](/vonage-business-cloud/number-programmability/guides/provision-nps) using the Nexmo Voice API `application_id`.
+> The next step is to [provision the Number Programmability service](/vonage-business-cloud/number-programmability/guides/provision-nps) using the Nexmo Application `id`.


### PR DESCRIPTION
## Description

Replaces the existing description of creating a Nexmo Application for VBC Number Programmability. You must enable the VBC capability for number programmability calls to be zero-rated in Nexmo. This is only available in version 2 of the Application API, which the Nexmo CLI and Dashboard do not yet use.
