### PR TITLE
Cache sidenav

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
-release: bundle exec rake db:migrate && bundle exec rake tmp:clear
+release: bundle exec rake db:migrate && bundle exec rake cache:clear
 web: rails s

--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
-release: bundle exec rake db:migrate
+release: bundle exec rake db:migrate && bundle exec rake tmp:clear
 web: rails s

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -18,10 +18,12 @@ module ApplicationHelper
     end
   end
 
-  def show_canonical_meta?
-    return true if params[:code_language].present?
-    return true if Rails.env.production? && request.base_url != 'https://developer.nexmo.com'
-    false
+  def active_sidenav_item
+    if params[:tutorial_name]
+      "/#{params[:product]}/tutorials/#{params[:tutorial_name]}"
+    else
+      request.path.chomp("/#{params[:code_language]}")
+    end
   end
 
   def canonical_path

--- a/app/javascript/navigation/index.js
+++ b/app/javascript/navigation/index.js
@@ -433,7 +433,13 @@ function toggleMobileNavBtn() {
     }
 }
 
+function setActiveNavItem() {
+  const activeItem = $('nav.sidenav').data('active');
+  $(`.Vlt-sidemenu__link[href="${activeItem}"]`).addClass('Vlt-sidemenu__link_active')
+}
+
 export default () => {
+    setActiveNavItem();
     Volta.menu.init();
     toggleMobileNavBtn();
 }

--- a/app/presenters/sidenav_subitem.rb
+++ b/app/presenters/sidenav_subitem.rb
@@ -45,20 +45,4 @@ class SidenavSubitem < SidenavItem
       :use_case
     end
   end
-
-  def active?
-    if navigation == :tutorials
-      active_path.starts_with?(url)
-    else
-      url == active_path
-    end
-  end
-
-  def active_path
-    @active_path ||= request_path.chomp("/#{code_language}")
-  end
-
-  def link_css_class
-    active? ? 'Vlt-sidemenu__link_active' : ''
-  end
 end

--- a/app/views/layouts/documentation.html.erb
+++ b/app/views/layouts/documentation.html.erb
@@ -6,7 +6,7 @@
     <%= render partial: 'layouts/partials/header' %>
     <div id="Vlt-sidenav" class="Vlt-sidenav Vlt-sidenav--light">
       <div class="Vlt-sidenav__scroll">
-        <nav class="sidenav" tabindex="0" >
+        <nav class="sidenav" tabindex="0" data-active="<%= active_sidenav_item %>">
           <%= render partial: 'layouts/partials/sidenav' %>
         </nav>
       </div>

--- a/app/views/layouts/documentation.html.erb
+++ b/app/views/layouts/documentation.html.erb
@@ -7,7 +7,9 @@
     <div id="Vlt-sidenav" class="Vlt-sidenav Vlt-sidenav--light">
       <div class="Vlt-sidenav__scroll">
         <nav class="sidenav" tabindex="0" data-active="<%= active_sidenav_item %>">
-          <%= render partial: 'layouts/partials/sidenav' %>
+          <% cache 'sidenav', expires_in: 10.hours do %>
+            <%= render partial: 'layouts/partials/sidenav' %>
+          <% end %>
         </nav>
       </div>
     </div>

--- a/app/views/layouts/documentation.html.erb
+++ b/app/views/layouts/documentation.html.erb
@@ -7,7 +7,7 @@
     <div id="Vlt-sidenav" class="Vlt-sidenav Vlt-sidenav--light">
       <div class="Vlt-sidenav__scroll">
         <nav class="sidenav" tabindex="0" data-active="<%= active_sidenav_item %>">
-          <% cache 'sidenav', expires_in: 10.hours do %>
+          <% cache_unless params[:namespace].present?, 'sidenav', expires_in: 10.hours do %>
             <%= render partial: 'layouts/partials/sidenav' %>
           <% end %>
         </nav>

--- a/app/views/layouts/partials/_sidenav_subitem.html.erb
+++ b/app/views/layouts/partials/_sidenav_subitem.html.erb
@@ -1,6 +1,6 @@
 <li class="navigation-item--<%= sidenav_subitem.title.parameterize %> navigation-item">
   <% if sidenav_subitem.show_link? %>
-    <%= link_to(sidenav_subitem.url, class: "Vlt-sidemenu__link #{sidenav_subitem.link_css_class}") do %>
+    <%= link_to(sidenav_subitem.url, class: 'Vlt-sidemenu__link') do %>
       <% if sidenav_subitem.label? %>
         <span class="Vlt-sidemenu__label">
           <%= sidenav_subitem.title %>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -16,11 +16,9 @@ Rails.application.configure do
   # Run rails dev:cache to toggle caching.
   if Rails.root.join('tmp', 'caching-dev.txt').exist?
     config.action_controller.perform_caching = true
+    config.action_controller.enable_fragment_cache_logging = true
 
-    config.cache_store = :memory_store
-    config.public_file_server.headers = {
-      'Cache-Control' => "public, max-age=#{2.days.to_i}",
-    }
+    config.cache_store = :memory_store, { size: 32.megabytes }
   else
     config.action_controller.perform_caching = false
 

--- a/lib/tasks/cache.rake
+++ b/lib/tasks/cache.rake
@@ -1,0 +1,6 @@
+namespace :cache do
+  desc "Clear Rails' redis cache"
+  task 'clear': :environment do
+    Rails.cache.clear
+  end
+end

--- a/spec/presenters/sidenav_subitem_spec.rb
+++ b/spec/presenters/sidenav_subitem_spec.rb
@@ -54,12 +54,4 @@ RSpec.describe SidenavSubitem do
       it { expect(subject.url).to eq('/product-lifecycle/beta') }
     end
   end
-
-  describe '#active?' do
-    it { expect(subject.active?).to eq(true) }
-  end
-
-  describe '#link_css_class' do
-    it { expect(subject.link_css_class).to eq('Vlt-sidemenu__link_active') }
-  end
 end


### PR DESCRIPTION
## Description

* Cache the sidenav to ease the memory consumption
* Move the logic of marking the active link in the sidenav to the frontend

## Note:
We need to add memcachier plugin to heroku, it has a free plan that I think will work for us. 

EDIT: looks like we use redis for caching, so we can use that one,