### PR TITLE
Add the OAS_PATH env var for the docker setup

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,7 @@ services:
       - update
       - db
     environment:
+      - OAS_PATH=_open_api/api_specs
       - POSTGRES_HOST=db
       - POSTGRES_USERNAME=postgres
       - RAILS_ENV=development


### PR DESCRIPTION
## Description

I found that the api reference docs didn't render in my local docker machine due to a missing environment variable. This sets `OAS_PATH` for the docker setup
