### PR TITLE
Use GET instead of POST for NI guide example

### DIFF
--- a/_documentation/number-insight/guides/cnam.md
+++ b/_documentation/number-insight/guides/cnam.md
@@ -19,7 +19,7 @@ Passing `cname=true` as an extra parameter in a call to the Advanced API looks u
 The following example shows how you would request CNAM data using `curl`:
 
 ```bash
-$ curl "https://api.nexmo.com/ni/advanced/json?api_key=NEXMO_API_KEY&api_secret=NEXMO_API_KEY&number=14155550100&cname=true"
+$ curl "https://api.nexmo.com/ni/advanced/json?api_key=NEXMO_API_KEY&api_secret=NEXMO_API_SECRET&number=14155550100&cname=true"
 ```
 
 ## Understanding the response

--- a/_documentation/number-insight/guides/cnam.md
+++ b/_documentation/number-insight/guides/cnam.md
@@ -19,11 +19,7 @@ Passing `cname=true` as an extra parameter in a call to the Advanced API looks u
 The following example shows how you would request CNAM data using `curl`:
 
 ```bash
-$ curl -X "POST" "https://api.nexmo.com/ni/advanced/json" \
-> -d "api_key=NEXMO_API_KEY" \
-> -d "api_secret=NEXMO_API_KEY" \
-> -d "number=14155550100" \
-> -d "cname=true"
+$ curl "https://api.nexmo.com/ni/advanced/json?api_key=NEXMO_API_KEY&api_secret=NEXMO_API_KEY&number=14155550100&cname=true"
 ```
 
 ## Understanding the response


### PR DESCRIPTION
## Description

Another instance of when we're using `POST` instead of `GET`. Number Insight supports both but we want to steer people to using `GET` in a read-only API.

