### PR TITLE
Add sinatra-contrib gem to Ruby code snippets

### DIFF
--- a/_examples/messaging/sms/delivery-receipts/ruby.yml
+++ b/_examples/messaging/sms/delivery-receipts/ruby.yml
@@ -1,6 +1,7 @@
 ---
 dependencies:
     - sinatra
+    - sinatra-contrib
 code:
     source: .repos/nexmo/nexmo-ruby-code-snippets/sms/delivery_receipt.rb
     from_line: 15

--- a/_examples/messaging/sms/receiving-an-sms/ruby.yml
+++ b/_examples/messaging/sms/receiving-an-sms/ruby.yml
@@ -1,6 +1,7 @@
 ---
 dependencies:
     - sinatra
+    - sinatra-contrib
 code:
     source: .repos/nexmo/nexmo-ruby-code-snippets/sms/receive.rb
     from_line: 15

--- a/_examples/voice/connect-an-inbound-call/ruby.yml
+++ b/_examples/voice/connect-an-inbound-call/ruby.yml
@@ -1,6 +1,7 @@
 ---
 dependencies:
     - sinatra
+    - sinatra-contrib
 code:
     source: .repos/nexmo/nexmo-ruby-code-snippets/voice/connect_an_inbound_call.rb
     from_line: 9

--- a/_examples/voice/connect-callers-to-a-conference/ruby.yml
+++ b/_examples/voice/connect-callers-to-a-conference/ruby.yml
@@ -1,6 +1,7 @@
 ---
 dependencies:
     - sinatra
+    - sinatra-contrib
 code:
     source: .repos/nexmo/nexmo-ruby-code-snippets/voice/join_a_conference_call.rb
     from_line: 9

--- a/_examples/voice/handle-user-input-with-dtmf/ruby.yml
+++ b/_examples/voice/handle-user-input-with-dtmf/ruby.yml
@@ -1,6 +1,7 @@
 ---
 dependencies:
     - sinatra
+    - sinatra-contrib
 code:
     source: .repos/nexmo/nexmo-ruby-code-snippets/voice/dtmf.rb
     from_line: 15

--- a/_examples/voice/play-tts-into-a-call/ruby.yml
+++ b/_examples/voice/play-tts-into-a-call/ruby.yml
@@ -1,6 +1,7 @@
 ---
 dependencies:
     - sinatra
+    - sinatra-contrib
 code:
     source: .repos/nexmo/nexmo-ruby-code-snippets/voice/play-text-to-speech-into-a-call.rb
     from_line: 15

--- a/_examples/voice/receive-an-inbound-call/ruby.yml
+++ b/_examples/voice/receive-an-inbound-call/ruby.yml
@@ -1,6 +1,7 @@
 ---
 dependencies:
     - sinatra
+    - sinatra-contrib
 code:
     source: .repos/nexmo/nexmo-ruby-code-snippets/voice/inbound_tts_call.rb
     from_line: 15

--- a/_examples/voice/record-a-call-with-split-audio/ruby.yml
+++ b/_examples/voice/record-a-call-with-split-audio/ruby.yml
@@ -1,6 +1,7 @@
 ---
 dependencies:
     - sinatra
+    - sinatra-contrib
 code:
     source: .repos/nexmo/nexmo-ruby-code-snippets/voice/record-a-call-with-split-audio.rb
     from_line: 22

--- a/_examples/voice/record-a-call/ruby.yml
+++ b/_examples/voice/record-a-call/ruby.yml
@@ -1,6 +1,7 @@
 ---
 dependencies:
     - sinatra
+    - sinatra-contrib
 code:
     source: .repos/nexmo/nexmo-ruby-code-snippets/voice/record_a_call.rb
     from_line: 22

--- a/_examples/voice/record-a-conversation/ruby.yml
+++ b/_examples/voice/record-a-conversation/ruby.yml
@@ -1,6 +1,7 @@
 ---
 dependencies:
     - sinatra
+    - sinatra-contrib
 code:
     source: .repos/nexmo/nexmo-ruby-code-snippets/voice/record-a-conversation.rb
     from_line: 15

--- a/_examples/voice/record-a-message/ruby.yml
+++ b/_examples/voice/record-a-message/ruby.yml
@@ -1,6 +1,7 @@
 ---
 dependencies:
     - sinatra
+    - sinatra-contrib
 code:
     source: .repos/nexmo/nexmo-ruby-code-snippets/voice/record-a-message.rb
     from_line: 15


### PR DESCRIPTION
…ulti-route sinatra

## Description

Several of the Ruby code snippets use the Sinatra `multiroute` functionality to include `get` and `post` in one route. This PR adds the `sinatra-contrib` gem as a dependency to those snippets, since the multiroute functionality is a part of that gem, and not included in the base sinatra gem.

## Deploy Notes

Notes regarding deployment the contained body of work. These should note any db migrations, etc.
