### PR TITLE
Fix the JWT generator.

### DIFF
--- a/app/javascript/components/jwt_generator/JwtGenerator.vue
+++ b/app/javascript/components/jwt_generator/JwtGenerator.vue
@@ -206,8 +206,7 @@ export default {
       payload.iat = this.iat;
       payload.exp = this.exp;
       payload.jti = this.jti;
-      payload.nbf = this.nbf;
-      payload.applicationId = this.applicationId;
+      payload.application_id = this.applicationId;
       if (this.sub) { payload.sub = this.sub; }
       if (this.acl) { payload.acl = JSON.parse(this.acl); }
       return JSON.stringify(payload);


### PR DESCRIPTION
## Description

There were two issues that were causing invalid tokens:
* One of the keys was wrong, it should be `application_id`.
* Passing the `nbf`. Even though a correct value was used, the server
respond with invalid token. We will follow up in a separate issue to fix
it.
