### PR TITLE
[DEVX-1459] Prevent nested tabs from changing the url.

### DIFF
--- a/app/javascript/volta_tabbed_examples/index.js
+++ b/app/javascript/volta_tabbed_examples/index.js
@@ -64,6 +64,9 @@ export default class VoltaTabbedExamples {
   }
 
   onTabClick(event) {
+    // Prevent nested tabs from changing the url
+    if ($(event.target).parents('.Vlt-tabs').length > 1) { return; }
+
     const language = $(event.currentTarget).data('language')
     const languageType = $(event.currentTarget).data('language-type')
     const linkable = $(event.currentTarget).data('language-linkable')


### PR DESCRIPTION
## Description

Previously, when clicking on a nested tab, e.g. https://developer.nexmo.com/client-sdk/in-app-voice/getting-started/app-to-app-call
(clicking objective-C) the url was updated, this behaviour is fine for
first level tabs, but not for nested ones.
