### PR TITLE
Remove explicit render call in AdminApi::FeedbackController

### DIFF
--- a/app/controllers/admin_api/feedback_controller.rb
+++ b/app/controllers/admin_api/feedback_controller.rb
@@ -6,8 +6,6 @@ module AdminApi
       return unless authenticate
 
       @feedbacks = Feedback::Feedback.created_between(params[:created_after], params[:created_before])
-
-      render :index
     end
   end
 end


### PR DESCRIPTION
Views with the same name as the action are rendered implicitly.