### PR TITLE
Fix secret management snippet list in guide

### DIFF
--- a/_documentation/account/guides/secret-management.md
+++ b/_documentation/account/guides/secret-management.md
@@ -30,4 +30,4 @@ Code snippets are examples showing how to use the API to perform various tasks.
 
 ```code_snippet_list
 product: account
-
+```


### PR DESCRIPTION
## Description

We were missing a closing code fence in the secret management guide. This adds it so that things render correctly

## Deploy Notes

N/A
