### PR TITLE
[DEVX-1747] Update Android Push to FCMV1

### DIFF
--- a/_documentation/client-sdk/setup/set-up-push-notifications/android.md
+++ b/_documentation/client-sdk/setup/set-up-push-notifications/android.md
@@ -19,18 +19,20 @@ In case you have not done that already, more details can be found in the [offici
 
 Obtain a `jwt_dev`, which is a `jwt` without a `sub` claim. More details on how to generate a JWT can be found in the [setup guide](/tutorials/client-sdk-generate-test-credentials#generate-a-user-jwt).
 
-Get your `server_api_key` from the Firebase console. Navigate to `Firebase console, Project settings, CloudMessaging, Server key`.
+Get your `private_key_file` from the Firebase console. Navigate to `Firebase console, Project settings, Service accounts, Firebase Admin SDK, generate new private key`. You will need to stringify the JSON private_key_file before you can send it to the push service.
+
+Get your `projectId` from the Firebase console. Navigate to `Firebase console, Project settings, General, projectId`.
 
 Get your Nexmo Application ID, `app_id`. It can be obtained from [Nexmo Dashboard](https://dashboard.nexmo.com/voice/your-applications).
 
-Run the following Curl command, replacing `jwt_dev`, `server_api_key`, `app_id` with your values:
+Run the following Curl command, replacing `jwt_dev`, `google-services.json`, `projectId`, `app_id` with your values:
 
 ```sh
 curl -v -X PUT \
    -H "Authorization: Bearer $jwt_dev" \
    -H "Content-Type: application/json" \
-   -d "{\"token\":\"$server_api_key\"}" \
-   https://api.nexmo.com/v1/applications/$app_id/push_tokens/android
+   -d "{\"token\":\"$private_key_file\", \"projectId\":\"$projectId\"}" \
+   https://api.nexmo.com/v1/applications/$app_id/push_tokens/android  
 ```
 
 ## Add Firebase Cloud Messaging to your Android project

--- a/_documentation/client-sdk/setup/set-up-push-notifications/android.md
+++ b/_documentation/client-sdk/setup/set-up-push-notifications/android.md
@@ -25,7 +25,7 @@ Get your `projectId` from the Firebase console. Navigate to `Firebase console, P
 
 Get your Nexmo Application ID, `app_id`. It can be obtained from [Nexmo Dashboard](https://dashboard.nexmo.com/voice/your-applications).
 
-Run the following Curl command, replacing `jwt_dev`, `google-services.json`, `projectId`, `app_id` with your values:
+Run the following Curl command, replacing `jwt_dev`, `private_key_file`, `projectId`, `app_id` with your values:
 
 ```sh
 curl -v -X PUT \

--- a/_documentation/client-sdk/setup/set-up-push-notifications/android.md
+++ b/_documentation/client-sdk/setup/set-up-push-notifications/android.md
@@ -19,7 +19,7 @@ In case you have not done that already, more details can be found in the [offici
 
 Obtain a `jwt_dev`, which is a `jwt` without a `sub` claim. More details on how to generate a JWT can be found in the [setup guide](/tutorials/client-sdk-generate-test-credentials#generate-a-user-jwt).
 
-Get your `private_key_file` from the Firebase console. Navigate to `Firebase console, Project settings, Service accounts, Firebase Admin SDK, generate new private key`. You will need to stringify the JSON private_key_file before you can send it to the push service.
+Get your `private_key_file` from the Firebase console. Navigate to `Firebase console, Project settings, Service accounts, Firebase Admin SDK, generate new private key`. You will need to ensure the `private_key_file` is encoded to JSON using a suitable method before you can send it to the push service.
 
 Get your `projectId` from the Firebase console. Navigate to `Firebase console, Project settings, General, projectId`.
 


### PR DESCRIPTION
For android push, developers can now use FCMV1. While FCM legacy is still supported by Google and Nexmo Push Service it is recommended they use FCMV1.

## Description

We are now supporting Googles FCMV1 for Push for Android

## Deploy Notes

NOTE : there is some difficulty in sending the JSON file to the push server as one needs to serialize the JSON before sending over the network. I used stringify in JS to do this, but I'm not sure how to accomplish this when using curl (as that seems to be the implementation in the docs). 