### PR TITLE
Switch career page URL from Bamboo to new portal

### DIFF
--- a/app/views/static/team.html.erb
+++ b/app/views/static/team.html.erb
@@ -11,7 +11,7 @@
     Our mission is to build a world-class open source documentation platform to help developers build connected products.
   </p>
   <p class="p-large">
-    Here are some of the people behind Nexmo Developer. Oh, and we're hiring for <a href="#join">the developer relations team</a> and <a href="https://nexmo.bamboohr.co.uk/jobs/">other teams at Nexmo</a>.
+    Here are some of the people behind Nexmo Developer. Oh, and we're hiring for <a href="#join">the developer relations team</a> and <a href="https://www.vonage.com/corporate/careers/">other teams at Nexmo</a>.
   </p>
 
   <br>


### PR DESCRIPTION
## Description

We had the wrong career page URL. Fixed. :)

## Deploy Notes

Nothing fancy
