### PR TITLE
Add lograge log formatting in production

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -143,6 +143,9 @@ gem 'titleize'
 # Used in our reporting rake tasks
 gem 'terminal-table'
 
+# Single line logging for production
+gem 'lograge'
+
 group :development, :test do
   gem 'awesome_print'
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -204,6 +204,11 @@ GEM
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
       ruby_dep (~> 1.2)
+    lograge (0.11.0)
+      actionpack (>= 4)
+      activesupport (>= 4)
+      railties (>= 4)
+      request_store (~> 1.0)
     loofah (2.2.3)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
@@ -303,6 +308,8 @@ GEM
     recaptcha (4.3.1)
       json
     redcarpet (3.4.0)
+    request_store (1.4.1)
+      rack (>= 1.4)
     responders (2.4.1)
       actionpack (>= 4.2.0, < 6.0)
       railties (>= 4.2.0, < 6.0)
@@ -439,6 +446,7 @@ DEPENDENCIES
   jbuilder (~> 2.7.0)
   jquery-rails
   listen (>= 3.0.5, < 3.2)
+  lograge
   neatjson
   nokogiri (~> 1.8.5)
   oas_parser (= 0.18.1)

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -91,4 +91,7 @@ Rails.application.configure do
 
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
+
+  # Enable single line logging
+  config.lograge.enabled = true
 end


### PR DESCRIPTION
## Description

We've started pushing logs to Kibana and the default multiline
formatting is causing issues. This renders all logs on a single line as
key=value pairs

## Deploy Notes
N/A
