### PR TITLE
Add Google Analytics ownership verification tag

### DIFF
--- a/app/views/layouts/partials/_head.html.erb
+++ b/app/views/layouts/partials/_head.html.erb
@@ -3,6 +3,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
   <title><%= title %></title>
+  <meta name="google-site-verification" content="_DNZpugW9Fl4BUMbPsepvc_2McwbRvNBHHuI99MZH7c" />
 
   <% if @frontmatter && @frontmatter['description'] %>
     <meta name="description" content="<%= @frontmatter['description'] %>">


### PR DESCRIPTION
## Description

To capture keyword search history we need to add Google Search Console, which requires proof of domain ownership. This meta tag is enough to prove it to Google

## Deploy Notes

N/A