### PR TITLE
Discourage synchronous access to Number Insight Advanced API

### DIFF
--- a/_documentation/number-insight/code-snippets/number-insight-advanced-async-callback.md
+++ b/_documentation/number-insight/code-snippets/number-insight-advanced-async-callback.md
@@ -1,15 +1,11 @@
 ---
-title: Number Insight Advanced Async Callback
+title: Number Insight Advanced Webhook
 navigation_weight: 5
 ---
 
-# Number Insight Advanced Async Callback
+# Number Insight Advanced Webhook
 
-You can optionally use the [Number Insight Advanced API](number-insight-advanced) asynchronously to return the insight data when it becomes available, via a webhook.
-
-> Note that the Basic and Standard API levels do no offer this feature.
-
-This code snippet shows you how to code the webhook handler that deals with the data returned by an asynchronous call to the Number Insight Advanced API. See the [Number Insight Advanced Async Trigger](/number-insight/code-snippets/number-insight-advanced-async) code snippet to learn how to code the initial request for the insight data.
+This code snippet shows you how to code the webhook handler that receives the data returned by an asynchronous call to the Number Insight Advanced API. See the [Number Insight Advanced](/number-insight/code-snippets/number-insight-advanced-async) code snippet to learn how to code the initial request for the insight data.
 
 Before attempting to run the code examples, replace the variable placeholders as instructed in [replaceable variables](/number-insight/code-snippets/before-you-begin#replaceable-variables).
 

--- a/_documentation/number-insight/code-snippets/number-insight-advanced-async.md
+++ b/_documentation/number-insight/code-snippets/number-insight-advanced-async.md
@@ -1,15 +1,22 @@
 ---
-title: Number Insight Advanced Async Trigger
-navigation_weight: 5
+title: Number Insight Advanced
+navigation_weight: 4
 ---
 
-# Number Insight Advanced Async Trigger
+# Number Insight Advanced
 
-You can optionally use the [Number Insight Advanced API](number-insight-advanced) asynchronously to return the insight data when it becomes available, via a webhook.
+The Number Insight Advanced API provides all the data from the [Number Insight Standard API](/number-insight/code-snippets/number-insight-standard) together with the following additional information:
 
-> Note that the Basic and Standard API levels do no offer this feature.
+* If the number is likely to be valid
+* If the number is ported
+* If the number is reachable
+* If the number is roaming and, if so, the carrier and country
 
-This code snippet shows you how to trigger an asynchronous call to the Number Insight API. 
+Use this information to determine the risk associated with a number.
+
+> Note that the Advanced API does not provide any extra information about landlines than the [Number Insight Standard API](/number-insight/code-snippets/number-insight-standard). For insights about landline numbers, use the Standard API.
+
+This code snippet shows you how to trigger an **asynchronous** call to the Number Insight API. __This is the approach Nexmo recommends__. You can optionally use the Number Insight Advanced API [synchronously](number-insight-advanced-sync), but be aware that synchronous use can result in timeouts.
 
 Before attempting to run the code examples, replace the variable placeholders as instructed in [replaceable variables](before-you-begin#replaceable-variables).
 
@@ -29,4 +36,4 @@ The API acknowledges the request by returning the following information to the c
 }
 ```
 
-When it becomes available, the Advanced Number Insight API data is sent to the specified webhook via a `POST` request. See the [Number Insight Advanced Async Callback](/number-insight/code-snippets/number-insight-advanced-async-callback) code snippet to learn how to code the webhook handler.
+When the data becomes available, it is sent to the specified webhook via a `POST` request. See the [Number Insight Advanced Async Callback](/number-insight/code-snippets/number-insight-advanced-async-callback) code snippet to learn how to code the webhook handler.

--- a/_documentation/number-insight/code-snippets/number-insight-advanced-sync.md
+++ b/_documentation/number-insight/code-snippets/number-insight-advanced-sync.md
@@ -1,20 +1,13 @@
 ---
-title: Number Insight Advanced
-navigation_weight: 4
+title: Number Insight Advanced (Sync)
+navigation_weight: 6
 ---
 
-# Number Insight Advanced
+# Number Insight Advanced (Synchronous)
 
-The Number Insight Advanced API provides all the data from the [Number Insight Standard API](/number-insight/code-snippets/number-insight-standard) together with the following additional information:
+This code snippet shows you how to use Number Insight Advanced API synchronously.
 
-* If the number is likely to be valid
-* If the number is ported
-* If the number is reachable
-* If the number is roaming and, if so, the carrier and country
-
-Use this information to determine the risk associated with a number.
-
-> Note that the Advanced API does not provide any extra information about landlines than the [Number Insight Standard API](/number-insight/code-snippets/number-insight-standard). For insights about landline numbers, use the Standard API.
+> **Note**: Nexmo does not recommend this approach, because it can result in timeouts. In most cases, you should use an [asynchronous call](number-insight-advanced-async) to the Number Insight API.
 
 Before attempting to run the code examples, replace the variable placeholders as instructed in [replaceable variables](/number-insight/code-snippets/before-you-begin#replaceable-variables).
 

--- a/_documentation/number-insight/overview.md
+++ b/_documentation/number-insight/overview.md
@@ -25,7 +25,7 @@ This document contains the following information:
 ## Basic, Standard and Advanced APIs
 Each API level builds upon the capabilities of the previous one. For example, the Standard API includes all of the locale and formatting information from the Basic API and returns extra data about the type of number, whether it is ported and the identity of the caller (US only). The Advanced API provides the most comprehensive data. It includes everything that is available in the Basic and Standard APIs and adds roaming and reachability information.
 
-> Unlike the Basic and Standard APIs, you can optionally use the Advanced API asynchronously. 
+> Unlike the Basic and Standard APIs which are synchronous APIs, the Advanced API is intended to be used asynchronously. 
 
 ### Typical use cases
 

--- a/_tutorials/number-insight-async-tutorial.md
+++ b/_tutorials/number-insight-async-tutorial.md
@@ -1,17 +1,17 @@
 ---
-title: Number Insight Advanced API Async
+title: Number Insight Advanced API
 products: number-insight
-description: Learn how to access comprehensive information about the validity and reachability of a number asynchronously.
+description: Learn how to access comprehensive information about the validity and reachability of a number.
 languages:
     - Node
 ---
 
 
-# Number Insight Advanced API Async
+# Number Insight Advanced API 
 
 The Number Insight API gives you real-time information about phone numbers worldwide. There are three levels available: Basic, Standard and Advanced.
 
-The Advanced level provides you with the most comprehensive data to help protect your organization from fraud and spam. Unlike the Basic and Standard levels, you can also access the Advanced API asynchronously via a [webhook](/concepts/guides/webhooks).
+The Advanced level provides you with the most comprehensive data to help protect your organization from fraud and spam. Unlike the Basic and Standard levels, you typically access the Advanced API asynchronously, via a [webhook](/concepts/guides/webhooks).
 
 ## In this tutorial
 
@@ -247,6 +247,6 @@ The following resources will help you use Number Insight in your applications:
 * [Number Insight API product page](https://www.nexmo.com/products/number-insight)
 * [Comparing the Basic, Standard and Advanced Insight APIs](/number-insight/overview#basic-standard-and-advanced-apis)
 * [Webhooks guide](/concepts/guides/webhooks)
-* [Number Insight Advanced Async API reference](/api/number-insight#getNumberInsightAsync)
+* [Number Insight Advanced API reference](/api/number-insight#getNumberInsightAsync)
 * [Connect your local development server to the Nexmo API using an ngrok tunnel](https://www.nexmo.com/blog/2017/07/04/local-development-nexmo-ngrok-tunnel-dr/)
 * [More tutorials](/number-insight/tutorials)


### PR DESCRIPTION
## Description

See [DEVX-148](https://nexmoinc.atlassian.net/browse/DEVX-1048).

TL/DR: Using NI Advanced synchronously leads to timeouts, so we should de-empahasize this capability. This PR includes changes to NI overview, code snippets, tutorials and the OAS (under PR#121, which has been approved and merged).

