### PR TITLE
Fix incorrect git clone command

### DIFF
--- a/_use_cases/client-sdk-click-to-call.md
+++ b/_use_cases/client-sdk-click-to-call.md
@@ -33,7 +33,7 @@ There is some initial set up you need to do before you can start working with th
 Download the source code from GitHub:
 
 ```
-git clone git@github.com:https://github.com/nexmo-community/client-sdk-click-to-call
+git clone https://github.com/nexmo-community/client-sdk-click-to-call
 cd client-sdk-click-to-call
 ```
 


### PR DESCRIPTION
## Description

The `git clone` command in the Client SDK Click to Call use case was incorrect. Fixed.

