### PR TITLE
Check for migration pending Rails error in CI rake tasks

### DIFF
--- a/lib/common_errors.rb
+++ b/lib/common_errors.rb
@@ -1,5 +1,5 @@
 class CommonErrors
   def self.check_for_migration_error(body)
-    raise 'DB Migration is pending. Please run RAILS_ENV=development bin/rake db:migrate' if body && body.downcase.include?('migrations are pending')
+    raise 'DB Migration is pending. Please run RAILS_ENV=development bin/rake db:migrate' if body&.downcase&.include?('migrations are pending')
   end
 end

--- a/lib/common_errors.rb
+++ b/lib/common_errors.rb
@@ -1,5 +1,5 @@
 class CommonErrors
-  def self.check_for_migration_error(session)
-    raise 'DB Migration is pending. Please run rake db:migrate RAILS_ENV=development.' if session.response.body.include?('Migrations are pending.')
+  def self.check_for_migration_error(body)
+    raise 'DB Migration is pending. Please run RAILS_ENV=development bin/rake db:migrate' if body.downcase.include?('migrations are pending')
   end
 end

--- a/lib/common_errors.rb
+++ b/lib/common_errors.rb
@@ -1,5 +1,5 @@
 class CommonErrors
   def self.check_for_migration_error(session)
-    errors.push('DB Migration is pending. Please run rake db:migrate RAILS_ENV=development.') if session.response.body.include?('Migrations are pending.')
+    raise 'DB Migration is pending. Please run rake db:migrate RAILS_ENV=development.' if session.response.body.include?('Migrations are pending.')
   end
 end

--- a/lib/common_errors.rb
+++ b/lib/common_errors.rb
@@ -1,5 +1,5 @@
 class CommonErrors
   def self.check_for_migration_error(body)
-    raise 'DB Migration is pending. Please run RAILS_ENV=development bin/rake db:migrate' if body.downcase.include?('migrations are pending')
+    raise 'DB Migration is pending. Please run RAILS_ENV=development bin/rake db:migrate' if body && body.downcase.include?('migrations are pending')
   end
 end

--- a/lib/common_errors.rb
+++ b/lib/common_errors.rb
@@ -1,0 +1,5 @@
+class CommonErrors
+  def self.check_for_migration_error(session)
+    errors.push('DB Migration is pending. Please run rake db:migrate RAILS_ENV=development.') if session.response.body.include?('Migrations are pending.')
+  end
+end

--- a/lib/tasks/ci.rake
+++ b/lib/tasks/ci.rake
@@ -1,3 +1,5 @@
+require './lib/common_errors.rb'
+
 namespace :ci do
   desc 'Verify all pages to make sure that no exceptions are thrown'
   task 'verify_pages': :environment do
@@ -24,6 +26,10 @@ namespace :ci do
   task 'verify_navigation': :environment do
     session = ActionDispatch::Integration::Session.new(Rails.application)
     res = session.get '/documentation'
+
+    # Check for migration pending error
+    CommonErrors.check_for_migration_error(session)
+
     raise 'Error rendering documentation index page' if res == 500
   end
 
@@ -32,6 +38,10 @@ namespace :ci do
     session = ActionDispatch::Integration::Session.new(Rails.application)
     OpenApiConstraint.list.each do |name|
       res = session.get "/api/#{name}"
+
+      # Check for migration pending error
+      CommonErrors.check_for_migration_error(session)
+
       raise "Error rendering /api/#{name} OAS page" if res == 500
     end
   end
@@ -79,6 +89,9 @@ namespace :ci do
 
                 # Get the page
                 session.get path
+
+                # Check for migration pending error
+                CommonErrors.check_for_migration_error(session)
 
                 # Make sure it includes the correct ID
                 errors.push({ 'document' => name, 'path' => path }) unless session.response.body.include?("<tr id=\"#{error}\">")

--- a/lib/tasks/ci.rake
+++ b/lib/tasks/ci.rake
@@ -28,7 +28,7 @@ namespace :ci do
     res = session.get '/documentation'
 
     # Check for migration pending error
-    CommonErrors.check_for_migration_error(session)
+    CommonErrors.check_for_migration_error(session.body)
 
     raise 'Error rendering documentation index page' if res == 500
   end
@@ -40,7 +40,7 @@ namespace :ci do
       res = session.get "/api/#{name}"
 
       # Check for migration pending error
-      CommonErrors.check_for_migration_error(session)
+      CommonErrors.check_for_migration_error(session.body)
 
       raise "Error rendering /api/#{name} OAS page" if res == 500
     end
@@ -91,7 +91,7 @@ namespace :ci do
                 session.get path
 
                 # Check for migration pending error
-                CommonErrors.check_for_migration_error(session)
+                CommonErrors.check_for_migration_error(session.body)
 
                 # Make sure it includes the correct ID
                 errors.push({ 'document' => name, 'path' => path }) unless session.response.body.include?("<tr id=\"#{error}\">")

--- a/spec/lib/common_errors_spec.rb
+++ b/spec/lib/common_errors_spec.rb
@@ -3,15 +3,19 @@ require 'common_errors'
 
 RSpec.describe CommonErrors do
   describe '#check_for_migration_error' do
-    it 'raises an error if request body includes a migration request' do
-      session = ActionDispatch::Integration::Session.new(Rails.application)
-      allow(session).to receive(:get).and_return(mock_body)
+    let(:migrate_error) { 'Error! Migrations are pending. Please run rake db:migrate' }
+    let(:expected_error) { 'DB Migration is pending. Please run RAILS_ENV=development bin/rake db:migrate' }
 
-      puts described_class.check_for_migration_error(session)
+    it 'does not raise if migrations are not pending' do
+      expect { described_class.check_for_migration_error('Everything is fine! No need to worry') }.not_to raise_error
+    end
+
+    it 'raises an error if request body includes a migration request' do
+      expect { described_class.check_for_migration_error(migrate_error) }.to raise_error(expected_error)
+    end
+
+    it 'is not case sensitive' do
+      expect { described_class.check_for_migration_error(migrate_error.upcase) }.to raise_error(expected_error)
     end
   end
-end
-
-def mock_body
-  'Migrations are pending.'
 end

--- a/spec/lib/common_errors_spec.rb
+++ b/spec/lib/common_errors_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+require 'common_errors'
+
+RSpec.describe CommonErrors do
+  describe '#check_for_migration_error' do
+    it 'raises an error if request body includes a migration request' do
+      session = ActionDispatch::Integration::Session.new(Rails.application)
+      allow(session).to receive(:get).and_return(mock_body)
+
+      puts described_class.check_for_migration_error(session)
+    end
+  end
+end
+
+def mock_body
+  'Migrations are pending.'
+end


### PR DESCRIPTION
… into rake tasks

## Description

Up to this point, the CI Rake tasks do not provide feedback if it fails because migrations are pending. This PR adds a new class for `CommonErrors` and adds a class method in it to check for migration pending errors. That method is then incorporated in `./lib/ci.rake` tasks.
