### PR TITLE
Agent canHear and canSpeak

### DIFF
--- a/_examples/voice/guides/ncco-reference/conversation/selective-audio-conference.md
+++ b/_examples/voice/guides/ncco-reference/conversation/selective-audio-conference.md
@@ -15,7 +15,7 @@ menu_weight: 2
   }
 ]
 
-// The agent joins and can both speak to, and be heard by the customer
+// The agent joins and can both hear, and speak to the customer
 // The agent's leg ID is 533c0874-f43d-446c-a153-f35bf30783fa
 [
   {


### PR DESCRIPTION
I believe that in this context both "can speak to" and "be heard by" refer to the "canSpeak" option. I find something like "The agent joins and can both hear, and speak to the customer" a clearer way of describing both of the "canHear" and "canSpeak" options.

## Description

Please describe what the changes are made in this pull request and why the change was necessary.

## Deploy Notes

Notes regarding deployment the contained body of work. These should note any db migrations, etc.
