### PR TITLE
update android docs

### DIFF
--- a/public/sdk/stitch/android
+++ b/public/sdk/stitch/android
@@ -1,1 +1,1 @@
-../../../.repos/nexmo/conversation-docs/android
+../../../.repos/nexmo/conversation-docs/android/latest


### PR DESCRIPTION
In order to maintain that the docs will always point to latest version I created a latest version In `conversation-dcos` repo and link it to the latest version, in order to make it work, changed the link to reference the ../../../.repos/nexmo/conversation-docs/android/latest instead of ../../../.repos/nexmo/conversation-docs/android

## Description

Please describe what the changes are made in this pull request and why the change was necessary.

## Deploy Notes

Notes regarding deployment the contained body of work. These should note any db migrations, etc.
