### PR TITLE
Add Transfer a call with Inline NCCO Markdown, Folder Structure & Ruby YAML

### DIFF
--- a/_documentation/voice/voice-api/code-snippets/transfer-a-call-inline-ncco.md
+++ b/_documentation/voice/voice-api/code-snippets/transfer-a-call-inline-ncco.md
@@ -1,0 +1,34 @@
+---
+title: Transfer a call with inline NCCO
+navigation_weight: 19
+---
+
+# Transfer a call with inline NCCO
+
+A code snippet that shows how to transfer control of the current call
+to control using inline NCCO.
+
+## Example
+
+Replace the following variables in the example code:
+
+Key |	Description
+-- | --
+`UUID` | The UUID of the call to modify.
+`action` | The action to use in updating the call. In this case `transfer`.
+
+```code_snippets
+source: '_examples/voice/transfer-a-call-inline-ncco'
+application:
+  type: voice
+  use_existing: |
+    Modifying an existing call requires that the <code>UUID</code> provided is a currently active call. To modify a call, you must use the same <code>NEXMO_APPLICATION_ID</code> and private key that were used to create the call.
+```
+
+## Try it out
+
+You will need to:
+
+1. Set up a call and obtain the call UUID. You could use the 'connect an inbound call' code snippet to do this.
+2. Run the example code to transfer the call.
+3. Control will be transferred to a new NCCO, and you will hear a text-to-speech message to confirm this.

--- a/_examples/voice/transfer-a-call-inline-ncco/ruby.yml
+++ b/_examples/voice/transfer-a-call-inline-ncco/ruby.yml
@@ -1,0 +1,15 @@
+---
+title: Ruby
+language: ruby
+dependencies:
+    - nexmo
+code:
+    source: .repos/nexmo/nexmo-ruby-code-snippets/voice/transfer-a-call-ncco.rb
+    from_line: 19
+    to_line: 29
+client:
+    source: .repos/nexmo/nexmo-ruby-code-snippets/voice/transfer-a-call-ncco.rb
+    from_line: 12
+    to_line: 17
+file_name: transfer-a-call-ncco.rb
+run_command: 'ruby transfer-a-call-ncco.rb'


### PR DESCRIPTION
## Description

This adds the code snippet markdown for transferring a call with inline NCCO, along with the appropriate folder structure, and the YAML pointing to the Ruby snippet.

## Deploy Notes

Notes regarding deployment the contained body of work. These should note any db migrations, etc.
