### PR TITLE
Add Framework Libraries to NDP Tools Page

### DIFF
--- a/app/views/static/tools.html.erb
+++ b/app/views/static/tools.html.erb
@@ -170,6 +170,72 @@
 <hr>
 <br>
 
+
+
+<h2>Framework Libraries</h2>
+
+<p>The Nexmo framework libraries can get you up and running with the Nexmo APIs quickly and easily in your framework of choice.</p>
+
+<div class="Vlt-grid Vlt-grid--margin-top3">
+  <div class="Vlt-col Vlt-col--1of3">
+    <a href="https://github.com/Nexmo/nexmo-laravel" class="Vlt-card Nxd-github-card" data-github="Nexmo/nexmo-laravel">
+      <h3 class="Vlt-blue-dark">nexmo-laravel</h3>
+      <p>Nexmo framework library for Laravel</p>
+      <img src="//badge.fury.io/rb/nexmo.svg" class="Nxd-github-card__badge" height="18">
+      <p>
+        <small class="Nxd-github-card__meta">
+          <span>
+            <span class="Vlt-red-dark">●</span> PHP
+          </span>
+          <span>
+            <svg class="Vlt-icon Vlt-icon--smaller Vlt-icon--text-bottom Vlt-grey-darker" aria-hidden="true"><use xlink:href="/symbol/volta-icons.svg#Vlt-icon-star-full"/></svg>
+            <span data-stars>
+              <svg class="Vlt-icon Vlt-icon--smaller Vlt-icon--text-bottom Vlt-grey-darker" aria-hidden="true"><use xlink:href="/symbol/volta-icons.svg#Vlt-icon-more"/></svg>
+            </span>
+          </span>
+          <span>
+            <svg class="Vlt-icon Vlt-icon--smaller Vlt-icon--text-bottom Vlt-grey-darker" aria-hidden="true"><use xlink:href="/symbol/volta-icons.svg#Vlt-icon-fork"/></svg>
+            <span data-forks>
+              <svg class="Vlt-icon Vlt-icon--smaller Vlt-icon--text-bottom Vlt-grey-darker" aria-hidden="true"><use xlink:href="/symbol/volta-icons.svg#Vlt-icon-more"/></svg>
+            </span>
+          </span>
+        </small>
+      </p>
+    </a>
+  </div>
+
+  <div class="Vlt-col Vlt-col--1of3">
+    <a href="https://github.com/Nexmo/nexmo-rails" class="Vlt-card Nxd-github-card" data-github="Nexmo/nexmo-rails">
+      <h3 class="Vlt-blue-dark">nexmo-rails</h3>
+      <p>Nexmo framework library for Ruby on Rails</p>
+      <img src="//badge.fury.io/ph/nexmo%2Fclient.svg" class="Nxd-github-card__badge" height="18">
+      <p>
+        <small class="Nxd-github-card__meta">
+          <span>
+            <span class="Vlt-blue-dark">●</span> Ruby
+          </span>
+          <span>
+            <svg class="Vlt-icon Vlt-icon--smaller Vlt-icon--text-bottom Vlt-grey-darker" aria-hidden="true"><use xlink:href="/symbol/volta-icons.svg#Vlt-icon-star-full"/></svg>
+            <span data-stars>
+              <svg class="Vlt-icon Vlt-icon--smaller Vlt-icon--text-bottom Vlt-grey-darker" aria-hidden="true"><use xlink:href="/symbol/volta-icons.svg#Vlt-icon-more"/></svg>
+            </span>
+          </span>
+          <span>
+            <svg class="Vlt-icon Vlt-icon--smaller Vlt-icon--text-bottom Vlt-grey-darker" aria-hidden="true"><use xlink:href="/symbol/volta-icons.svg#Vlt-icon-fork"/></svg>
+            <span data-forks>
+              <svg class="Vlt-icon Vlt-icon--smaller Vlt-icon--text-bottom Vlt-grey-darker" aria-hidden="true"><use xlink:href="/symbol/volta-icons.svg#Vlt-icon-more"/></svg>
+            </span>
+          </span>
+        </small>
+      </p>
+    </a>
+  </div>
+</div>
+
+<hr>
+<br>
+
+
 <h2>Nexmo CLI</h2>
 
 <p>You use the Nexmo Command Line Interface (CLI) to manage your Nexmo account and use Nexmo products from the command line.</p>

--- a/app/views/static/tools.html.erb
+++ b/app/views/static/tools.html.erb
@@ -215,7 +215,7 @@
     <a href="https://github.com/Nexmo/nexmo-laravel" class="Vlt-card Nxd-github-card" data-github="Nexmo/nexmo-laravel">
       <h3 class="Vlt-blue-dark">nexmo-laravel</h3>
       <p>Nexmo framework library for Laravel</p>
-      <img src="//poser.pugx.org/nexmo/laravel/v/stable" class="Nxd-github-card__badge" height="18">
+      <img src="https://poser.pugx.org/nexmo/laravel/v/stable" class="Nxd-github-card__badge" height="18">
       <p>
         <small class="Nxd-github-card__meta">
           <span>

--- a/app/views/static/tools.html.erb
+++ b/app/views/static/tools.html.erb
@@ -203,38 +203,11 @@
       </p>
     </a>
   </div>
-
-  <div class="Vlt-col Vlt-col--1of3">
-    <a href="https://github.com/Nexmo/nexmo-rails" class="Vlt-card Nxd-github-card" data-github="Nexmo/nexmo-rails">
-      <h3 class="Vlt-blue-dark">nexmo-rails</h3>
-      <p>Nexmo framework library for Ruby on Rails</p>
-      <!-- # add when published <img src="//badge.fury.io/ph/nexmo%2Fclient.svg" class="Nxd-github-card__badge" height="18"> -->
-      <p>
-        <small class="Nxd-github-card__meta">
-          <span>
-            <span class="Vlt-blue-dark">●</span> Ruby
-          </span>
-          <span>
-            <svg class="Vlt-icon Vlt-icon--smaller Vlt-icon--text-bottom Vlt-grey-darker" aria-hidden="true"><use xlink:href="/symbol/volta-icons.svg#Vlt-icon-star-full"/></svg>
-            <span data-stars>
-              <svg class="Vlt-icon Vlt-icon--smaller Vlt-icon--text-bottom Vlt-grey-darker" aria-hidden="true"><use xlink:href="/symbol/volta-icons.svg#Vlt-icon-more"/></svg>
-            </span>
-          </span>
-          <span>
-            <svg class="Vlt-icon Vlt-icon--smaller Vlt-icon--text-bottom Vlt-grey-darker" aria-hidden="true"><use xlink:href="/symbol/volta-icons.svg#Vlt-icon-fork"/></svg>
-            <span data-forks>
-              <svg class="Vlt-icon Vlt-icon--smaller Vlt-icon--text-bottom Vlt-grey-darker" aria-hidden="true"><use xlink:href="/symbol/volta-icons.svg#Vlt-icon-more"/></svg>
-            </span>
-          </span>
-        </small>
-      </p>
-    </a>
-  </div>
+  
 </div>
 
 <hr>
 <br>
-
 
 <h2>Nexmo CLI</h2>
 

--- a/app/views/static/tools.html.erb
+++ b/app/views/static/tools.html.erb
@@ -181,7 +181,7 @@
     <a href="https://github.com/Nexmo/nexmo-laravel" class="Vlt-card Nxd-github-card" data-github="Nexmo/nexmo-laravel">
       <h3 class="Vlt-blue-dark">nexmo-laravel</h3>
       <p>Nexmo framework library for Laravel</p>
-      <img src="//badge.fury.io/rb/nexmo.svg" class="Nxd-github-card__badge" height="18">
+      <img src="//poser.pugx.org/nexmo/laravel/v/stable" class="Nxd-github-card__badge" height="18">
       <p>
         <small class="Nxd-github-card__meta">
           <span>
@@ -208,7 +208,7 @@
     <a href="https://github.com/Nexmo/nexmo-rails" class="Vlt-card Nxd-github-card" data-github="Nexmo/nexmo-rails">
       <h3 class="Vlt-blue-dark">nexmo-rails</h3>
       <p>Nexmo framework library for Ruby on Rails</p>
-      <img src="//badge.fury.io/ph/nexmo%2Fclient.svg" class="Nxd-github-card__badge" height="18">
+      <!-- # add when published <img src="//badge.fury.io/ph/nexmo%2Fclient.svg" class="Nxd-github-card__badge" height="18"> -->
       <p>
         <small class="Nxd-github-card__meta">
           <span>

--- a/app/views/static/tools.html.erb
+++ b/app/views/static/tools.html.erb
@@ -170,7 +170,41 @@
 <hr>
 <br>
 
+<h2>Nexmo CLI</h2>
 
+<p>You use the Nexmo Command Line Interface (CLI) to manage your Nexmo account and use Nexmo products from the command line.</p>
+
+<div class="Vlt-grid Vlt-grid--margin-top3">
+  <div class="Vlt-col Vlt-col--1of3">
+    <a href="https://github.com/Nexmo/nexmo-cli" class="Vlt-card Nxd-github-card" data-github="Nexmo/nexmo-cli">
+      <h3 class="Vlt-blue-dark">nexmo-cli</h3>
+      <p>Nexmo CLI (Command Line Interface) </p>
+      <img src="//badge.fury.io/js/nexmo-cli.svg" class="Nxd-github-card__badge" height="18">
+      <p>
+        <small class="Nxd-github-card__meta">
+          <span>
+            <span class="Vlt-yellow">●</span> JavaScript
+          </span>
+          <span>
+            <svg class="Vlt-icon Vlt-icon--smaller Vlt-icon--text-bottom Vlt-grey-darker" aria-hidden="true"><use xlink:href="/symbol/volta-icons.svg#Vlt-icon-star-full"/></svg>
+            <span data-stars>
+              <svg class="Vlt-icon Vlt-icon--smaller Vlt-icon--text-bottom Vlt-grey-darker" aria-hidden="true"><use xlink:href="/symbol/volta-icons.svg#Vlt-icon-more"/></svg>
+            </span>
+          </span>
+          <span>
+            <svg class="Vlt-icon Vlt-icon--smaller Vlt-icon--text-bottom Vlt-grey-darker" aria-hidden="true"><use xlink:href="/symbol/volta-icons.svg#Vlt-icon-fork"/></svg>
+            <span data-forks>
+              <svg class="Vlt-icon Vlt-icon--smaller Vlt-icon--text-bottom Vlt-grey-darker" aria-hidden="true"><use xlink:href="/symbol/volta-icons.svg#Vlt-icon-more"/></svg>
+            </span>
+          </span>
+        </small>
+      </p>    
+    </a>
+  </div>
+</div>
+
+<hr>
+<br>
 
 <h2>Framework Libraries</h2>
 
@@ -208,37 +242,3 @@
 
 <hr>
 <br>
-
-<h2>Nexmo CLI</h2>
-
-<p>You use the Nexmo Command Line Interface (CLI) to manage your Nexmo account and use Nexmo products from the command line.</p>
-
-<div class="Vlt-grid Vlt-grid--margin-top3">
-  <div class="Vlt-col Vlt-col--1of3">
-    <a href="https://github.com/Nexmo/nexmo-cli" class="Vlt-card Nxd-github-card" data-github="Nexmo/nexmo-cli">
-      <h3 class="Vlt-blue-dark">nexmo-cli</h3>
-      <p>Nexmo CLI (Command Line Interface) </p>
-      <img src="//badge.fury.io/js/nexmo-cli.svg" class="Nxd-github-card__badge" height="18">
-      <p>
-        <small class="Nxd-github-card__meta">
-          <span>
-            <span class="Vlt-yellow">●</span> JavaScript
-          </span>
-          <span>
-            <svg class="Vlt-icon Vlt-icon--smaller Vlt-icon--text-bottom Vlt-grey-darker" aria-hidden="true"><use xlink:href="/symbol/volta-icons.svg#Vlt-icon-star-full"/></svg>
-            <span data-stars>
-              <svg class="Vlt-icon Vlt-icon--smaller Vlt-icon--text-bottom Vlt-grey-darker" aria-hidden="true"><use xlink:href="/symbol/volta-icons.svg#Vlt-icon-more"/></svg>
-            </span>
-          </span>
-          <span>
-            <svg class="Vlt-icon Vlt-icon--smaller Vlt-icon--text-bottom Vlt-grey-darker" aria-hidden="true"><use xlink:href="/symbol/volta-icons.svg#Vlt-icon-fork"/></svg>
-            <span data-forks>
-              <svg class="Vlt-icon Vlt-icon--smaller Vlt-icon--text-bottom Vlt-grey-darker" aria-hidden="true"><use xlink:href="/symbol/volta-icons.svg#Vlt-icon-more"/></svg>
-            </span>
-          </span>
-        </small>
-      </p>
-      
-    </a>
-  </div>
-</div>

--- a/app/views/static/tools.html.erb
+++ b/app/views/static/tools.html.erb
@@ -215,7 +215,7 @@
     <a href="https://github.com/Nexmo/nexmo-laravel" class="Vlt-card Nxd-github-card" data-github="Nexmo/nexmo-laravel">
       <h3 class="Vlt-blue-dark">nexmo-laravel</h3>
       <p>Nexmo framework library for Laravel</p>
-      <img src="https://poser.pugx.org/nexmo/laravel/v/stable" class="Nxd-github-card__badge" height="18">
+      <img src="//badge.fury.io/ph/nexmo%2Flaravel.svg" class="Nxd-github-card__badge" height="18">
       <p>
         <small class="Nxd-github-card__meta">
           <span>


### PR DESCRIPTION
## Description

Add Nexmo framework libraries to the `/tools` page on NDP

