### PR TITLE
Clarify omission of leading plus symbol for E164 format

### DIFF
--- a/_documentation/concepts/guides/glossary.md
+++ b/_documentation/concepts/guides/glossary.md
@@ -118,9 +118,9 @@ A measure of the impact of inbound phone calls in digital marketing efforts. For
 
 ## E.164 format
 
-Phone number format for all Nexmo APIs.
+The Nexmo APIs expect numbers to be in [E.164 format](https://en.wikipedia.org/wiki/E.164), except that the leading `+` is omitted.
 
-This means that numbers:
+Numbers must therefore:
 
 * Omit both a leading `+` and the international access code such as `00` or `001`.
 * Contain no special characters, such as a space, `(`, `)`, or `-`.


### PR DESCRIPTION
## Description

E164 format expects the `+` symbol, but we require that it is omitted. Updated the glossary to clarify that.
