### PR TITLE
Add Video tile to homepage

### DIFF
--- a/app/assets/stylesheets/objects/_card.scss
+++ b/app/assets/stylesheets/objects/_card.scss
@@ -174,3 +174,18 @@
     padding: 10px;
   }
 }
+
+
+.Vlt-card {
+  &__image {
+    &--aqua {
+      background: linear-gradient(to right, lighten($aqua, 5), darken($aqua, 10));
+
+      .Vlt-card__image__icon svg {
+        fill: $aqua;
+      }
+    }
+  }
+
+
+}

--- a/app/views/static/_products.html.erb
+++ b/app/views/static/_products.html.erb
@@ -71,37 +71,40 @@
 
   <div class="Vlt-col Vlt-col--1of3 Vlt-col--M-1of2">
     <div class="Vlt-card Vlt-article--reverse Vlt-card--image Nxd-card--products">
-      <div class="Vlt-card__image Vlt-card__image--app Vlt-card__image--teal">
+      <div class="Vlt-card__image Vlt-card__image--app Vlt-card__image--aqua">
         <div class="Vlt-card__image__icon">
           <svg>
-            <use xlink:href="/symbol/volta-icons.svg#Vlt-icon-queue" /></svg>
+            <use xlink:href="/symbol/volta-icons.svg#Vlt-icon-video" /></svg>
         </div>
       </div>
+
       <div class="Vlt-card__content">
-        <small class="Vlt-teal">Programmable Conversations</small>
+        <small class="Vlt-grey-dark">Programmable</small>
         <h2>
-          <a href="/conversation/overview">
-            Conversation API
+          <a target="_blank" href="https://tokbox.com/developer/guides/basics/">
+            Video
           </a>
+          <small class="Vlt-grey-dark" style="font-size:1.4rem; font-weight:normal;">powered by OpenTok
+           <svg style="height: 15px; width: 15px;" class="Vlt-icon Vlt-icon--text-bottom Vlt-grey-dark" aria-hidden="true">
+            <use xlink:href="/symbol/volta-icons.svg#Vlt-icon-open" />
+           </svg>
+          </small>
         </h2>
         <nav>
-          <a href="/conversation/overview"><svg class="Vlt-icon Vlt-icon--small Vlt-icon--text-bottom Vlt-teal"
+          <a target="_blank" href="https://tokbox.com/developer/guides/basics/"><svg class="Vlt-icon Vlt-icon--small Vlt-icon--text-bottom Vlt-aqua"
               aria-hidden="true">
               <use xlink:href="/symbol/volta-icons.svg#Vlt-icon-home" /></svg>Overview</a>
-          <a href="/conversation/concepts/conversation"><svg
-              class="Vlt-icon Vlt-icon--small Vlt-icon--text-bottom Vlt-teal" aria-hidden="true">
-              <use xlink:href="/symbol/volta-icons.svg#Vlt-icon-books" /></svg>Concepts</a>
-          <a href="/conversation/guides/application-setup"><svg
-              class="Vlt-icon Vlt-icon--small Vlt-icon--text-bottom Vlt-teal" aria-hidden="true">
+          <a target="_blank" href="https://tokbox.com/developer/guides/"><svg class="Vlt-icon Vlt-icon--small Vlt-icon--text-bottom Vlt-aqua"
+              aria-hidden="true">
               <use xlink:href="/symbol/volta-icons.svg#Vlt-icon-books" /></svg>Guides</a>
-          <a href="/conversation/code-snippets/conversation/list-conversations"><svg
-              class="Vlt-icon Vlt-icon--small Vlt-icon--text-bottom Vlt-teal" aria-hidden="true">
+          <a target="_blank" href="https://tokbox.com/developer/samples/"><svg class="Vlt-icon Vlt-icon--small Vlt-icon--text-bottom Vlt-aqua"
+              aria-hidden="true">
               <use xlink:href="/symbol/volta-icons.svg#Vlt-icon-code" /></svg>Code Snippets</a>
-          <a href="/conversation/tutorials"><svg class="Vlt-icon Vlt-icon--small Vlt-icon--text-bottom Vlt-teal"
+          <a target="_blank" href="https://tokbox.com/developer/tutorials/"><svg class="Vlt-icon Vlt-icon--small Vlt-icon--text-bottom Vlt-aqua"
               aria-hidden="true">
               <use xlink:href="/symbol/volta-icons.svg#Vlt-icon-mockup" /></svg>Tutorials</a>
           <hr class="hr--short">
-          <a href="/api/conversation">API Reference</a>
+          <a target="_blank" href="https://tokbox.com/developer/sdks/js/">API Reference</a>
         </nav>
       </div>
     </div>
@@ -177,6 +180,73 @@
     </div>
   </div>
 
+
+
+  <div class="Vlt-col Vlt-col--1of3 Vlt-col--M-1of2">
+    <div class="Vlt-card Vlt-article--reverse Vlt-card--image Nxd-card--products">
+      <div class="Vlt-card__image Vlt-card__image--app Vlt-card__image--teal">
+        <div class="Vlt-card__image__icon">
+          <svg>
+            <use xlink:href="/symbol/volta-icons.svg#Vlt-icon-queue" /></svg>
+        </div>
+      </div>
+      <div class="Vlt-card__content">
+        <small class="Vlt-grey-dark">Programmable Conversations</small>
+        <h2>
+          <a href="/conversation/overview">
+            Conversation API
+          </a>
+        </h2>
+        <nav>
+          <a href="/conversation/overview"><svg class="Vlt-icon Vlt-icon--small Vlt-icon--text-bottom Vlt-teal"
+              aria-hidden="true">
+              <use xlink:href="/symbol/volta-icons.svg#Vlt-icon-home" /></svg>Overview</a>
+          <a href="/conversation/concepts/conversation"><svg class="Vlt-icon Vlt-icon--small Vlt-icon--text-bottom Vlt-teal"
+              aria-hidden="true">
+              <use xlink:href="/symbol/volta-icons.svg#Vlt-icon-books" /></svg>Concepts</a>
+          <a href="/conversation/code-snippets/conversation/list-conversations"><svg class="Vlt-icon Vlt-icon--small Vlt-icon--text-bottom Vlt-teal"
+              aria-hidden="true">
+              <use xlink:href="/symbol/volta-icons.svg#Vlt-icon-code" /></svg>Code Snippets</a>
+          <a href="/conversation/use-cases"><svg class="Vlt-icon Vlt-icon--small Vlt-icon--text-bottom Vlt-teal"
+              aria-hidden="true">
+              <use xlink:href="/symbol/volta-icons.svg#Vlt-icon-mockup" /></svg>Tutorials</a>
+          <hr class="hr--short">
+          <a href="/api/conversation">API Reference</a>
+        </nav>
+      </div>
+    </div>
+  </div>
+
+   <div class="Vlt-col Vlt-col--1of3 Vlt-col--M-1of2">
+    <div class="Vlt-card Vlt-article--reverse Vlt-card--image Nxd-card--products">
+      <div class="Vlt-card__image Vlt-card__image--app Vlt-card__image--blue">
+        <div class="Vlt-card__image__icon">
+          <svg>
+            <use xlink:href="/symbol/volta-icons.svg#Vlt-icon-flow" /></svg>
+        </div>
+      </div>
+      <div class="Vlt-card__content">
+        <small class="Vlt-grey-dark">Configure</small>
+        <h2>
+          <a href="/application/overview">
+            Applications
+          </a>
+        </h2>
+        <nav>
+          <a href="/application/overview"><svg class="Vlt-icon Vlt-icon--small Vlt-icon--text-bottom Vlt-blue" aria-hidden="true">
+              <use xlink:href="/symbol/volta-icons.svg#Vlt-icon-home" /></svg>Overview</a>
+          <a href="/application/overview"><svg class="Vlt-icon Vlt-icon--small Vlt-icon--text-bottom Vlt-blue" aria-hidden="true">
+            <use xlink:href="/symbol/volta-icons.svg#Vlt-icon-books" /></svg>Concepts</a>
+          <a href="/application/code-snippets"><svg class="Vlt-icon Vlt-icon--small Vlt-icon--text-bottom Vlt-blue" aria-hidden="true">
+              <use xlink:href="/symbol/volta-icons.svg#Vlt-icon-code" /></svg>Code Snippets</a>
+          <br>
+          <hr class="hr--short">
+          <a href="/api/application.v2">API Reference</a>
+        </nav>
+      </div>
+    </div>
+  </div>
+
   <div class="Vlt-col Vlt-col--1of3 Vlt-col--M-1of2">
     <div class="Vlt-card Vlt-article--reverse Vlt-card--image Nxd-card--products">
       <div class="Vlt-card__image Vlt-card__image--app Vlt-card__image--blue-light">
@@ -213,19 +283,19 @@
   <div class="Vlt-col Vlt-col--1of3 Vlt-col--M-1of2 Nxd-col-stretch">
     <div class="Vlt-card Vlt-article--reverse Vlt-card--center">
 
-      <nav>
+      <nav class="Vlt-center" style="width:100%;">
         <h3 class="Vlt-grey-dark">Developer API</h3>
         <a href="/api/developer/messages">Messages</a> |
         <a href="/api/developer/numbers">Numbers</a> |
         <a href="/api/developer/pricing">Pricing</a>
       </nav>
       <hr class="hr--short">
-      <nav>
+      <nav class="Vlt-center" style="width:100%;">
         <h3 class="Vlt-grey-dark">Global APIs</h3>
-        <a href="/api/application">Application</a> |
-        <a href="/api/conversion">Conversion</a>
+        <a href="/api/account">Account</a> |
+        <a href="/api/conversion">Conversion</a> |
+        <a href="/api/media">Media</a>
         <br />
-        <a href="/api/media">Media</a> |
         <a href="/api/redact">Redact</a> |
         <a href="/api/account/secret-management">Secret Management</a>
       </nav>

--- a/config/navigation.yml
+++ b/config/navigation.yml
@@ -56,7 +56,7 @@ navigation_weight:
 navigation_overrides:
   application:
     svg: 'flow'
-    svgColor: 'indigo'
+    svgColor: 'blue'
   concepts:
     navigation_weight: 0
     svg: 'mind-map'

--- a/spec/features/landing_page_spec.rb
+++ b/spec/features/landing_page_spec.rb
@@ -47,16 +47,15 @@ RSpec.feature 'Landing page' do
       end
 
       within('.Vlt-col.Vlt-col--1of3.Vlt-col--M-1of2:nth-of-type(3)') do
-        expect(page).to have_css('small', text: 'Programmable Conversations')
-        expect(page).to have_link('Conversation API', href: '/conversation/overview')
+        expect(page).to have_css('small', text: 'Programmable')
+        expect(page).to have_link('Video', href: 'https://tokbox.com/developer/guides/basics/')
 
         within('nav') do
-          expect(page).to have_link('Overview', href: '/conversation/overview')
-          expect(page).to have_link('Concepts', href: '/conversation/concepts/conversation')
-          expect(page).to have_link('Guides', href: '/conversation/guides/application-setup')
-          expect(page).to have_link('Code Snippets', href: '/conversation/code-snippets/conversation/list-conversations')
-          expect(page).to have_link('Tutorials', href: '/conversation/tutorials')
-          expect(page).to have_link('API Reference', href: '/api/conversation')
+          expect(page).to have_link('Overview', href: 'https://tokbox.com/developer/guides/basics/')
+          expect(page).to have_link('Guides', href: 'https://tokbox.com/developer/guides/')
+          expect(page).to have_link('Code Snippets', href: 'https://tokbox.com/developer/samples/')
+          expect(page).to have_link('Tutorials', href: 'https://tokbox.com/developer/tutorials/')
+          expect(page).to have_link('API Reference', href: 'https://tokbox.com/developer/sdks/js/')
         end
       end
 
@@ -87,6 +86,31 @@ RSpec.feature 'Landing page' do
       end
 
       within('.Vlt-col.Vlt-col--1of3.Vlt-col--M-1of2:nth-of-type(6)') do
+        expect(page).to have_css('small', text: 'Programmable Conversations')
+        expect(page).to have_link('Conversation API', href: '/conversation/overview')
+
+        within('nav') do
+          expect(page).to have_link('Overview', href: '/conversation/overview')
+          expect(page).to have_link('Concepts', href: '/conversation/concepts/conversation')
+          expect(page).to have_link('Code Snippets', href: '/conversation/code-snippets/conversation/list-conversations')
+          expect(page).to have_link('Tutorials', href: '/conversation/use-cases')
+          expect(page).to have_link('API Reference', href: '/api/conversation')
+        end
+      end
+
+      within('.Vlt-col.Vlt-col--1of3.Vlt-col--M-1of2:nth-of-type(7)') do
+        expect(page).to have_css('small', text: 'Configure')
+        expect(page).to have_link('Applications', href: '/application/overview')
+
+        within('nav') do
+          expect(page).to have_link('Overview', href: '/application/overview')
+          expect(page).to have_link('Concepts', href: '/application/overview')
+          expect(page).to have_link('Code Snippets', href: '/application/code-snippets')
+          expect(page).to have_link('API Reference', href: '/api/application.v2')
+        end
+      end
+
+      within('.Vlt-col.Vlt-col--1of3.Vlt-col--M-1of2:nth-of-type(8)') do
         expect(page).to have_css('small', text: 'Management')
         expect(page).to have_link('Account', href: '/account/overview')
 
@@ -98,7 +122,7 @@ RSpec.feature 'Landing page' do
         end
       end
 
-      within('.Vlt-col.Vlt-col--1of3.Vlt-col--M-1of2:nth-of-type(7)') do
+      within('.Vlt-col.Vlt-col--1of3.Vlt-col--M-1of2:nth-of-type(9)') do
         within('nav:nth-of-type(1)') do
           expect(page).to have_css('h3', text: 'Developer API')
           expect(page).to have_link('Messages', href: '/api/developer/messages')
@@ -108,7 +132,6 @@ RSpec.feature 'Landing page' do
 
         within('nav:nth-of-type(2)') do
           expect(page).to have_css('h3', text: 'Global APIs')
-          expect(page).to have_link('Application', href: '/api/application')
           expect(page).to have_link('Conversion', href: '/api/conversion')
           expect(page).to have_link('Media', href: '/api/media')
           expect(page).to have_link('Redact', href: '/api/redact')


### PR DESCRIPTION
## Description

Add a Video tile to the homepage that links out to tokbox.com

This involved a little tile reorganisation, and I took the opportunity to add a tile for Applications to balance the number of tiles

The homepage is getting quite large, but this is a step in the right direction and we can look at a more substantial overhaul on #1693

## Deploy Notes

N/A