### PR TITLE
Fix horizontal scrolling for campus banner

### DIFF
--- a/app/views/layouts/partials/_notices.html.erb
+++ b/app/views/layouts/partials/_notices.html.erb
@@ -19,8 +19,7 @@
 .vonage-campus {
     background-image: url('/assets/campus/banner_background.png');
     min-height: 100px;
-    margin-top: 10px;
-    margin-bottom: 10px;
+    margin: 10px 0;
 }
 
 .vonage-campus .campus-content{


### PR DESCRIPTION
## Description
<img width="145" alt="Screenshot 2019-10-07 at 13 16 15" src="https://user-images.githubusercontent.com/690132/66286695-223c5b80-e905-11e9-9fe3-cd2858a09399.png">

Volta grid has a negative left/right margin that's making the content not fixed width. And that creates horizontal scrolling. Setting left/right margins for the banner to 0 fixes the issue.
