### PR TITLE
Fix broken link in Conversation API Event Flow guide

### DIFF
--- a/_documentation/conversation/guides/event-flow.md
+++ b/_documentation/conversation/guides/event-flow.md
@@ -41,7 +41,7 @@ As a result of `answer_url` execution, a new [Conversation](/conversation/concep
 
     b. **To your client-side application**, which is [integrated with the Nexmo Client SDK](/client-sdk/setup/add-sdk-to-your-app/android). These events can be received via callbacks that the Client SDKs trigger if a user is logged in to the SDK. They can also be received via push notifications, if they [have been enabled](/client-sdk/setup/set-up-push-notifications), and the app is in the background.
 
-> **Note:** Only selected events are dispatched to the Client SDKs. In order to receive all events, make sure you [set `event_url` webhooks for your Nexmo Application](application/overview#webhooks). Setting of event webhooks is not mandatory but is highly recommended.
+> **Note:** Only selected events are dispatched to the Client SDKs. In order to receive all events, make sure you [set `event_url` webhooks for your Nexmo Application](/application/overview#webhooks). Setting of event webhooks is not mandatory but is highly recommended.
 
 ## Reference
 


### PR DESCRIPTION
## Description

Fixed broken link to Webhooks section of Application overview.
