### PR TITLE
Remove quotes from generate JWT step

### DIFF
--- a/app/services/code_snippet_renderer/curl.rb
+++ b/app/services/code_snippet_renderer/curl.rb
@@ -5,7 +5,7 @@ module CodeSnippetRenderer
       raise 'The only permitted curl dependency is `jwt`' unless dependencies.include?('JWT')
       {
         'text' => 'Execute the following command at your terminal prompt to create the <a href="/concepts/guides/authentication#json-web-tokens-jwt">JWT</a> for authentication:',
-        'code' => 'export JWT=\'$(nexmo jwt:generate $PATH_TO_PRIVATE_KEY application_id=$NEXMO_APPLICATION_ID)\'',
+        'code' => 'export JWT=$(nexmo jwt:generate $PATH_TO_PRIVATE_KEY application_id=$NEXMO_APPLICATION_ID)',
       }
     end
 


### PR DESCRIPTION
## Description

The docs tell you to generate the JWT like this:

```
export JWT='$(nexmo jwt:generate $PATH_TO_PRIVATE_KEY application_id=$NEXMO_APPLICATION_ID)'
```

But the single quotes around the statement cause the statement itself to be stored as the JWT.

Changed to:

```
export JWT='$(nexmo jwt:generate $PATH_TO_PRIVATE_KEY application_id=$NEXMO_APPLICATION_ID)'
```
