### PR TITLE
Prevent tabs to be focused by default and making the page scroll.

### DIFF
--- a/vendor/assets/javascripts/volta/components/volta.tab.js
+++ b/vendor/assets/javascripts/volta/components/volta.tab.js
@@ -125,7 +125,6 @@ Volta.tab = function () {
 
 			this._activeLink.setAttribute('tabindex', '0');
 			this._activeLink.setAttribute('aria-selected', 'true');
-			this._activeLink.focus();
 			if (this._activePanel) {
 				this._activePanel.removeAttribute('hidden');
 			}


### PR DESCRIPTION
## Description

Pages under /api that have tabs were automatically scrolled to the bottom of the page if they have tabs in the like `/api/verify`. 
This fixes the issue for now, I need to push a change to volta later.