### PR TITLE
Add new Advanced NI IP matching guide

### DIFF
--- a/_documentation/number-insight/guides/cnam.md
+++ b/_documentation/number-insight/guides/cnam.md
@@ -1,5 +1,7 @@
 ---
 title: Retrieving CNAM Owner Details
+description: Retrieve identity details for US callers.
+navigation_weight: 1
 ---
 
 # Retrieving CNAM Owner Details

--- a/_documentation/number-insight/guides/ip-matching.md
+++ b/_documentation/number-insight/guides/ip-matching.md
@@ -8,23 +8,16 @@ navigation_weight: 2
 
 ## Overview
 
-You can use Nexmo's Number Insight Advanced API to determine whether a user's IP address is in the same location as their handset. This can help you detect potentially fraudulent use of your services.
+You can use Nexmo's Number Insight Advanced API to determine whether a user's IP address is in the same location as their phone. This can help you detect potentially fraudulent use of your services.
 
 ## Making the request
 
 Pass the user's IP address in the `ip` parameter when you make the request, as shown in the following `curl` example.
 
-Replace the following values in the code snippets with your own details:
-
-Key |	Description
--- | --
-`NEXMO_API_KEY` | API key.
-`NEXMO_API_SECRET` | API secret.
-`INSIGHT_NUMBER` | The number you want to retrieve insight information for.
-`IP_ADDRESS` | The user's IP address.
+Replace the `NEXMO_API_KEY` and `NEXMO_API_SECRET` placeholder variables with your own API key and secret from the [developer dashboard](https://dashboard.nexmo.com/getting-started-guide).
 
 ```bash
-curl 'https://api.nexmo.com/ni/advanced/json?api_key=NEXMO_API_KEY&api_secret=NEXMO_API_SECRET&number=INSIGHT_NUMBER&ip=IP_ADDRESS&cname=true'
+curl 'https://api.nexmo.com/ni/advanced/json?api_key=NEXMO_API_KEY&api_secret=NEXMO_API_SECRET&number=INSIGHT_NUMBER&ip=&cname=true'
 ```
 
 ## Understanding the response
@@ -34,30 +27,30 @@ When you include the `ip` parameter in the request, the `ip` field in the respon
 * `address`: the IP address you specified in the request
 * `ip_match_level`: either `country` (if Number Insight was able to determine the country the IP address originates from) or `mismatch` (if it couldn't)
 * `ip_country`: the country that `ip` originates from (if successful)
-* `ip_city`: the city that `ip` originates from (if successful)
+* `ip_city`: the city that `ip` originates from (if successful and known)
 
-> *** MARK:
-
-The `ip_warnings` property in the response consists of `no_warning` if the `ip_country` is the same as `country_name` and `unknown` if not.
 
 ### Example response
 
+In the following sample response, the user's IP address originates from South Korea (`KR`), but the user's phone is located in the United Kingdom (`GB`). The `ip_match_level` indicates that there is a possible mismatch.
+
+> **Note**: The `ip_warnings` property is deprecated and can safely be ignored. 
+
 ```json
 {
-{
-    "status": 44,
-    "status_message": "Lookup Handler unable to handle request",
+    "status": 0,
+    "status_message": "Success",
     "lookup_outcome": 1,
     "lookup_outcome_message": "Partial success - some fields populated",
-    "request_id": "6b1abd76-9bdf-4a22-936c-2b4fc98ce446",
-    "international_format_number": "*****",
-    "national_format_number": "******",
+    "request_id": "0aad8f5f-1ff4-404b-9dc2-6fc47737a668",
+    "international_format_number": "447700900001",
+    "national_format_number": "07700 900001",
     "country_code": "GB",
     "country_code_iso3": "GBR",
     "country_name": "United Kingdom",
     "country_prefix": "44",
     "request_price": "0.03000000",
-    "remaining_balance": "123.20567499",
+    "remaining_balance": "5.00",
     "current_carrier": {
         "network_code": "23410",
         "name": "Telefonica UK Limited",
@@ -81,46 +74,7 @@ The `ip_warnings` property in the response consists of `no_warning` if the `ip_c
         "ip_match_level": "mismatch",
         "ip_country": "KR",
         "ip_city": ""
-    }
-}
-}
-```
-
-### Business example
-
-```json
-{
-    "status": 0,
-    "status_message": "Success",
-    "lookup_outcome": 1,
-    "lookup_outcome_message": "Partial success - some fields populated",
-    "request_id": "27c61a46-5b4a-4e80-b16d-725432559078",
-    "international_format_number": "14155550101",
-    "national_format_number": "(415) 555-0101",
-    "country_code": "US",
-    "country_code_iso3": "USA",
-    "country_name": "United States of America",
-    "country_prefix": "1",
-    "request_price": "0.04000000",
-    "remaining_balance": "10.000000",
-    "current_carrier": {
-        "network_code": "US-FIXED",
-        "name": "United States of America Landline",
-        "country": "US",
-        "network_type": "landline"
     },
-    "original_carrier": {
-        "network_code": "US-FIXED",
-        "name": "United States of America Landline",
-        "country": "US",
-        "network_type": "landline"
-    },
-    "valid_number": "valid",
-    "reachable": "unknown",
-    "ported": "not_ported",
-    "roaming": {"status": "unknown"},
-    "ip_warnings": "unknown",
-    "caller_name": "ACME Corporation",
-    "caller_type": "business"
+    "ip_warnings": "unknown"
 }
 ```

--- a/_documentation/number-insight/guides/ip-matching.md
+++ b/_documentation/number-insight/guides/ip-matching.md
@@ -1,0 +1,126 @@
+---
+title: IP Matching
+description: Detecting potential fraud by checking the location of the user's IP against their phone number.
+navigation_weight: 2
+---
+
+# IP Matching
+
+## Overview
+
+You can use Nexmo's Number Insight Advanced API to determine whether a user's IP address is in the same location as their handset. This can help you detect potentially fraudulent use of your services.
+
+## Making the request
+
+Pass the user's IP address in the `ip` parameter when you make the request, as shown in the following `curl` example.
+
+Replace the following values in the code snippets with your own details:
+
+Key |	Description
+-- | --
+`NEXMO_API_KEY` | API key.
+`NEXMO_API_SECRET` | API secret.
+`INSIGHT_NUMBER` | The number you want to retrieve insight information for.
+`IP_ADDRESS` | The user's IP address.
+
+```bash
+curl 'https://api.nexmo.com/ni/advanced/json?api_key=NEXMO_API_KEY&api_secret=NEXMO_API_SECRET&number=INSIGHT_NUMBER&ip=IP_ADDRESS&cname=true'
+```
+
+## Understanding the response
+
+When you include the `ip` parameter in the request, the `ip` field in the response contains an object with the following properties:
+
+* `address`: the IP address you specified in the request
+* `ip_match_level`: either `country` (if Number Insight was able to determine the country the IP address originates from) or `mismatch` (if it couldn't)
+* `ip_country`: the country that `ip` originates from (if successful)
+* `ip_city`: the city that `ip` originates from (if successful)
+
+> *** MARK:
+
+The `ip_warnings` property in the response consists of `no_warning` if the `ip_country` is the same as `country_name` and `unknown` if not.
+
+### Example response
+
+```json
+{
+{
+    "status": 44,
+    "status_message": "Lookup Handler unable to handle request",
+    "lookup_outcome": 1,
+    "lookup_outcome_message": "Partial success - some fields populated",
+    "request_id": "6b1abd76-9bdf-4a22-936c-2b4fc98ce446",
+    "international_format_number": "*****",
+    "national_format_number": "******",
+    "country_code": "GB",
+    "country_code_iso3": "GBR",
+    "country_name": "United Kingdom",
+    "country_prefix": "44",
+    "request_price": "0.03000000",
+    "remaining_balance": "123.20567499",
+    "current_carrier": {
+        "network_code": "23410",
+        "name": "Telefonica UK Limited",
+        "country": "GB",
+        "network_type": "mobile"
+    },
+    "original_carrier": {
+        "network_code": "23410",
+        "name": "Telefonica UK Limited",
+        "country": "GB",
+        "network_type": "mobile"
+    },
+    "valid_number": "valid",
+    "reachable": "reachable",
+    "ported": "not_ported",
+    "roaming": {
+        "status": "not_roaming"
+    },
+    "ip": {
+        "address": "123.0.0.255",
+        "ip_match_level": "mismatch",
+        "ip_country": "KR",
+        "ip_city": ""
+    }
+}
+}
+```
+
+### Business example
+
+```json
+{
+    "status": 0,
+    "status_message": "Success",
+    "lookup_outcome": 1,
+    "lookup_outcome_message": "Partial success - some fields populated",
+    "request_id": "27c61a46-5b4a-4e80-b16d-725432559078",
+    "international_format_number": "14155550101",
+    "national_format_number": "(415) 555-0101",
+    "country_code": "US",
+    "country_code_iso3": "USA",
+    "country_name": "United States of America",
+    "country_prefix": "1",
+    "request_price": "0.04000000",
+    "remaining_balance": "10.000000",
+    "current_carrier": {
+        "network_code": "US-FIXED",
+        "name": "United States of America Landline",
+        "country": "US",
+        "network_type": "landline"
+    },
+    "original_carrier": {
+        "network_code": "US-FIXED",
+        "name": "United States of America Landline",
+        "country": "US",
+        "network_type": "landline"
+    },
+    "valid_number": "valid",
+    "reachable": "unknown",
+    "ported": "not_ported",
+    "roaming": {"status": "unknown"},
+    "ip_warnings": "unknown",
+    "caller_name": "ACME Corporation",
+    "caller_type": "business"
+}
+```

--- a/_documentation/number-insight/guides/number-insight-via-cli.md
+++ b/_documentation/number-insight/guides/number-insight-via-cli.md
@@ -1,6 +1,7 @@
 ---
 title: Using Number Insight via the Nexmo CLI
 description: Use the Nexmo CLI to get information about a phone number.
+navigation_weight: 3
 ---
 
 # Using Number Insight via the Nexmo CLI

--- a/_documentation/number-insight/guides/number-insight-via-cli.md
+++ b/_documentation/number-insight/guides/number-insight-via-cli.md
@@ -1,5 +1,6 @@
 ---
 title: Using Number Insight via the Nexmo CLI
+description: Use the Nexmo CLI to get information about a phone number.
 ---
 
 # Using Number Insight via the Nexmo CLI


### PR DESCRIPTION
## Description

Added a new guide showing developers how to IP match in the Number Insight Advanced API.

I've added a note about the `ip_warnings` response property after discussion with James Wren:

> ...this field is pretty much defunct, as we’re always returning unknown. unknown means “we don’t know whether the there are warnings for this IP being an anonymous proxy / satellite provider, or whether there are no warnings”.

If reviewers agree it is OK to mention this here, I'll submit another PR to add the same to the `ip_warnings` response field description in the API reference.
