### PR TITLE
NCCO connect guide | updated terminology for app

### DIFF
--- a/_documentation/voice/voice-api/ncco-reference.md
+++ b/_documentation/voice/voice-api/ncco-reference.md
@@ -156,11 +156,11 @@ Value | Description
 `dtmfAnswer` | Set the digits that are sent to the user as soon as the Call is answered. The * and # digits are respected. You create pauses using p. Each pause is 500ms.
 `onAnswer` | An object containing a `url` key. The URL serves an NCCO to execute in the connected number before the call is joined to your existing conversation
 
-#### app - Connect the call to an IP leg
+#### app - Connect the call to an app
 
 Value | Description
 -- | --
-`user` | the username of the member to connect. This username must have been [added as a user](/api/conversation#createUser)
+`user` | the username of the user to connect to. This username must have been [added as a user](/api/conversation#createUser)
 
 #### Websocket - the websocket to connect to
 


### PR DESCRIPTION
we should not use the term 'ip' externally. the leg type: app (both in the code and in the docs). 
no need to mention 'legs' here as well. we connect TO users VIA legs(legs is the means). 

can either use: application or app
i used app here so that people dont get confudes with the concept of Nexmo application :/

we connect to a denoted user, not a member. the member is created as a result of this ncco. the vapi user is also unaware of the concept of the member so lets not add confusion ;)

