### PR TITLE
Add 8kHz rate for websocket endpoint

### DIFF
--- a/_documentation/voice/voice-api/ncco-reference.md
+++ b/_documentation/voice/voice-api/ncco-reference.md
@@ -168,7 +168,7 @@ Value | Description
 Value | Description
 -- | --
 `uri` | the URI to the websocket you are streaming to.
-`content-type` | the internet media type for the audio you are streaming. Possible values are: `audio/l16;rate=16000`
+`content-type` | the internet media type for the audio you are streaming. Possible values are: `audio/l16;rate=16000` or `audio/l16;rate=8000`.
 `headers` | a JSON object containing any metadata you want. See [connecting to a websocket](/voice/voice-api/guides/websockets#connecting-to-a-websocket) for example headers
 
 #### sip - the sip endpoint to connect to


### PR DESCRIPTION
## Description

Both 16kHz and 8kHz are supported for websocket endpoint. This PR adds 8kHz which was missing from reference.

## Review

See NCCO reference websocket endpoint in review app.