### PR TITLE
Collapse all nested navigation by default

### DIFF
--- a/app/assets/stylesheets/objects/_navigation.scss
+++ b/app/assets/stylesheets/objects/_navigation.scss
@@ -58,10 +58,6 @@
     color: $blue-dark;
   }
 
-  .navigation-item--sdk-documentation > a {
-    color: $green
-  }
-
   .navigation-item--ncco-reference a {
     color: $teal;
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -191,11 +191,11 @@ module ApplicationHelper
       # If it's a file, add a link
       output = output_link(child, title, options) if child[:is_file?]
 
-      # If it's a top level folder, add another dropdown
-      output = output_nested_dropdown(child, title) if options['collapsible']
+      # If we've explicitly said not to collapse this section, add a header
+      output = output_header_with_children(child, title) if !child[:is_file?] && !options['collapsible'].nil? && !options['collapsible']
 
-      # Otherwise we output a header and children
-      output ||= output_header_with_children(child, title)
+      # Otherwise render it inside a dropdown
+      output ||= output_nested_dropdown(child, title)
 
       ss << output
 

--- a/config/navigation.yml
+++ b/config/navigation.yml
@@ -63,22 +63,13 @@ navigation_overrides:
   messaging:
     svg: 'message'
     svgColor: 'purple'
-    sms:
-      collapsible: true
-    conversion-api:
-      collapsible: true
-    us-short-codes:
-      collapsible: true
   voice:
     svg: 'phone'
     svgColor: 'green'
     voice-api:
-      collapsible: true
       guides:
         websockets:
           label: 'Beta'
-    sip:
-      collapsible: true
   verify:
     svg: 'lock'
     svgColor: 'indigo'
@@ -88,8 +79,6 @@ navigation_overrides:
   account:
     svg: 'user'
     svgColor: 'blue'
-    secret-management:
-      collapsible: true
   redact:
     label: 'Dev Preview'
     svg: 'lock'
@@ -100,18 +89,7 @@ navigation_overrides:
     label: 'Dev Preview'
     sdk-documentation:
       link: false
-      android:
-        collapsible: true
-      ios:
-        collapsible: true
-      javascript:
-        collapsible: true
-    setup:
-      collapsible: true
-    in-app-voice:
-      collapsible: true
-    in-app-messaging:
-      collapsible: true
+      collapsible: false
   numbers:
     svg: 'phone-number'
     svgColor: 'red'
@@ -125,16 +103,6 @@ navigation_overrides:
     label: 'Beta'
     code-snippets:
       collapsible: false
-      sms:
-        collapsible: true
-      mms:
-        collapsible: true
-      messenger:
-        collapsible: true
-      viber:
-        collapsible: true
-      whatsapp:
-        collapsible: true
   dispatch:
     svg: 'flow'
     svgColor: 'purple'
@@ -145,16 +113,6 @@ navigation_overrides:
     label: 'Dev Preview'
     code-snippets:
       collapsible: false
-      conversation: 
-        collapsible: true
-      member: 
-        collapsible: true
-      user: 
-        collapsible: true
-      leg: 
-        collapsible: true
-      event: 
-        collapsible: true
   vonage-business-cloud:
     svg: 'telephone'
     svgColor: 'green'


### PR DESCRIPTION
## Description

We've seen that sections of navigation that we've marked as `collapsible` are working well. This PR makes it the default and adds the ability to mark sections as non-collapsible

## Deploy Notes

N/A
