### PR TITLE
Fix OAS array response field rendering

### DIFF
--- a/app/views/open_api/_response_description_parameters.html.erb
+++ b/app/views/open_api/_response_description_parameters.html.erb
@@ -6,6 +6,12 @@
   end
 %>
 
+<%
+  # If it's an array, look at the items for the response schema as all items within
+  # the array are expected to be identical
+  schema = schema['items'] if schema['type'] == 'array'
+%>
+
 <% if schema['properties'] %>
 <% schema['properties'].each do |key, value| %>
   <% next if key == '_links' %>


### PR DESCRIPTION
## Description

If it's an array, look at the items for the response schema as all items within the array are expected to be identical

## Deploy Notes

N/A