### PR TITLE
Add Voice V2 OAS

### DIFF
--- a/app/constraints/open_api_constraint.rb
+++ b/app/constraints/open_api_constraint.rb
@@ -7,6 +7,7 @@ OPEN_API_PRODUCTS = %w[
   dispatch
   redact
   audit
+  voice.v2
   voice
   account
   external-accounts

--- a/app/views/open_api/_response_descriptions.html.erb
+++ b/app/views/open_api/_response_descriptions.html.erb
@@ -1,6 +1,7 @@
 <% endpoint.responses.each do |response| %>
     <% next unless response.success? %>
     <% next if response.code.to_i == 204 %>
+    <% next unless response.content %>
     <% id = SecureRandom.hex %>
     <p class="collapsible">
     <a class="Vlt-js-accordion__trigger Nxd-accordion-button" data-accordion="acc<%= id %>">


### PR DESCRIPTION
## Description

Pulls in Voice V2 OAS.

It is a beta, with only one endpoint (POST /calls) supported. The
only difference to v1 is that this request returns a 202 rather than
a 201 containing a call ID.

This change is required as a call ID is not generated until a call is
placed, which can be at an indeterminate point in the future for IP legs

## Deploy Notes

https://github.com/Nexmo/api-specification/pull/105 needs merging first