### PR TITLE
Fixed URL inspection to ignore parameters when identifying Community page

### DIFF
--- a/app/controllers/static_controller.rb
+++ b/app/controllers/static_controller.rb
@@ -15,7 +15,7 @@ class StaticController < ApplicationController
       end
     end
 
-    if request.fullpath.split('/').last == 'community'
+    if request.path.gsub('/', '') == 'community'
       @upcoming_events = Event.upcoming
       @past_events_count = Event.past.count
 

--- a/app/controllers/static_controller.rb
+++ b/app/controllers/static_controller.rb
@@ -15,7 +15,7 @@ class StaticController < ApplicationController
       end
     end
 
-    if request.path.gsub('/', '') == 'community'
+    if request.path.delete('/') == 'community'
       @upcoming_events = Event.upcoming
       @past_events_count = Event.past.count
 


### PR DESCRIPTION
This PR addresses a ticket raised in JIRA by @cr0wst that the new Community page was failing to display upcoming events in either the map or in the listings if the URL had additional parameters (e.g. referral attributes). The Controller method uses the URL path to identify the requested page as the Community page and then query the DB for upcoming events. The method has now been fixed to ignore trailing parameters during that identification process. 
