### PR TITLE
Add Reports API to API listing page

### DIFF
--- a/app/views/api/index.html.erb
+++ b/app/views/api/index.html.erb
@@ -83,6 +83,11 @@
             <h5>Conversation API</h5> <span class="Vlt-badge Vlt-badge--blue">Developer Preview</span></h5>
             <p>Create real-time communications channels for text, voice and video.</p>
           </a>
+
+          <a href="/api/reports" class="Nxd-card__link">
+            <h5>Reports API <span class="Vlt-badge Vlt-badge--green">Beta</span></h5>
+            <p>Request a report of activity on your Nexmo account. Reports are generated as CSV files compressed in zip archives.</p>
+          </a>
         </nav>
       </div>
     </div>


### PR DESCRIPTION
## Description

We have a new API but I missed it when I looked on the API reference page. This PR adds the link to the reports API to the `/api` page
