### PR TITLE
Modifying prerequisite steps on app-to-phone/phone-to-app tutorials

### DIFF
--- a/config/tutorials/app-to-phone.yml
+++ b/config/tutorials/app-to-phone.yml
@@ -22,9 +22,9 @@ introduction:
 prerequisites:
 - create-nexmo-account
 - install-nodejs
-- install-express
-- install-nexmo-cli-beta
 - install-node-client-sdk
+- install-nexmo-cli-beta
+- install-express
 - run-ngrok
 
 tasks:

--- a/config/tutorials/phone-to-app.yml
+++ b/config/tutorials/phone-to-app.yml
@@ -19,9 +19,9 @@ introduction:
 prerequisites:
 - create-nexmo-account
 - install-nodejs
-- install-express
-- install-nexmo-cli-beta
 - install-node-client-sdk
+- install-nexmo-cli-beta
+- install-express
 - run-ngrok
 
 tasks:


### PR DESCRIPTION
## Description

The `install-express` instructions includes the following copy:

> If you've not already done so initialize your project directory with:
> ``` bash
> npm init
> ```

Later, in the `install-node-client-sdk` instructions, the copy reads:


>Create a new project directory and change into it. Then run the following command:
>
>``` bash
> npm init
> npm install nexmo-client --save
>```

Made a simple change to swap those steps so the user creates the directory and runs `npm init` at the appropriate time.

Reviewed @conshus's PRs to make sure it wasn't already included.

## Deploy Notes

None
