### PR TITLE
Upgrade OAS Renderer to 0.6.4

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -138,7 +138,7 @@ gem 'lograge'
 gem 'countries'
 gem 'country_select', '~> 4.0'
 
-gem 'nexmo-oas-renderer', '~> 0.6.3', require: false
+gem 'nexmo-oas-renderer', '~> 0.6.4', require: false
 
 # A/B Testing
 gem 'split', '~> 3.3.2', require: 'split/dashboard'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -282,13 +282,13 @@ GEM
     neatjson (0.9)
     nenv (0.3.0)
     netrc (0.11.0)
-    nexmo-oas-renderer (0.6.3)
+    nexmo-oas-renderer (0.6.4)
       activemodel (~> 6.0)
       activesupport (~> 6.0)
       banzai (~> 0.1.2)
       dotenv (~> 2.7)
       neatjson (~> 0.8)
-      oas_parser (= 0.22.2)
+      oas_parser (= 0.22.4)
       octicons_helper (~> 8.2)
       redcarpet (= 3.4.0)
       rouge (= 2.0.7)
@@ -301,7 +301,7 @@ GEM
     notiffany (0.1.3)
       nenv (~> 0.1)
       shellany (~> 0.0)
-    oas_parser (0.22.2)
+    oas_parser (0.22.4)
       activesupport (>= 4.0.0)
       addressable (~> 2.3)
       builder (~> 3.2.3)
@@ -559,7 +559,7 @@ DEPENDENCIES
   listen (~> 3.2)
   lograge
   neatjson
-  nexmo-oas-renderer (~> 0.6.3)
+  nexmo-oas-renderer (~> 0.6.4)
   nokogiri (~> 1.10.4)
   octicons_helper
   octokit


### PR DESCRIPTION
## Description

Upgrade OAS renderer to enable `required` support on `oneOf` request bodies (via underlying `oas_parser`)

## Deploy Notes

N/A