### PR TITLE
Adding nexmo setup instructions to in-app-messaging tutorial

### DIFF
--- a/_tutorials/install-nexmo-cli-beta.md
+++ b/_tutorials/install-nexmo-cli-beta.md
@@ -10,3 +10,11 @@ To install the Beta version of the CLI with NPM you can use:
 ``` shell
 npm install nexmo-cli@beta -g
 ```
+
+Set up the Nexmo CLI to use your Nexmo API Key and API Secret. You can get these from the [settings page](https://dashboard.nexmo.com/settings) in the Nexmo Dashboard.
+
+Run the following command in a terminal, while replacing `api_key` and `api_secret` with your own:
+
+```bash
+nexmo setup api_key api_secret
+```


### PR DESCRIPTION
## Description

In the "Install the Nexmo CLI Beta" prerequisite for the in-app-messaging tutorial, the user isn't instructed to run `nexmo setup`.  This results in an error for the user on the next step "Create your Nexmo Client SDK Application" stating to run `nexmo setup`.

## Deploy Notes

Added the following to the `install-nexmo-cli-beta.md`:


Set up the Nexmo CLI to use your Nexmo API Key and API Secret. You can get these from the [settings page](https://dashboard.nexmo.com/settings) in the Nexmo Dashboard.

Run the following command in a terminal, while replacing `api_key` and `api_secret` with your own:

```bash
nexmo setup api_key api_secret
```
