### PR TITLE
Add a list of language definitions for Verify API

### DIFF
--- a/_documentation/verify/guides/verify-languages.md
+++ b/_documentation/verify/guides/verify-languages.md
@@ -6,17 +6,17 @@ navigation_weight: 1
 
 # Verify Languages
 
-The Verify API supports a variety of languages with the `lg` parameter to the "Verify Request" endpoint (see [API Reference](/api/verify#verifyRequest)). The currently-supported language options are listed here:
+The Verify API supports many languages with the `lg` parameter to the "Verify Request" endpoint (see [API Reference](/api/verify#verifyRequest)). The currently-supported language options and the codes to use are listed here:
 
-`lg` | Language
+Value of `lg` | Language
   --|--
-`ar-xa ` | [not found]
-`cs-cz` | [not found]
-`cy-cy` | [not found]
-`cy-gb` | [not found]
+`ar-xa` | Arabic
+`cs-cz` | Czech
+`cy-cy` | Welsh
+`cy-gb` | Welsh (UK)
 `da-dk` | Danish
 `de-de` | German
-`el-gr` |[not found] 
+`el-gr` | Greek
 `en-au` | English (Australia)
 `en-gb` | English (UK)
 `en-in` | English (India)
@@ -25,17 +25,17 @@ The Verify API supports a variety of languages with the `lg` parameter to the "V
 `es-mx` | Spanish (Mexico)
 `es-us` | Spanish (US)
 `fi-fi` | Finnish
-`fil-ph` | [not found]
+`fil-ph` | Filipino
 `fr-ca` | French (Canada)
 `fr-fr` | French (France)
-`hi-in` | [not found]
-`hu-hu` | [not found]
-`id-id` | [not found]
+`hi-in` | Hindi
+`hu-hu` | Hungarian
+`id-id` | Indonesian
 `is-is` | Icelandic
 `it-it` | Italian
 `ja-jp` | Japanese
 `ko-kr` | Korean
-`nb-no` | [not found]
+`nb-no` | Norwegian
 `nl-nl` | Dutch
 `pl-pl` | Polish
 `pt-br` | Portuguese (Brazil)
@@ -44,7 +44,7 @@ The Verify API supports a variety of languages with the `lg` parameter to the "V
 `ru-ru` | Russian
 `sv-se` | Swedish
 `tr-tr` | Turkish
-`vi-vn` | [not found]
-`zh-cn` | Mandarin Chinese
-`zh-tw` | [not found]
+`vi-vn` | Vietnamese
+`zh-cn` | Chinese (Mainland)
+`zh-tw` | Chinese (Taiwan)
 

--- a/_documentation/verify/guides/verify-languages.md
+++ b/_documentation/verify/guides/verify-languages.md
@@ -1,0 +1,50 @@
+---
+title: Verify Languages
+description: The available languges for Verify API
+navigation_weight: 1
+---
+
+# Verify Languages
+
+The Verify API supports a variety of languages with the `lg` parameter to the "Verify Request" endpoint (see [API Reference](/api/verify#verifyRequest)). The currently-supported language options are listed here:
+
+`lg` | Language
+  --|--
+`ar-xa ` | [not found]
+`cs-cz` | [not found]
+`cy-cy` | [not found]
+`cy-gb` | [not found]
+`da-dk` | Danish
+`de-de` | German
+`el-gr` |[not found] 
+`en-au` | English (Australia)
+`en-gb` | English (UK)
+`en-in` | English (India)
+`en-us` | English (US)
+`es-es` | Spanish (Spain)
+`es-mx` | Spanish (Mexico)
+`es-us` | Spanish (US)
+`fi-fi` | Finnish
+`fil-ph` | [not found]
+`fr-ca` | French (Canada)
+`fr-fr` | French (France)
+`hi-in` | [not found]
+`hu-hu` | [not found]
+`id-id` | [not found]
+`is-is` | Icelandic
+`it-it` | Italian
+`ja-jp` | Japanese
+`ko-kr` | Korean
+`nb-no` | [not found]
+`nl-nl` | Dutch
+`pl-pl` | Polish
+`pt-br` | Portuguese (Brazil)
+`pt-pt` | Portuguese (Portugal)
+`ro-ro` | Romanian
+`ru-ru` | Russian
+`sv-se` | Swedish
+`tr-tr` | Turkish
+`vi-vn` | [not found]
+`zh-cn` | Mandarin Chinese
+`zh-tw` | [not found]
+


### PR DESCRIPTION
## Description

We have a list of allowed values as an enum in the API reference, but no lookup for what the language codes mean - so I'm adding this. Currently a work in progress as we don't have definitions for all the languages.
