### PR TITLE
Fix a bug with the sidenavigation not beeing expandend.

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -208,7 +208,7 @@ module ApplicationHelper
 
   def output_link(item, title, options)
     # Setup
-    active_path = request.path
+    active_path = request.path.chomp("/#{params[:code_language]}")
     url = path_to_url(item[:path])
     has_active_class = (url == active_path)
 


### PR DESCRIPTION
## Description

Sidenavigation wasn't being expanded when visiting a code snippet with a specific
`code_language` or when clicking the back button.
## Deploy Notes

Notes regarding deployment the contained body of work. These should note any db migrations, etc.
