### PR TITLE
Check for `meta_title` and `description` Rake task for documentation

### DIFF
--- a/lib/tasks/documentation.rake
+++ b/lib/tasks/documentation.rake
@@ -3,11 +3,11 @@ namespace :documentation do
   task 'check_keys': :environment do
     documentation_path = "#{Rails.root}/_documentation/**/*.md"
     documents = []
-    
+
     Dir.glob(documentation_path).each do |filename|
       document = YAML.safe_load(File.read(filename))
-      
-      if (!document.key?('meta_title') == false || !document.key?('description') == false)
+
+      if !document.key?('meta_title') == false || !document.key?('description') == false
         documents.push(filename.split('/_documentation')[1])
       end
     end

--- a/lib/tasks/documentation.rake
+++ b/lib/tasks/documentation.rake
@@ -6,11 +6,13 @@ namespace :documentation do
 
     Dir.glob(documentation_path).each do |filename|
       document = YAML.safe_load(File.read(filename))
-
-      if !document.key?('meta_title') == false || !document.key?('description') == false
+      meta_title = document['meta_title']
+      description = document['description']
+      if meta_title.blank? || description.blank?
         documents.push(filename.split('/_documentation')[1])
       end
     end
-    puts "The following #{documents.count} documents are missing either a 'meta_title' or 'description' key:\n#{documents.join("\n")}"
+    count = documents.count
+    raise "The following #{count} documents are missing either a 'meta_title' or 'description' key:\n#{documents.join("\n")}" if count.positive?
   end
 end

--- a/lib/tasks/documentation.rake
+++ b/lib/tasks/documentation.rake
@@ -1,0 +1,16 @@
+namespace :documentation do
+  desc 'Verify all pages have meta_title and description keys'
+  task 'check_keys': :environment do
+    documentation_path = "#{Rails.root}/_documentation/**/*.md"
+    documents = []
+    
+    Dir.glob(documentation_path).each do |filename|
+      document = YAML.safe_load(File.read(filename))
+      
+      if (!document.key?('meta_title') == false || !document.key?('description') == false)
+        documents.push(filename.split('/_documentation')[1])
+      end
+    end
+    puts "The following #{documents.count} documents are missing either a 'meta_title' or 'description' key:\n#{documents.join("\n")}"
+  end
+end


### PR DESCRIPTION
## Description

This PR adds a rake task to check for the existence of `meta_title` and `description` in every document in `/_documentation`.

## Deploy Notes

Notes regarding deployment the contained body of work. These should note any db migrations, etc.
