### PR TITLE
Color of dot next to Laravel framework library in tools page

### DIFF
--- a/app/views/static/tools.html.erb
+++ b/app/views/static/tools.html.erb
@@ -220,7 +220,7 @@
       <p>
         <small class="Nxd-github-card__meta">
           <span>
-            <span class="Vlt-red-dark">●</span> PHP
+            <span class="Vlt-blue-dark">●</span> PHP
           </span>
           <span>
             <svg class="Vlt-icon Vlt-icon--smaller Vlt-icon--text-bottom Vlt-grey-darker" aria-hidden="true"><use xlink:href="/symbol/volta-icons.svg#Vlt-icon-star-full"/></svg>


### PR DESCRIPTION
## Description

Responding to issue #1673 -- color has been changed for PHP from red to blue.

## Deploy Notes

Notes regarding deployment the contained body of work. These should note any db migrations, etc.
