### PR TITLE
Make the LabelFilter only apply to HTTP verbs

### DIFF
--- a/app/controllers/markdown_controller.rb
+++ b/app/controllers/markdown_controller.rb
@@ -17,7 +17,6 @@ class MarkdownController < ApplicationController
     @content = MarkdownPipeline.new({
       code_language: @code_language,
       current_user: current_user,
-      disable_label_filter: params[:namespace].present? # Disable if we're in the contribute section
     }).call(document)
 
     if !Rails.env.development? && @frontmatter['wip']

--- a/app/controllers/tutorials_controller.rb
+++ b/app/controllers/tutorials_controller.rb
@@ -34,7 +34,7 @@ class TutorialsController < ApplicationController
     @document_title = @frontmatter['title']
     @product = @frontmatter['products']
 
-    @content = MarkdownPipeline.new({ code_language: @code_language, disable_label_filter: true }).call(document)
+    @content = MarkdownPipeline.new({ code_language: @code_language }).call(document)
 
     @namespace_path = "_documentation/#{@product}"
     @namespace_root = '_documentation'

--- a/app/filters/label_filter.rb
+++ b/app/filters/label_filter.rb
@@ -1,7 +1,6 @@
 class LabelFilter < Banzai::Filter
   def call(input)
-    return input if options[:disable_label_filter]
-    input.gsub(/\[([a-zA-Z0-9\s:\-\.]+)\]/) do |_s|
+    input.gsub(/\[(GET|POST|PUT|DELETE|OPTIONS)\]/i) do |_s|
       "<span class='Vlt-badge #{class_name($1)}'>#{$1}</span> "
     end
   end
@@ -18,6 +17,8 @@ class LabelFilter < Banzai::Filter
       'Vlt-badge--red'
     when 'PUT'
       'Vlt-badge--yellow'
+    when 'OPTIONS'
+      'Vlt-badge--grey'
     end
   end
 end

--- a/spec/filters/label_filter_spec.rb
+++ b/spec/filters/label_filter_spec.rb
@@ -9,12 +9,10 @@ RSpec.describe LabelFilter do
     expect(described_class.call(input)).to eq(expected_output)
   end
 
-  it 'returns an HTML span tag when provided with random text inside brackets' do
+  it 'does not alter random text inside brackets' do
     input = '[some text]'
 
-    expected_output = "<span class='Vlt-badge '>some text</span> "
-
-    expect(described_class.call(input)).to eq(expected_output)
+    expect(described_class.call(input)).to eq(input)
   end
 
   it 'does not transform a matching string if it is not inside brackets' do
@@ -53,6 +51,14 @@ RSpec.describe LabelFilter do
     input = '[PUT]'
 
     expected_output = "<span class='Vlt-badge Vlt-badge--yellow'>PUT</span> "
+
+    expect(described_class.call(input)).to eq(expected_output)
+  end
+
+  it 'converts [OPTIONS] to a grey label' do
+    input = '[OPTIONS]'
+
+    expected_output = "<span class='Vlt-badge Vlt-badge--grey'>OPTIONS</span> "
 
     expect(described_class.call(input)).to eq(expected_output)
   end


### PR DESCRIPTION
## Description

Previously we were catching everything within `[]` but it was highlighting array access etc. 99% of the time we're trying to highlight HTTP verbs, so let's simplify to just that use case.

This will change the rendering on some legacy API pages, but we're in the process of replacing them with OAS documents

## Deploy Notes

N/A