### PR TITLE
Bump Nokogiri to 1.10.4.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -54,7 +54,7 @@ gem 'rouge', '~> 2.0.7'
 gem 'banzai', '~> 0.1.2'
 
 # Nokogiri (鋸) is an HTML, XML, SAX, and Reader parser. Among Nokogiri's many features is the ability to search documents via XPath or CSS3 selectors.
-gem 'nokogiri', '~> 1.8.5'
+gem 'nokogiri', '~> 1.10.4'
 
 # Autoload dotenv in Rails.
 gem 'dotenv-rails', groups: %i[development test]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -233,7 +233,7 @@ GEM
     mime-types-data (3.2016.0521)
     mimemagic (0.3.3)
     mini_mime (1.0.2)
-    mini_portile2 (2.3.0)
+    mini_portile2 (2.4.0)
     minitest (5.11.3)
     msgpack (1.2.4)
     multi_json (1.12.1)
@@ -259,8 +259,8 @@ GEM
       shotgun (~> 0.9)
       sinatra (~> 2.0)
     nio4r (2.4.0)
-    nokogiri (1.8.5)
-      mini_portile2 (~> 2.3.0)
+    nokogiri (1.10.4)
+      mini_portile2 (~> 2.4.0)
     notiffany (0.1.1)
       nenv (~> 0.1)
       shellany (~> 0.0)
@@ -497,7 +497,7 @@ DEPENDENCIES
   lograge
   neatjson
   nexmo-oas-renderer (~> 0.3.5)
-  nokogiri (~> 1.8.5)
+  nokogiri (~> 1.10.4)
   oas_parser (= 0.18.1)
   octicons_helper
   octokit


### PR DESCRIPTION
## Description

Fixes CVE-2019-5477, more here
https://github.com/sparklemotion/nokogiri/issues/1915.

## Deploy Notes

Notes regarding deployment the contained body of work. These should note any db migrations, etc.
