### PR TITLE
Change Number Type to Network Type

### DIFF
--- a/_documentation/number-insight/overview.md
+++ b/_documentation/number-insight/overview.md
@@ -37,7 +37,7 @@ Each API level builds upon the capabilities of the previous one. For example, th
 Feature | Basic | Standard | Advanced
 :--|:--:|:--:|:--:
 Number format and origin| ✅ | ✅ | ✅    
-Number type| ❌ | ✅ | ✅
+Network type| ❌ | ✅ | ✅
 Carrier and country| ❌ | ✅ | ✅
 Ported| ❌ | ❌ | ✅
 IP match| ❌ | ❌ | ✅


### PR DESCRIPTION
## Description

The table of features for the different Number Insight APIs replicates the one on the [pricing page](https://www.nexmo.com/products/number-insight/pricing), where "Number Type" should read "Network Type" as described in [DOTCOM-1977]( https://nexmoinc.atlassian.net/browse/DOTCOM-1797).
