### PR TITLE
[DEVX-1735] Use Mermaid.js default styles.

### DIFF
--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -127,7 +127,7 @@ $(document).ready(function() {
       sequence: {
           useMaxWidth: false,
       },
-      theme: 'dark',
+      themeCSS: '.actor { fill: #BDD5EA; stroke: #81B1DB; }',
       htmlLabels: true
   });
 });


### PR DESCRIPTION
## Description

It has a better contrast ratio and makes our diagrams easier to read, also add the blue boxes that the `dark` one has.