### PR TITLE
Add support for canonical URLs in tutorials

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -265,19 +265,17 @@ module ApplicationHelper
     YAML.load_file(path)
   end
 
-  def show_canonical_meta?
-    return true if params[:code_language].present?
-    return true if Rails.env.production? && request.base_url != 'https://developer.nexmo.com'
-    false
-  end
-
   def canonical_path
     request.path.chomp("/#{params[:code_language]}")
   end
 
   def canonical_url
-    base_url = Rails.env.production? ? 'https://developer.nexmo.com' : request.base_url
-    canonical_path.prepend(base_url)
+    return @canonical_url if @canonical_url
+    canonical_path.prepend(canonical_base)
+  end
+
+  def canonical_base
+    Rails.env.production? ? 'https://developer.nexmo.com' : request.base_url
   end
 
   def normalize_summary_title(summary, operation_id)

--- a/app/views/layouts/partials/_head.html.erb
+++ b/app/views/layouts/partials/_head.html.erb
@@ -67,9 +67,7 @@
   <% end %>
 
 
-  <% if show_canonical_meta? %>
-    <link rel="canonical" href="<%= canonical_url %>">
-  <% end %>
+  <link rel="canonical" href="<%= canonical_url %>">
 
   <%= stylesheet_link_tag "application", :media => "all" %>
   <%= javascript_include_tag 'application' %>

--- a/app/views/tutorial/single.html.erb
+++ b/app/views/tutorial/single.html.erb
@@ -1,0 +1,1 @@
+<%= @content.html_safe %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -85,6 +85,7 @@ Rails.application.routes.draw do
     mount Split::Dashboard, at: 'split' if ENV['REDIS_URL']
   end
 
+  get '/task/(:tutorial_step)', to: 'tutorial#single'
   get '/(:product)/tutorials', to: 'tutorial#list', constraints: DocumentationConstraint.documentation
   get '/tutorials', to: 'tutorial#list', constraints: DocumentationConstraint.documentation
   get '/(:product)/tutorials/(:tutorial_name)(/*tutorial_step)(/:code_language)', to: 'tutorial#index', constraints: DocumentationConstraint.documentation

--- a/config/tutorials/sending-facebook-message-with-failover.yml
+++ b/config/tutorials/sending-facebook-message-with-failover.yml
@@ -1,0 +1,38 @@
+title: Sending a Facebook message with failover
+description: The Dispatch API provides the ability to create message workflows with failover to secondary channels. This task looks at using the Dispatch API to send a Facebook message with failover to the SMS channel.
+products:
+  - dispatch
+
+introduction: 
+  title: Introduction to this task
+  description: This task shows you how to use the failover functionality of the Dispatch API.
+  content: |
+    # Introduction
+    The Dispatch API features workflows with automatic failover. In this task you see how to send a Facebook Messenger message with automatic failover to SMS.
+
+    > **NOTE:** This task assumes you have already created a Facebook Profile and a Facebook Page.
+
+prerequisites:
+- create-nexmo-account
+- install-nodejs
+- install-nexmo-cli-beta
+- install-node-sdk-beta
+- olympus/configure-webhooks
+- olympus/write-webhook-server
+- olympus/test-webhook-server
+
+tasks:
+- olympus/create-application
+- olympus/link-facebook-page
+- olympus/link-application-to-facebook
+- olympus/send-facebook-failover
+
+conclusion:
+  title: What's next?
+  description: What else can you do with the Dispatch API?
+  content: |
+
+    # What's next?
+    You can do a lot more with the Dispatch API.
+
+    See [Dispatch API documentation](/dispatch/overview) and [a multi-user, multi-channel workflow Dispatch use case](/tutorials/dispatch-user-fallback).


### PR DESCRIPTION
## Description

As we're reusing content across tutorials we need a way to mark content as a duplicate rendering using `rel=canonical`. If it's a single task, we link to `/task/:name`. If it's an intro/conclusion, link to the tutorial page without the product prefix.

As an intended side effect, this makes every page contain a canonical URL. This has no harmful sideeffects and is recommended. [[1]](https://yoast.com/rel-canonical/) [[2]](http://www.thesempost.com/using-rel-canonical-on-all-pages-for-duplicate-content-protection/)

## Deploy Notes

N/A
