### PR TITLE
Add JWT dependency to curl building blocks

### DIFF
--- a/_examples/voice/make-an-outbound-call/curl.yml
+++ b/_examples/voice/make-an-outbound-call/curl.yml
@@ -1,6 +1,8 @@
 ---
 title: cURL
 language: curl
+dependencies:
+  - JWT
 code:
     source: .repos/nexmo/nexmo-curl-code-snippets/voice/voice-api/make-an-outbound-call.sh
     from_line: 5

--- a/app/filters/code_snippet_filter.rb
+++ b/app/filters/code_snippet_filter.rb
@@ -115,9 +115,9 @@ class CodeSnippetFilter < Banzai::Filter
     end
   end
 
-  def generate_dependencies(language, _dependencies)
+  def generate_dependencies(language, dependencies)
     # The only valid dependency for curl examples is `JWT`
-    dependencies = _dependencies.map(&:upcase)
+    dependencies = dependencies.map(&:upcase)
     if dependencies.include?('JWT')
       title = 'Generate your JWT'
     else

--- a/app/filters/code_snippet_filter.rb
+++ b/app/filters/code_snippet_filter.rb
@@ -115,7 +115,14 @@ class CodeSnippetFilter < Banzai::Filter
     end
   end
 
-  def generate_dependencies(language, dependencies)
+  def generate_dependencies(language, _dependencies)
+    # The only valid dependency for curl examples is `JWT`
+    dependencies = _dependencies.map(&:upcase)
+    if dependencies.include?('JWT') then
+      title = 'Generate your JWT'
+    else
+      title = 'Install dependencies'
+    end
     deps = @renderer.dependencies(dependencies)
     id = SecureRandom.hex
     erb = File.read("#{Rails.root}/app/views/code_snippets/_dependencies.html.erb")

--- a/app/filters/code_snippet_filter.rb
+++ b/app/filters/code_snippet_filter.rb
@@ -118,7 +118,7 @@ class CodeSnippetFilter < Banzai::Filter
   def generate_dependencies(language, _dependencies)
     # The only valid dependency for curl examples is `JWT`
     dependencies = _dependencies.map(&:upcase)
-    if dependencies.include?('JWT') then
+    if dependencies.include?('JWT')
       title = 'Generate your JWT'
     else
       title = 'Install dependencies'

--- a/app/services/code_snippet_renderer/curl.rb
+++ b/app/services/code_snippet_renderer/curl.rb
@@ -6,7 +6,7 @@ module CodeSnippetRenderer
       {
         'text' => 'Run the following <code>curl</code> command to create the <a href="/concepts/guides/authentication#json-web-tokens-jwt">JWT</a> for authentication:',
         'code' => 'export JWT=\'$(nexmo jwt:generate $PATH_TO_PRIVATE_KEY application_id=$NEXMO_APPLICATION_ID)\'',
-      } if dependencies.include?('JWT')    
+      }    
     end
 
     def self.run_command(command, _filename, _file_path)

--- a/app/services/code_snippet_renderer/curl.rb
+++ b/app/services/code_snippet_renderer/curl.rb
@@ -1,7 +1,14 @@
 module CodeSnippetRenderer
   class Curl
     def self.dependencies(_deps)
-      raise 'No dependency support for Curl'
+      deps = _deps.map(&:upcase)
+      if deps.include?('JWT') then
+        {
+          'text' => 'Run the following <code>curl</code> command to create the <a href="/concepts/guides/authentication#json-web-tokens-jwt">JWT</a> for authentication:',
+          'code' => 'export JWT=\'$(nexmo jwt:generate $PATH_TO_PRIVATE_KEY application_id=$NEXMO_APPLICATION_ID)\'',
+        }
+      else raise 'The only permitted curl dependency is `jwt`'
+      end
     end
 
     def self.run_command(command, _filename, _file_path)

--- a/app/services/code_snippet_renderer/curl.rb
+++ b/app/services/code_snippet_renderer/curl.rb
@@ -4,7 +4,7 @@ module CodeSnippetRenderer
       dependencies = deps.map(&:upcase)
       raise 'The only permitted curl dependency is `jwt`' unless dependencies.include?('JWT')
       {
-        'text' => 'Run the following <code>curl</code> command to create the <a href="/concepts/guides/authentication#json-web-tokens-jwt">JWT</a> for authentication:',
+        'text' => 'Execute the following command at your terminal prompt to create the <a href="/concepts/guides/authentication#json-web-tokens-jwt">JWT</a> for authentication:',
         'code' => 'export JWT=\'$(nexmo jwt:generate $PATH_TO_PRIVATE_KEY application_id=$NEXMO_APPLICATION_ID)\'',
       }    
     end

--- a/app/services/code_snippet_renderer/curl.rb
+++ b/app/services/code_snippet_renderer/curl.rb
@@ -2,7 +2,7 @@ module CodeSnippetRenderer
   class Curl
     def self.dependencies(_deps)
       deps = _deps.map(&:upcase)
-      if deps.include?('JWT') then
+      if deps.include?('JWT')
         {
           'text' => 'Run the following <code>curl</code> command to create the <a href="/concepts/guides/authentication#json-web-tokens-jwt">JWT</a> for authentication:',
           'code' => 'export JWT=\'$(nexmo jwt:generate $PATH_TO_PRIVATE_KEY application_id=$NEXMO_APPLICATION_ID)\'',

--- a/app/services/code_snippet_renderer/curl.rb
+++ b/app/services/code_snippet_renderer/curl.rb
@@ -1,14 +1,12 @@
 module CodeSnippetRenderer
   class Curl
-    def self.dependencies(_deps)
-      deps = _deps.map(&:upcase)
-      if deps.include?('JWT')
-        {
-          'text' => 'Run the following <code>curl</code> command to create the <a href="/concepts/guides/authentication#json-web-tokens-jwt">JWT</a> for authentication:',
-          'code' => 'export JWT=\'$(nexmo jwt:generate $PATH_TO_PRIVATE_KEY application_id=$NEXMO_APPLICATION_ID)\'',
-        }
-      else raise 'The only permitted curl dependency is `jwt`'
-      end
+    def self.dependencies(deps)
+      dependencies = deps.map(&:upcase)
+      raise 'The only permitted curl dependency is `jwt`' unless dependencies.include?('JWT')
+      {
+        'text' => 'Run the following <code>curl</code> command to create the <a href="/concepts/guides/authentication#json-web-tokens-jwt">JWT</a> for authentication:',
+        'code' => 'export JWT=\'$(nexmo jwt:generate $PATH_TO_PRIVATE_KEY application_id=$NEXMO_APPLICATION_ID)\'',
+      } if dependencies.include?('JWT')    
     end
 
     def self.run_command(command, _filename, _file_path)

--- a/app/views/code_snippets/_dependencies.html.erb
+++ b/app/views/code_snippets/_dependencies.html.erb
@@ -1,5 +1,5 @@
 <div class="Vlt-box Vlt-box--lesspadding Nxd-accordion-emphasis">
-	<h5 class="Vlt-js-accordion__trigger Vlt-accordion__trigger" data-accordion="acc<%= id %>" tabindex="0">Install dependencies</h5>
+	<h5 class="Vlt-js-accordion__trigger Vlt-accordion__trigger" data-accordion="acc<%= id %>" tabindex="0"><%= title %></h5>
 
 	<div id="acc<%= id %>" class="Vlt-js-accordion__content Vlt-accordion__content Vlt-accordion__content--noborder">
 		    <p><%=deps['text']%></p>


### PR DESCRIPTION
## Description

The curl voice code snippets assumed knowledge of how to generate a JWT for authentication but we don't ever show how to do this.

After discussion with Michael we agreed that the best approach would be to add a `JWT` dependency to curl code snippets.

If this dependency is present, we also change the title  of the `_dependencies.html.erb` view from "Install dependencies" to "Generate your JWT"

I have added the JWT dependency to the Voice API "Make an outbound call" curl code snippet for testing.

```
title: cURL
language: curl
dependencies:
  - JWT
code:
    source: .repos/nexmo/nexmo-curl-code-snippets/voice/voice-api/make-an-outbound-call.sh
    from_line: 5
    to_line: 10
file_name: make-an-outbound-call.sh
run_command: bash make-an-outbound-call.sh
```
