### PR TITLE
Add redirect for application code snippets

### DIFF
--- a/config/redirects.yml
+++ b/config/redirects.yml
@@ -21,6 +21,7 @@
 "/account/secret-management/api-reference": "/api/account"
 "/account/api-reference": "/api/account"
 "/application/api-reference": "/api/application.v2"
+"/application/code-snippets": "/application/code-snippets/create-application"
 "/voice/voice-api": "/voice/voice-api/overview"
 "/audit/api-reference": "/api/audit"
 "/concepts": "/concepts/overview"


### PR DESCRIPTION
## Description

The link /application/code-snippet is used but currently does not point to anything. Make this point to the first code snippet using a redirect. This PR adds the necessary redirect.

## Review app

Check review app before approval. Go to developer.nexmo.com/documentation scroll down to Application section and click on code snippets. You should be taken to the first code snippet - create application.