### PR TITLE
Define NEXMO_NUMBER in VAPI overview

### DIFF
--- a/_documentation/voice/voice-api/overview.md
+++ b/_documentation/voice/voice-api/overview.md
@@ -50,7 +50,7 @@ More details are available in this blog post: [Meet Voice Playground, Your Testi
 
 The primary way that you'll interact with the Nexmo voice platform is via the [public API](/voice/voice-api/api-reference). To place an outbound call, you make a `POST` request to `https://api.nexmo.com/v1/calls`.
 
-To make this easier, we provide client libraries in various languages that take care of authentication and creating the correct request body for you.
+To make this easier, Nexmo provides Server SDKs in various languages that take care of authentication and creating the correct request body for you.
 
 To get started, choose your language below and replace the following variables in the example code:
 

--- a/_documentation/voice/voice-api/overview.md
+++ b/_documentation/voice/voice-api/overview.md
@@ -50,7 +50,14 @@ More details are available in this blog post: [Meet Voice Playground, Your Testi
 
 The primary way that you'll interact with the Nexmo voice platform is via the [public API](/voice/voice-api/api-reference). To place an outbound call, you make a `POST` request to `https://api.nexmo.com/v1/calls`.
 
-To make this easier, we provide client libraries in various languages that take care of authentication and creating the correct request body for you. Choose your language below to get started.
+To make this easier, we provide client libraries in various languages that take care of authentication and creating the correct request body for you.
+
+To get started, choose your language below and replace the following variables in the example code:
+
+Key |	Description
+-- | --
+`NEXMO_NUMBER` |	Your Nexmo number that the call will be made from. For example `447700900000`.
+`TO_NUMBER` |	The number you would like to call to in E.164 format. For example `447700900001`.
 
 ```code_snippets
 source: '_examples/voice/make-an-outbound-call'


### PR DESCRIPTION
## Description

NEXMO_NUMBER is defined in the VAPI code snippets, but not the Overview that uses the Make Outbound Call snippet. As reported by @fauna5 in https://nexmoinc.atlassian.net/browse/DEVX-1396

