### PR TITLE
Bump nexmo-oas-renderer.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -138,7 +138,7 @@ gem 'lograge'
 gem 'countries'
 gem 'country_select', '~> 4.0'
 
-gem 'nexmo-oas-renderer', '~> 0.6.4', require: false
+gem 'nexmo-oas-renderer', '~> 0.6.5', require: false
 
 # A/B Testing
 gem 'split', '~> 3.3.2', require: 'split/dashboard'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -282,7 +282,7 @@ GEM
     neatjson (0.9)
     nenv (0.3.0)
     netrc (0.11.0)
-    nexmo-oas-renderer (0.6.4)
+    nexmo-oas-renderer (0.6.5)
       activemodel (~> 6.0)
       activesupport (~> 6.0)
       banzai (~> 0.1.2)
@@ -559,7 +559,7 @@ DEPENDENCIES
   listen (~> 3.2)
   lograge
   neatjson
-  nexmo-oas-renderer (~> 0.6.4)
+  nexmo-oas-renderer (~> 0.6.5)
   nokogiri (~> 1.10.4)
   octicons_helper
   octokit


### PR DESCRIPTION
## Description
Fixes the rendering of the versions switch in OAS specifications.
