### PR TITLE
Generate JWT does not create correct permissions

### DIFF
--- a/_tutorials/client-sdk-generate-test-credentials.md
+++ b/_tutorials/client-sdk-generate-test-credentials.md
@@ -87,7 +87,7 @@ The user ID is used to perform tasks by the SDK, such as login, starting a call 
 Generate a JWT for the user. Remember to replace `MY_APP_ID` and `MY_USER_NAME` values in the command:
 
 ```bash
-nexmo jwt:generate ./private.key sub=MY_USER_NAME exp=$(($(date +%s)+86400)) acl='{"paths":{"/v1/users/**":{},"/v1/conversations/**":{},"/v1/sessions/**":{},"/v1/devices/**":{},"/v1/image/**":{},"/v3/media/**":{},"/v1/applications/**":{},"/v1/push/**":{},"/v1/knocking/**":{}}}' application_id=MY_APP_ID
+nexmo jwt:generate ./private.key sub=MY_USER_NAME exp=$(($(date +%s)+86400)) acl='{"paths":{"/*/users/**":{},"/*/conversations/**":{},"/*/sessions/**":{},"/*/devices/**":{},"/*/image/**":{},"/*/media/**":{},"/*/applications/**":{},"/*/push/**":{},"/*/knocking/**":{}}}' application_id=MY_APP_ID
 ```
 
 The above command sets the expiry of the JWT to one day from now, which is the maximum amount of time. You may change the expiration to a shortened amount of time, or regenerate a JWT for the user after the current JWT has expired.


### PR DESCRIPTION
## Description

Reported by Rich Chamberlain in NDP feedback:

It is giving error while executing generate jwt token command. I hard-coded the expiry time, still it is giving ""type: system:error:permission, description: " error while trying to create a ConversationClient client.

https://developer.nexmo.com/tutorials/client-sdk-generate-test-credentials


----

I believe the solution is to change v1 and v3 to '*'.
