### PR TITLE
Update ncco-reference.md

### DIFF
--- a/_documentation/voice/voice-api/ncco-reference.md
+++ b/_documentation/voice/voice-api/ncco-reference.md
@@ -210,7 +210,7 @@ You can use the following options to control a *talk* action:
 ## Stream
 The `stream` action allows you to send an audio stream to a Conversation
 
-By default, the talk action is synchronous. However, if you set *bargeIn* to *true* you must set an *input* action later in the NCCO stack.
+By default, the stream action is synchronous. However, if you set *bargeIn* to *true* you must set an *input* action later in the NCCO stack.
 
 The following NCCO example shows how to send an audio stream to a Conversation or Call:
 


### PR DESCRIPTION
## Description

The explanation for `stream` is incorrect. It explains `talk` action. So, I change the work `talk` to `stream`.


