### PR TITLE
Change check yarn integrity in webpacker to false in development

### DIFF
--- a/config/webpacker.yml
+++ b/config/webpacker.yml
@@ -54,7 +54,7 @@ development:
   compile: true
 
   # Verifies that correct packages and versions are installed by inspecting package.json, yarn.lock, and node_modules
-  check_yarn_integrity: true
+  check_yarn_integrity: false
 
   dev_server:
     host: localhost

--- a/config/webpacker.yml
+++ b/config/webpacker.yml
@@ -53,9 +53,6 @@ development:
   <<: *default
   compile: true
 
-  # Verifies that correct packages and versions are installed by inspecting package.json, yarn.lock, and node_modules
-  check_yarn_integrity: false
-
   dev_server:
     host: localhost
     port: 3035


### PR DESCRIPTION
## Description

Right now, a local development server does not compile with `check_yarn_integrity` set to `true` in development mode. @fabianrbz and I consulted on this and determined that removing the flag from the `development` settings entirely is the best course of action. The `default` settings already have it set to `false`. 

## Deploy Notes

Notes regarding deployment the contained body of work. These should note any db migrations, etc.
