### PR TITLE
Added transfer with NCCO example for PHP

### DIFF
--- a/_examples/voice/transfer-a-call-inline-ncco/php.yml
+++ b/_examples/voice/transfer-a-call-inline-ncco/php.yml
@@ -1,0 +1,9 @@
+---
+code:
+    source: .repos/nexmo/nexmo-php-code-snippets/voice/transfer-a-call-with-ncco/index.php
+    from_line: 16
+    to_line: 33
+client:
+    source: .repos/nexmo/nexmo-php-code-snippets/voice/transfer-a-call-with-ncco/index.php
+    from_line: 6
+    to_line: 7


### PR DESCRIPTION
## Description

Adds example for transferring a call with an NCCO for PHP

## Deploy Notes

The existing code snippet is fine, but there is a small change in https://github.com/Nexmo/nexmo-php-code-snippets/commit/b84c86928855f4562f0f5ceee289563edafa2b0d to bring it in spec with https://github.com/Nexmo/code-snippet-specs/blob/master/voice/transfer-a-call-with-ncco.md. Line numbers are unchanged. 
