### PR TITLE
Clarify when completed status returned by a call

### DIFF
--- a/_documentation/voice/voice-api/guides/call-flow.md
+++ b/_documentation/voice/voice-api/guides/call-flow.md
@@ -24,10 +24,10 @@ You may choose to provide your NCCO as part of the request you send to create a 
 
 Each call goes through a sequence of states in its lifecycle:
 
-1. Created
-2. Ringing
-3. Answered
-4. Completed
+1. `started`
+2. `ringing`
+3. `answered`
+4. `completed`
 
 ## Event objects
 

--- a/_documentation/voice/voice-api/guides/call-flow.md
+++ b/_documentation/voice/voice-api/guides/call-flow.md
@@ -72,8 +72,6 @@ An example event object is shown here:
 
 In addition, certain errors are sent to the `event_url` such as when your `answer_url` returns an invalid NCCO. You can find more detail in the [Webhooks Reference](/voice/voice-api/webhook-reference#event-webhook).
 
-> **Note**: Events usually arrive at your `event_url` in the order they were generated but this is not guaranteed. Your application should use the `timestamp` field in the response to present the events in the correct order.
-
 ## Answer URL payload
 
 When a call is answered a payload is delivered to your `answer_url` [webhook](/concepts/guides/webhooks).

--- a/_documentation/voice/voice-api/guides/call-flow.md
+++ b/_documentation/voice/voice-api/guides/call-flow.md
@@ -72,6 +72,8 @@ An example event object is shown here:
 
 In addition, certain errors are sent to the `event_url` such as when your `answer_url` returns an invalid NCCO. You can find more detail in the [Webhooks Reference](/voice/voice-api/webhook-reference#event-webhook).
 
+> **Note**: Events usually arrive at your `event_url` in the order they were generated but this is not guaranteed. Your application should use the `timestamp` field in the response to present the events in the correct order.
+
 ## Answer URL payload
 
 When a call is answered a payload is delivered to your `answer_url` [webhook](/concepts/guides/webhooks).

--- a/_documentation/voice/voice-api/guides/call-flow.md
+++ b/_documentation/voice/voice-api/guides/call-flow.md
@@ -8,11 +8,11 @@ navigation_weight: 1
 
 ## Overview
 
-The Nexmo Voice API handles two types of phone call: inbound and outbound.
+The Nexmo Voice API handles two types of phone call: **inbound** and **outbound**.
 
-Inbound calls are calls made to a Nexmo number from another regular phone anywhere in the world.
+**Inbound** calls are calls made to a Nexmo number from another regular phone anywhere in the world.
 
-Outbound calls are calls made from the Nexmo platform to a regular phone number. Outbound calls are usually initiated in response to a request made via the REST API to create a new call. Outbound calls may also be made from within the call flow of an existing call (either inbound or outbound) using the `connect` action within the NCCO (Nexmo Call Control Object). This scenario is generally used for forwarding calls.
+**Outbound** calls are calls made from the Nexmo platform to a regular phone number. Outbound calls are usually initiated in response to a request made via the REST API to create a new call. Outbound calls may also be made from within the call flow of an existing call (either inbound or outbound) using the `connect` action within the NCCO (Nexmo Call Control Object). This scenario is generally used for forwarding calls.
 
 Both inbound and outbound calls follow the same call flow once answered. This call flow is controlled by an NCCO. An NCCO is a script of actions to be run within the context of the call. Actions are executed in the order they appear in the script, with the next action starting when the previous action has finished executing. For more information about NCCOs, see the [NCCO reference](/voice/voice-api/ncco-reference).
 
@@ -27,7 +27,7 @@ Each call goes through a sequence of states in its lifecycle:
 1. Created
 2. Ringing
 3. Answered
-4. Complete
+4. Completed
 
 ## Event objects
 
@@ -43,7 +43,7 @@ The following table shows possible values for the `status` field of an event obj
 | `started`    | The call is created on the Nexmo platform |
 | `ringing`    | The destination has confirmed that the call is ringing |
 | `answered`   | The destination has answered the call |
-| `completed`    | When a call has been completed successfully |
+| `completed`    | The call flow has been terminated. This event is always received at the end of a call unless the call was `rejected`. |
 | `machine`    | When machine detection has been requested and the call is answered by a machine|
 | `human`      | When machine detection has been requested and the call is answered by a human|
 | `input`  | User input has been collected via an `input` action |
@@ -95,7 +95,9 @@ In general, useful information such as the calling number and destination number
 
 ## Synchronous vs Asynchronous Actions
 
-Each *action* within an NCCO has certain conditions on which it will be considered "complete" and the call will progress to the next action. For some actions this complete state can depend on how they are configured.
+Each *action* within an NCCO has certain conditions on which it will be considered "complete" and the call progresses to the next action. For some actions this `completed` state depends on how they are configured.
+
+> Ultimately, all calls end up as `completed` unless the call was `rejected`.
 
 ### Record
 


### PR DESCRIPTION
## Description

This change is in response to the following feedback received by @fauna5:

> "completed" is always returned unless the call was rejected. "unanswered", "timeout", "failed", "busy" and "cancelled" all proceed to "completed". The description of the "completed" state probably needs to change to something like "When a call flow has been terminated. This is always received unless the status is 'rejected'"
