### PR TITLE
Document max verify requests/sec limit

### DIFF
--- a/_documentation/verify/code-snippets/send-verify-request.md
+++ b/_documentation/verify/code-snippets/send-verify-request.md
@@ -9,6 +9,8 @@ When you have collected a user's phone number, start the verification process by
 
 The Verify API returns a `request_id`. Use this to identify a specific verification request in subsequent calls to the API, such as when making a [check request](/verify/code-snippets/check-verify-request) to see if the user provided the correct code.
 
+> **Note**: You are limited to a maximum of one verify request per second.
+
 ```code_snippets
 source: '_examples/verify/send-verification-request'
 ```

--- a/_documentation/verify/guides/verification-events.md
+++ b/_documentation/verify/guides/verification-events.md
@@ -12,6 +12,8 @@ The Verify API then sends a verification code to the user by SMS. When they ente
 
 If the user does not enter the code within the allowed time, the Verify API makes two further attempts to verify the user by making  Text-to-speech (TTS) voice calls.
 
+> **Note**: You are limited to a maximum of one verify request per second.
+
 ## Timing of each event 
 
 The following table shows the three events that are triggered and the amount of time the Verify API waits by default before triggering the next event. You can also [trigger the next verification attempt](/verify/code-snippets/trigger-next-verification-process) programmatically.


### PR DESCRIPTION
## Description

Document the 1/sec limit for verify requests.

Note for reviewer: This change was approved and then got lost in an [earlier closed PR](https://github.com/Nexmo/nexmo-developer/pull/1582).

