### PR TITLE
Add tutorial language/product filtering

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -21,6 +21,7 @@
 //= require volta/tooltip.min.js
 //= require volta/components/volta.tooltip.js
 //= require volta/components/volta.modal.js
+//= require volta/components/volta.dropdown.js
 //= require clipboard
 //= require underscore
 //= require gmaps/google

--- a/app/controllers/tutorials_controller.rb
+++ b/app/controllers/tutorials_controller.rb
@@ -20,6 +20,20 @@ class TutorialsController < ApplicationController
       @base_path.gsub!(%r{/#{lang}$}, '')
     end
 
+    excluded_languages = ['csharp', 'javascript', 'kotlin', 'android', 'swift', 'objective_c']
+    @languages = CodeLanguage.languages.reject { |l| excluded_languages.include?(l.key) }
+
+    @products = [
+      { 'path' => 'messaging/sms', 'icon' => 'message', 'icon_colour' => 'purple', 'name' => 'SMS' },
+      { 'path' => 'voice/voice-api', 'icon' => 'phone', 'icon_colour' => 'green', 'name' => 'Voice' },
+      { 'path' => 'verify', 'icon' => 'lock', 'icon_colour' => 'purple-dark', 'name' => 'Verify' },
+      { 'path' => 'messages', 'icon' => 'chat', 'icon_colour' => 'blue', 'name' => 'Messages' },
+      { 'path' => 'dispatch', 'icon' => 'flow', 'icon_colour' => 'blue', 'name' => 'Dispatch' },
+      { 'path' => 'number-insight', 'icon' => 'file-search', 'icon_colour' => 'orange', 'name' => 'Number Insight' },
+      { 'path' => 'conversation', 'icon' => 'message', 'icon_colour' => 'blue', 'name' => 'Conversation' },
+      { 'path' => 'client-sdk', 'icon' => 'queue', 'icon_colour' => 'blue', 'name' => 'Client SDK' },
+    ]
+
     render layout: 'page'
   end
 

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -67,7 +67,7 @@ let refresh = () => {
   let rightPane = document.querySelector(".Vlt-main");
   if (rightPane) { rightPane.click(); }
 
-  Volta.init(['accordion', 'tooltip', 'tab', 'modal'])
+  Volta.init(['accordion', 'tooltip', 'tab', 'modal', 'dropdown'])
 
   // Fix for Turbolinks scrolling to in-page anchor when navigating to a new page
   if(window.location.hash){

--- a/app/views/tutorials/_index.html.erb
+++ b/app/views/tutorials/_index.html.erb
@@ -1,3 +1,11 @@
+<% unless @tutorials.count.positive? %>
+  <div class="Vlt-callout Vlt-callout--warning">
+    <i></i>
+    <div class="Vlt-callout__content">
+      No tutorials available in this language
+    </div>
+  </div>
+  <% else %>
 <div class="masonry" data-turbolinks="false">
   <% @tutorials.each_with_index do |tutorial, index| %>
     <div class="item">
@@ -30,3 +38,4 @@
     </div>
   <% end %>
 </div>
+<% end %>

--- a/app/views/tutorials/index.html.erb
+++ b/app/views/tutorials/index.html.erb
@@ -1,7 +1,48 @@
 <h1>Tutorials</h1>
 
-<p>Get started with Nexmo with tutorials that will walk you through building a variety of practical applications</p>
 
-<br>
+<style>
+  .tutorial-language-link svg {
+    height: 15px;
+    width: 15px;
+  }
+</style>
+
+<strong>Filter: &nbsp;&nbsp;</strong>
+
+<div class="Vlt-dropdown">
+  <button class="Vlt-dropdown__btn">
+    Choose a language
+  </button>
+  <div class="Vlt-dropdown__panel">
+    <div class="Vlt-dropdown__panel__content">
+      <ul>
+        <% @languages.each do |lang| %>
+          <li><a class="Vlt-dropdown__link" href="<%= "#{@base_path}/#{lang.key}" %>"><svg style="height: 20px; width: 20px;" ><use xlink:href="/assets/images/brands/<%= lang.icon %>.svg#<%= lang.icon %>"></use></svg><span><%= lang.label %></span></a></li>
+        <% end %>
+      </ul>
+    </div>
+  </div>
+</div>
+
+
+<div class="Vlt-dropdown">
+  <button class="Vlt-dropdown__btn">
+    Choose a product
+  </button>
+  <div class="Vlt-dropdown__panel">
+    <div class="Vlt-dropdown__panel__content">
+      <ul>
+        <% @products.each do |product| %>
+          <li><a class="Vlt-dropdown__link" href="/<%= product['path'] %>/tutorials/<%= @language %>"><svg style="height: 20px; width: 20px;" class="Vlt-<%= product['icon_colour'] %>"><use xlink:href="/symbol/volta-icons.svg#Vlt-icon-<%= product['icon'] %>"></use></svgc><span><%= product['name'] %></span></a></li>
+        <% end %>
+      </ul>
+    </div>
+  </div>
+</div>
+
+<br><br>
+
+<p>Get started with Nexmo with tutorials that will walk you through building a variety of practical applications</p>
 
 <%= render 'index' %>


### PR DESCRIPTION
## Description

We've had the ability to filter tutorials by language/product for a while. This makes it *really* obvious on the tutorials page.

## Deploy Notes

N/A
