### PR TITLE
PHP update example showing wrong snippet

### DIFF
--- a/_examples/numbers/update/php.yml
+++ b/_examples/numbers/update/php.yml
@@ -1,9 +1,9 @@
 ---
 code:
-    source: .repos/nexmo/nexmo-php-code-snippets/numbers/purchase.php
+    source: .repos/nexmo/nexmo-php-code-snippets/numbers/update.php
     from_line: 8
     to_line: 21
 client:
-    source: .repos/nexmo/nexmo-php-code-snippets/numbers/purchase.php 
+    source: .repos/nexmo/nexmo-php-code-snippets/numbers/update.php 
     from_line: 5
     to_line: 6


### PR DESCRIPTION
## Description

Mark Berkeland noticed that the 'update' example was showing the 'purchase' code snippet. This PR fixes that.

