### PR TITLE
Add Split for A/B testing

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -90,3 +90,6 @@ Style/Next:
 
 Style/ConditionalAssignment:
   Enabled: false
+
+Style/DoubleNegation:
+  Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -158,6 +158,9 @@ gem 'country_select', '~> 4.0'
 # gem 'nexmo-oas-renderer', github: 'nexmo/nexmo-oas-renderer', require: false
 gem 'nexmo-oas-renderer', '~> 0.2.1', require: false
 
+# A/B Testing
+gem 'split', '~> 3.3.2', require: 'split/dashboard'
+
 group :development, :test do
   gem 'awesome_print'
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -333,6 +333,7 @@ GEM
     recaptcha (4.3.1)
       json
     redcarpet (3.4.0)
+    redis (4.1.2)
     request_store (1.4.1)
       rack (>= 1.4)
     responders (2.4.1)
@@ -389,6 +390,7 @@ GEM
     shellany (0.0.1)
     shotgun (0.9.2)
       rack (>= 1.0)
+    simple-random (1.0.3)
     simplecov (0.16.1)
       docile (~> 1.1)
       json (>= 1.8, < 3)
@@ -403,6 +405,10 @@ GEM
     slack-notifier (2.3.1)
     sort_alphabetical (1.1.0)
       unicode_utils (>= 1.2.2)
+    split (3.3.2)
+      redis (>= 2.1)
+      simple-random (>= 0.9.3)
+      sinatra (>= 1.2.6)
     spring (2.0.2)
       activesupport (>= 4.2)
     spring-watcher-listen (2.0.1)
@@ -509,6 +515,7 @@ DEPENDENCIES
   sass-rails (~> 5.0)
   simplecov
   slack-notifier (= 2.3.1)
+  split (~> 3.3.2)
   spring
   spring-watcher-listen (~> 2.0.0)
   terminal-table

--- a/app/controllers/usage/ab_result_controller.rb
+++ b/app/controllers/usage/ab_result_controller.rb
@@ -1,0 +1,9 @@
+module Usage
+  class AbResultController < ApplicationController
+    skip_before_action :verify_authenticity_token
+
+    def create
+      ab_finished(params['t'].to_sym)
+    end
+  end
+end

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -102,6 +102,22 @@ let refresh = () => {
     }
     $(this).text(newText);
   });
+
+  $("[data-ab]").click(function(e) {
+      let r =  new Request('/usage/ab_result', {
+          method: 'POST',
+          credentials: 'same-origin',
+          body: JSON.stringify({'t': $(this).data('ab')}),
+          headers: {
+              'Content-Type': 'application/json'
+          }
+      });
+
+      fetch(r).then((response) => {
+          if (response.ok) { return response.json() }
+          return Promise.reject({ message: 'Bad response from server', response })
+      })
+  });
 }
 
 $(document).on('nexmo:load', function() {

--- a/app/views/layouts/partials/_header.html.erb
+++ b/app/views/layouts/partials/_header.html.erb
@@ -18,7 +18,11 @@
       <a class="Nxd-main-header__link Vlt-M-plus" href="https://nexmo.com">Nexmo.com</a>
       <a class="Nxd-main-header__link Vlt-M-plus" href="https://help.nexmo.com/hc/en-us">Support</a>
       <a class="Nxd-main-header__link Vlt-M-plus" href="https://dashboard.nexmo.com/sign-in">Sign In</a>
-      <a href="https://dashboard.nexmo.com/sign-up" class="Vlt-btn Vlt-btn--secondary"><b>Try it free</b></a>
+      <a href="https://dashboard.nexmo.com/sign-up" class="Vlt-btn Vlt-btn--secondary" data-ab="try_button"><b>
+        <% ab_test(:try_button, "Try it free", "Get started now") do |s| %>
+          <%= s %>
+        <% end %>
+      </b></a>
     </nav>
   </header>
 

--- a/config/initializers/split.rb
+++ b/config/initializers/split.rb
@@ -1,0 +1,3 @@
+Split.configure do |config|
+  config.enabled = !!ENV['REDIS_URL']
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,7 @@ Rails.application.routes.draw do
 
   namespace :usage do
     resources :code_snippet
+    resources :ab_result, only: [:create]
   end
 
   namespace :admin_api, defaults: { format: 'json' } do
@@ -79,6 +80,9 @@ Rails.application.routes.draw do
   get '/api', to: 'api#index'
 
   mount ::Nexmo::OAS::Renderer::API, at: '/api'
+  authenticated(:user) do
+    mount Split::Dashboard, at: 'split' if ENV['REDIS_URL']
+  end
 
   get '/(:product)/task/(:task_name)(/*task_step)(/:code_language)', to: 'task#index', constraints: DocumentationConstraint.documentation
   get '/task/(:task_name)(/*task_step)(/:code_language)', to: 'task#index', constraints: CodeLanguage.route_constraint


### PR DESCRIPTION
## Description

This adds the `Split` gem to perform A/B testing. If `REDIS_URL` is not provided as an environment variable then Split is not loaded.

To track a click on an element, add `data-ab="experiment_name"` to it. This will track a completion for `:experiment_name` on click

## Deploy Notes

This needs Redis to run. Without `REDIS_URL` being set, Split will not be loaded