### PR TITLE
Set cookie with utm_ parameters to track referrals

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -17,8 +17,6 @@
 //= require volta/volta.core.js
 //= require volta/components/volta.accordion.js
 //= require volta/components/volta.tab.js
-//= require volta/popper.min.js
-//= require volta/tooltip.min.js
 //= require volta/components/volta.tooltip.js
 //= require volta/components/volta.modal.js
 //= require volta/components/volta.dropdown.js

--- a/app/controllers/markdown_controller.rb
+++ b/app/controllers/markdown_controller.rb
@@ -3,6 +3,7 @@ class MarkdownController < ApplicationController
   before_action :set_product
   before_action :set_document
   before_action :set_namespace
+  before_action :set_tracking_cookie
 
   def show
     redirect = Redirector.find(request)
@@ -68,6 +69,10 @@ class MarkdownController < ApplicationController
     @document_path = path
     [params, request.parameters].each { |o| o.delete(:code_language) }
     @code_language = nil
+  end
+
+  def set_tracking_cookie
+    helpers.dashboard_cookie(params[:product])
   end
 
   def document

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -303,4 +303,27 @@ module ApplicationHelper
       c
     end.join(' ')
   end
+
+  def dashboard_cookie(campaign)
+    # This is the first touch time so we only want to set it if it's not already set
+    set_utm_cookie('ft', Time.now.getutc.to_i) unless cookies[:ft]
+
+    # These are the things we'll be tracking through the customer dashboard
+    set_utm_cookie('utm_source', 'developer.nexmo.com')
+    set_utm_cookie('utm_medium', 'referral')
+    set_utm_cookie('utm_campaign', campaign)
+
+    # We don't use term or content as it's not paid, but they may have been set by other things
+    # If they were, delete them so our data isn't tainted
+    cookies.delete('utm_term', domain: :all)
+    cookies.delete('utm_content', domain: :all)
+  end
+
+  def set_utm_cookie(name, value)
+    cookies[name] = {
+      value: value,
+      expires: 1.year.from_now,
+      domain: :all,
+    }
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -96,10 +96,8 @@ Rails.application.routes.draw do
   end
 
   scope '(:namespace)', namespace: /contribute/, defaults: { namespace: '' } do
-    get '/*document(/:code_language)', to: 'markdown#show', constraints: DocumentationConstraint.documentation
+    get '/(:product)/*document(/:code_language)', to: 'markdown#show', constraints: DocumentationConstraint.documentation
   end
-
-  get '/:product/*document(/:code_language)', to: 'markdown#show', constraints: DocumentationConstraint.documentation
 
   get '*unmatched_route', to: 'application#not_found'
 


### PR DESCRIPTION
## Description

This PR adds a set of utm_* cookies to help track referrals from Nexmo
Developer to the customer dashboard. It contains the latest product
viewed if available in utm_campaign

The testing of this functionality discovered some unused JS imports and
a redundant route, which have been removed

## Deploy Notes

N/A