### PR TITLE
Highlight path parameters in API references

### DIFF
--- a/app/assets/stylesheets/layout/_api.scss
+++ b/app/assets/stylesheets/layout/_api.scss
@@ -145,3 +145,7 @@
     }
   }
 }
+
+.api-path-parameter {
+    color: $aqua-dark;
+}

--- a/app/views/open_api/_endpoint.html.erb
+++ b/app/views/open_api/_endpoint.html.erb
@@ -12,7 +12,7 @@
           <%
               servers = endpoint.path.servers ? endpoint.path.servers : endpoint.definition.servers
           %>
-          <span><%= servers[0]['url'] %></span><%= endpoint.path.path.gsub(/\{(.+?)\}/, '<span class="api-path-parameter">:\1</span>').html_safe %>
+        <span><%= servers[0]['url'] %></span><%= endpoint.path.path.gsub(/\{(.+?)\}/, '<span class="api-path-parameter">{\1}</span>').html_safe %>
         </code>
       </div>
 


### PR DESCRIPTION
## Description

* Uses curly braces rather than a colon
* Highlight the parameter in a colour

Resolves #1685

## Deploy Notes

N/A
