### PR TITLE
Update TLS version

### DIFF
--- a/_documentation/voice/sip/overview.md
+++ b/_documentation/voice/sip/overview.md
@@ -79,7 +79,7 @@ You can use the following protocols:
 
 [Transport Layer Security](https://en.wikipedia.org/wiki/Transport_Layer_Security) (TLS) is a cryptographic protocol designed to provide communications security to your SIP connection. You can use self-signed certificates on your user agent, Nexmo does not validate the certificate on the client side.
 
-Connections using TLS 1.0 or more recent are accepted. Older protocols are disabled as they are considered insecure.
+Connections using TLS 1.2 are accepted. Older protocols are disabled as they are considered insecure.
 
 ## Inbound configuration
 


### PR DESCRIPTION
Since 20190829 only TLSv1.2 is accepted and used for outbound connections.

## Description

Please describe what the changes are made in this pull request and why the change was necessary.

## Deploy Notes

Notes regarding deployment the contained body of work. These should note any db migrations, etc.
