### PR TITLE
Fix OAS endpoint order rendering when no tag provided

### DIFF
--- a/app/controllers/open_api_controller.rb
+++ b/app/controllers/open_api_controller.rb
@@ -58,7 +58,7 @@ class OpenApiController < ApplicationController
     # For now we only use the first tag in the list as an equivalent for the old x-group functionality
     @groups = @definition.endpoints.group_by do |endpoint|
       next nil unless tags
-      endpoint.raw['tags'].first
+      endpoint.raw['tags']&.first
     end
 
     # We want to use the order in which the tags are defined in the definition, so iterate over the tags
@@ -70,7 +70,7 @@ class OpenApiController < ApplicationController
 
     # Sort by the order in which they're defined in the definition
     @groups = @groups.sort_by do |name, _|
-      return 999 if name.nil?
+      next -1 if name.nil?
       ordering[name.capitalize] || 999
     end
   end


### PR DESCRIPTION
## Description

This PR fixes two issues. Firstly, when an OAS document contains tags but an endpoint does not it currently errors. This PR prevents that error.

In addition, the ordering logic was wrong (used `return` rather than `next`, and put non-tagged endpoints at the end rather than the beginning). This is also fixed

## Deploy Notes

N/A
