### PR TITLE
Set default OAS_PATH in app.json for review apps

### DIFF
--- a/app.json
+++ b/app.json
@@ -22,7 +22,8 @@
     "GIT_REPO_URL": { "required": true },
     "GIT_SSH_KEY": { "required": true },
     "RACK_ENV": { "required": true },
-    "RAILS_ENV": { "required": true }
+    "RAILS_ENV": { "required": true },
+    "OAS_PATH": "_open_api/api_specs"
   },
   "stack": "heroku-18"
 }


### PR DESCRIPTION
## Description

API references don't work in review apps at the moment due to a missing `OAS_PATH` environment variable. This PR adds it to `app.json`

## Deploy Notes

N/A
