### PR TITLE
Make sure Before you begin is first

### DIFF
--- a/_documentation/voice/voice-api/code-snippets/before-you-begin.md
+++ b/_documentation/voice/voice-api/code-snippets/before-you-begin.md
@@ -1,6 +1,6 @@
 ---
 title: Before you begin
-navigation_weight: 1
+navigation_weight: 0
 ---
 
 # Before you begin


### PR DESCRIPTION
## Description

Make sure "Before you begin" is first. Did this because make outbound call with NCCO had also been given a `navigation_weight` of 1.

## Review

Review app is available.