### PR TITLE
Fix ci:verify_error_urls_resolve in dev.

### DIFF
--- a/lib/tasks/ci.rake
+++ b/lib/tasks/ci.rake
@@ -49,6 +49,7 @@ namespace :ci do
   desc 'Ensure all OAS error URLS resolve'
   task 'verify_error_urls_resolve': :environment do
     session = ActionDispatch::Integration::Session.new(Rails.application)
+    session.host! 'localhost' unless Rails.env.test?
 
     errors = []
 


### PR DESCRIPTION
## Description

In Rails 6 a guard against DNS attacks was introduced.
By default, a whitelist of host is set for every environment, in the CI
the host is set to test and the rake runs smoothly. However, the default
host for `ActionDispatch::Integration::Session` is www.example.org which
isn't whitelisted.
