### PR TITLE
Remove developer preview label from VBC docs

### DIFF
--- a/config/navigation.yml
+++ b/config/navigation.yml
@@ -136,7 +136,6 @@ navigation_overrides:
   vonage-business-cloud:
     svg: 'telephone'
     svgColor: 'green'
-    label: 'Dev Preview'
   contribute:
     administration:
       navigation_weight: 9999


### PR DESCRIPTION
## Description

Brian Dorry at Vonage wants to temporarily remove the `Developer Preview` label from the VBC docs for a few days while they're being evaluated by Forrester.

Agreed by @mheap and @leggetter.
