### PR TITLE
Add Hotjar for usage tracking

### DIFF
--- a/app/views/layouts/partials/_head.html.erb
+++ b/app/views/layouts/partials/_head.html.erb
@@ -52,6 +52,20 @@
     })(window,document,'script','dataLayer','<%= ENV['GOOGLE_TAG_MANAGER_ID'] %>');</script>
   <% end %>
 
+  <% if ENV['HOTJAR_ID'] %>
+    <script>
+    (function(h,o,t,j,a,r){
+        h.hj=h.hj||function(){(h.hj.q=h.hj.q||[]).push(arguments)};
+        h._hjSettings={hjid:<%= ENV['HOTJAR_ID'] %>,hjsv:6};
+        a=o.getElementsByTagName('head')[0];
+        r=o.createElement('script');r.async=1;
+        r.src=t+h._hjSettings.hjid+j+h._hjSettings.hjsv;
+        a.appendChild(r);
+    })(window,document,'https://static.hotjar.com/c/hotjar-','.js?sv=');
+    </script>
+  <% end %>
+
+
   <% if show_canonical_meta? %>
     <link rel="canonical" href="<%= canonical_url %>">
   <% end %>


### PR DESCRIPTION
## Description

We want to add some heatmap tracking to the homepage to see how people
interact with it. This adds the tracking code and we'll set an
environment variable so that it only shows on production

## Deploy Notes

Add `HOTJAR_ID` env var to prod