### PR TITLE
update the release notes to latest version

### DIFF
--- a/_documentation/client-sdk/sdk-documentation/android/release-notes.md
+++ b/_documentation/client-sdk/sdk-documentation/android/release-notes.md
@@ -85,7 +85,7 @@ navigation_weight: 0
 - remove `conversation.getEvents()`
 
 ### Fixed
-- `NexmoConversation` Parcelable fixed 
+- `NexmoConversation` `Parcelable` fixed 
 
 ## Version 1.0.0 - 2019-09-05
 

--- a/_documentation/client-sdk/sdk-documentation/android/release-notes.md
+++ b/_documentation/client-sdk/sdk-documentation/android/release-notes.md
@@ -6,6 +6,87 @@ navigation_weight: 0
 
 # Release Notes
 
+## Version 1.0.2 - 2019-11-11
+
+### Changes
+
+- Rename `GetConversationsPage` to `GetConversations`
+- Rename `GetEventsPage` to `GetEvents`
+- `NexmoClient.GetConversations` default `pageSize` is 10
+- `NexmoConversation.GetEvents` default `pageSize` is 10
+
+## Version 1.0.1
+
+### New
+
+- Add `getConversationsPage` in `NexmoClient`
+```NexmoClient.get().getConversationsPage(50, NexmoPageOrderDesc, new NexmoRequestListener<NexmoConversationsPage>(){
+   void onError(@NonNull NexmoApiError error){
+
+   }
+   void onSuccess(@Nullable NexmoConversationsPage result){
+        //Get the current page conversations -Sync
+        Collection<NexmoConversation> conversations = result.getData()
+        //Get the next page -Async
+        result.getNext(new NexmoRequestListener<NexmoConversationsPage>(){
+        void onError(@NonNull NexmoApiError error){
+        
+           }
+           void onSuccess(@Nullable NexmoConversationsPage result){
+            
+           }
+        })
+        
+        //Get the previous page -Async
+        result.getPrev(new NexmoRequestListener<NexmoConversationsPage>(){
+        void onError(@NonNull NexmoApiError error){
+        
+           }
+           void onSuccess(@Nullable NexmoConversationsPage result){
+            
+           }
+        })
+   }
+});
+```
+- Add `getEventsPage` in `NexmoConversation`
+```    NexmoConversation myConversation;
+    ...
+    myConversation.getEventsPage(50, NexmoPageOrderDesc, new NexmoRequestListener<NexmoEventsPage>(){
+        void onError(@NonNull NexmoApiError error){
+     
+        }
+        void onSuccess(@Nullable NexmoEventsPage result){
+            //Current event page data -Sync
+            Collection<NexmoEvent> events = result.getData();
+            //Get the next page -Async
+            result.getNext( new NexmoRequestListener<NexmoEventsPage>(){
+                 void onError(@NonNull NexmoApiError error){
+                     
+                        }
+                void onSuccess(@Nullable NexmoEventsPage result){
+                }
+            }
+            );
+            
+            //Get the previous page -Async
+            result.getPrev( new NexmoRequestListener<NexmoEventsPage>(){
+                 void onError(@NonNull NexmoApiError error){
+                     
+                        }
+                void onSuccess(@Nullable NexmoEventsPage result){
+                }
+            }
+            );
+        }
+    );
+``` 
+### Removed
+- remove `conversation.getEvents()`
+
+### Fixed
+- `NexmoConversation` Parcelable fixed 
+
 ## Version 1.0.0 - 2019-09-05
 
 ### Changed
@@ -78,12 +159,7 @@ NexmoChannel channel = someCallMember.getChannel();
     media.getEarmuffed();
 ```
 
-- Added `NexmoChannel` Object to `NexmoMember`.
-
-```java
-    NexmoMember someMember;
-    NexmoChannel channel = someMember.channel;
-```
+- `getNemxoEventType()` in `NexmoEvent` is public
 
 ### Fixed
 
@@ -95,6 +171,56 @@ NexmoChannel channel = someCallMember.getChannel();
 
 - Removed `conversation.getUser()`. The current user can be accessed with: `NexmoClient.getUser()`.
 
+### Added
+
+- `NexmoConversation` send and receive `CustomEvent`s
+- `NexmoCustomEvent`:`NexmoEvent`:
+    `String`                  `getCustomType()`
+    `HashMap<String, Object>` `getData()`
+- `NexmoChannel` Object to `NexmoMember`.
+
+```java
+    NexmoMember someMember;
+    NexmoChannel channel = someMember.channel;
+```
+
+## Version 0.3.0 - June 4, 2019
+
+This version contains many small bug fixes and stability improvements. The major changes are:
+
+### Added
+
+* `NexmoChannel` was added to `NexmoMember`, to exposes the [Channel](/conversation/concepts/channel) data when exists. The `NexmoChannel` object includes `to` and `from` fields with the data of the Channel destination and origin.
+
+### **Breaking Changes**
+
+#### Removed
+
+* `NexmoMember.ChannelType` - should be replaced with `NexmoMember.Channel.from.type`
+  
+* `NexmoMember.ChannelData` - should be replaced with `NexmoMember.Channel.from.data`
+
+#### Changed
+
+* `NexmoLoginListener` was improved and updated its interface:
+
+* `onLoginStateChange()` and `onAvailabilityChange()` were **removed**
+
+* `onConnectionStatusChange(ConnectionStatus status, ConnectionStatusReason reason)` was added, as an aggregated and improved version of the above methods
+
+### Added
+
+* Support for parsing the `MemberId` who initiated a call.
+
+### Fixed
+
+* Improvements for cross platform in app calls
+
+* Crash on processing push notifications without SDK initialization
+
+* Crash on sending `markAsDelivered` event
+
+-----
 ---
 
 ## Version 0.3.0 - June 4, 2019


### PR DESCRIPTION
update the release notes to latest version to 1.0.2
we release the 1.0.2 to public maven a week ago, although we the docs were updated the website don't reflect the latest version, manually fix the release notes 

## Description

Please describe what the changes are made in this pull request and why the change was necessary.

## Deploy Notes

Notes regarding deployment the contained body of work. These should note any db migrations, etc.
