### PR TITLE
Add documentation to list of allowed Greenhouse roles

### DIFF
--- a/app/services/greenhouse.rb
+++ b/app/services/greenhouse.rb
@@ -1,6 +1,6 @@
 class Greenhouse
   DEPARTMENT_ID = 4019731002
-  TITLES = ['sdk', 'advocate', 'community manager', 'education', 'dashboard'].freeze
+  TITLES = ['sdk', 'advocate', 'community manager', 'education', 'dashboard', 'documentation'].freeze
 
   def self.careers
     new.jobs


### PR DESCRIPTION
## Description

We need `documentation` in the list to show the new NDP role

## Deploy Notes

N/A
