### PR TITLE
Reachability info not available in the US

### DIFF
--- a/_documentation/number-insight/code-snippets/number-insight-advanced-async.md
+++ b/_documentation/number-insight/code-snippets/number-insight-advanced-async.md
@@ -9,7 +9,7 @@ The Number Insight Advanced API provides all the data from the [Number Insight S
 
 * If the number is likely to be valid
 * If the number is ported
-* If the number is reachable
+* If the number is reachable (not available in the US)
 * If the number is roaming and, if so, the carrier and country
 
 Use this information to determine the risk associated with a number.

--- a/_documentation/number-insight/overview.md
+++ b/_documentation/number-insight/overview.md
@@ -42,7 +42,7 @@ Carrier and country| ❌ | ✅ | ✅
 Ported| ❌ | ❌ | ✅
 IP match| ❌ | ❌ | ✅
 Validity| ❌ | ❌ | ✅
-Reachability| ❌ | ❌ | ✅
+Reachability (not available in the US)| ❌ | ❌ | ✅
 Roaming status| ❌ | ❌ | ✅
 Roaming carrier and country| ❌ | ❌ | ✅
 **US number** caller name and type| ❌ | ✅ | ✅


### PR DESCRIPTION
## Description

Addresses the issue reported in [DEVX-315](https://nexmoinc.atlassian.net/browse/DEVX-315): NI reachability info (Advanced API) is not available in the US.

Changed:
* NI overview page
* NI advanced code snippet description
