### PR TITLE
Fix account code snippet rendering

### DIFF
--- a/_documentation/account/code-snippets/account-balance.md
+++ b/_documentation/account/code-snippets/account-balance.md
@@ -7,7 +7,7 @@ navigation_weight: 1
 
 You can check the balance of your Nexmo account at any time by making an API request and receiving the balance of your account in the response.
 
-```building_blocks
+```code_snippets
 source: _examples/account/get-balance
 ```
 

--- a/_documentation/account/code-snippets/configure-account.md
+++ b/_documentation/account/code-snippets/configure-account.md
@@ -15,7 +15,7 @@ Key |	Description
 -- | --
 `SMS_CALLBACK_URL` | The publicly-accessible URL that Nexmo should send information to when your Nexmo number receives an SMS
 
-```building_blocks
+```code_snippets
 source: _examples/account/configure-account
 ```
 

--- a/_documentation/account/code-snippets/create-a-secret.md
+++ b/_documentation/account/code-snippets/create-a-secret.md
@@ -15,6 +15,6 @@ New API secrets must meet the following rules:
 * Minimum 1 upper case character
 * Minimum 1 digit
 
-```building_blocks
+```code_snippets
 source: _examples/account/secret-management/create-a-secret
 ```

--- a/_documentation/account/code-snippets/fetch-a-secret.md
+++ b/_documentation/account/code-snippets/fetch-a-secret.md
@@ -12,6 +12,6 @@ Key | Description
  -- | --
 `NEXMO_SECRET_ID` | The ID of the secret to delete.
 
-```building_blocks
+```code_snippets
 source: _examples/account/secret-management/fetch-a-secret
 ```

--- a/_documentation/account/code-snippets/list-all-secrets.md
+++ b/_documentation/account/code-snippets/list-all-secrets.md
@@ -8,6 +8,6 @@ navigation_weight: 3
 This will return all secrets, along with their `id` and `created_at` time. The
 value of the secret will never be shown
 
-```building_blocks
+```code_snippets
 source: _examples/account/secret-management/list-all-secrets
 ```

--- a/_documentation/account/code-snippets/revoke-a-secret.md
+++ b/_documentation/account/code-snippets/revoke-a-secret.md
@@ -13,6 +13,6 @@ Key | Description
  -- | --
 `NEXMO_SECRET_ID` | The ID of the secret to delete.
 
-```building_blocks
+```code_snippets
 source: _examples/account/secret-management/revoke-a-secret
 ```


### PR DESCRIPTION
## Description

The Account API code snippets were not being rendered properly because they used `building_blocks` instead of `code_snippets`.

Review app: https://nexmo-developer-pr-1601.herokuapp.com/
