### PR TITLE
Fix Geocoding for events

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -150,6 +150,7 @@ gem 'terminal-table'
 gem 'lograge'
 
 # Country picker for ActiveAdmin
+gem 'countries'
 gem 'country_select', '~> 4.0'
 
 gem 'nexmo-oas-renderer', '~> 0.4.1', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -488,6 +488,7 @@ DEPENDENCIES
   clipboard-rails
   coffee-rails (~> 4.2)
   colorize
+  countries
   country_select (~> 4.0)
   devise (>= 4.6.0)
   diffy

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -28,6 +28,13 @@ class Event < ApplicationRecord
   private
 
   def address
+    # Provide the full country name to the geocoder,
+    # otherwise it thinks that IL is Illinois, not Israel
+    if country
+      country = ISO3166::Country[self.country.downcase]
+      country = country.name if country
+    end
+
     [city, country].compact.join(', ')
   end
 end


### PR DESCRIPTION
## Description

The Google maps geocoder was intepreting "Tel Aviv, IL" as a place called Tel-Aviv in Chicago, Illinos. This PR provides the full country name to the geocoder to make the results more accurate

## Deploy Notes

N/A