### PR TITLE
Wording change on EuRuKo landing page

### DIFF
--- a/config/landing_pages/e/euruko.yml
+++ b/config/landing_pages/e/euruko.yml
@@ -210,7 +210,7 @@ page:
     - column:
       - type: section_header
         section_header:
-          title: "Handy Rails related links and further reading"
+          title: "Handy Ruby related links and further reading"
           icon:
             name: "icon-pin-2"
             color: "blue-dark"


### PR DESCRIPTION
Change word from `Rails` to `Ruby`