### PR TITLE
Update file send typos

### DIFF
--- a/_documentation/messages/code-snippets/whatsapp/send-file.md
+++ b/_documentation/messages/code-snippets/whatsapp/send-file.md
@@ -18,8 +18,8 @@ Key | Description
 `NEXMO_APPLICATION_ID` | The ID of the application that you created.
 `WHATSAPP_NUMBER` | The WhatsApp number that has been allocated to you by Nexmo.
 `TO_NUMBER` | The phone number you are sending the message to.
-`FILE_URL` | The URL of the image to send.
-`FILE_CAPTION` | The text describing the image being sent.
+`FILE_URL` | The URL of the file to send.
+`FILE_CAPTION` | The text describing the file being sent.
 
 > **NOTE:** Don't use a leading `+` or `00` when entering a phone number, start with the country code, for example, 447700900000.
 


### PR DESCRIPTION
Just replaced 'images' word with 'file' in the FILE_URL and FILE_CAPTION description.
