### PR TITLE
Add Node code snippets for Conversation API

### DIFF
--- a/_documentation/conversation/code-snippets/conversation/create-conversation.md
+++ b/_documentation/conversation/code-snippets/conversation/create-conversation.md
@@ -4,7 +4,7 @@ title: Create a Conversation
 
 # Create a Conversation
 
-In this code snippet you will see how to create a Conversation.
+In this code snippet you learn how to create a Conversation.
 
 ## Example
 

--- a/_documentation/conversation/code-snippets/conversation/create-conversation.md
+++ b/_documentation/conversation/code-snippets/conversation/create-conversation.md
@@ -1,5 +1,6 @@
 ---
 title: Create a Conversation
+navigation_weight: 1
 ---
 
 # Create a Conversation

--- a/_documentation/conversation/code-snippets/conversation/delete-conversation.md
+++ b/_documentation/conversation/code-snippets/conversation/delete-conversation.md
@@ -1,5 +1,6 @@
 ---
 title: Delete a Conversation
+navigation_weight: 2
 ---
 
 # Delete a Conversation

--- a/_documentation/conversation/code-snippets/conversation/delete-conversation.md
+++ b/_documentation/conversation/code-snippets/conversation/delete-conversation.md
@@ -4,7 +4,7 @@ title: Delete a Conversation
 
 # Delete a Conversation
 
-In this code snippet you will see how to delete a specified Conversation.
+In this code snippet you learn how to delete a specified Conversation.
 
 ## Example
 

--- a/_documentation/conversation/code-snippets/conversation/get-conversation.md
+++ b/_documentation/conversation/code-snippets/conversation/get-conversation.md
@@ -4,7 +4,7 @@ title: Get a Conversation
 
 # Get a Conversation
 
-In this code snippet you will see how to get a specified Conversation.
+In this code snippet you learn how to get a specified Conversation.
 
 ## Example
 

--- a/_documentation/conversation/code-snippets/conversation/get-conversation.md
+++ b/_documentation/conversation/code-snippets/conversation/get-conversation.md
@@ -1,5 +1,6 @@
 ---
 title: Get a Conversation
+navigation_weight: 3
 ---
 
 # Get a Conversation

--- a/_documentation/conversation/code-snippets/conversation/list-conversations.md
+++ b/_documentation/conversation/code-snippets/conversation/list-conversations.md
@@ -1,5 +1,6 @@
 ---
 title: List Conversations
+navigation_weight: 6
 ---
 
 # List Conversations

--- a/_documentation/conversation/code-snippets/conversation/list-conversations.md
+++ b/_documentation/conversation/code-snippets/conversation/list-conversations.md
@@ -4,7 +4,7 @@ title: List Conversations
 
 # List Conversations
 
-In this code snippet you will see how to list all Conversations.
+In this code snippet you learn how to list all Conversations.
 
 ## Example
 

--- a/_documentation/conversation/code-snippets/conversation/list-next-conversations.md
+++ b/_documentation/conversation/code-snippets/conversation/list-next-conversations.md
@@ -1,5 +1,6 @@
 ---
 title: List Next Conversations
+navigation_weight: 7
 ---
 
 # List Next Conversations

--- a/_documentation/conversation/code-snippets/conversation/list-next-conversations.md
+++ b/_documentation/conversation/code-snippets/conversation/list-next-conversations.md
@@ -1,0 +1,20 @@
+---
+title: List Next Conversations
+---
+
+# List Next Conversations
+
+In this code snippet you learn how to list the next page of Conversations.
+
+## Example
+
+```code_snippets
+source: '_examples/conversation/conversation/list-next-conversations'
+application:
+  use_existing: |
+    You will need to use an existing Application that contains Conversations in order to receive some results here. See the Create Conversation code snippet for information on how to create an Application and some sample Conversations.
+```
+
+## Try it out
+
+When you run the code you will retrieve the next page of Conversations.

--- a/_documentation/conversation/code-snippets/conversation/list-prev-conversations.md
+++ b/_documentation/conversation/code-snippets/conversation/list-prev-conversations.md
@@ -1,0 +1,20 @@
+---
+title: List Previous Conversations
+---
+
+# List Previous Conversations
+
+In this code snippet you learn how to list the previous page of Conversations.
+
+## Example
+
+```code_snippets
+source: '_examples/conversation/conversation/list-prev-conversations'
+application:
+  use_existing: |
+    You will need to use an existing Application that contains Conversations in order to receive some results here. See the Create Conversation code snippet for information on how to create an Application and some sample Conversations.
+```
+
+## Try it out
+
+When you run the code you will retrieve a list of the previous page of Conversations.

--- a/_documentation/conversation/code-snippets/conversation/list-prev-conversations.md
+++ b/_documentation/conversation/code-snippets/conversation/list-prev-conversations.md
@@ -1,5 +1,6 @@
 ---
 title: List Previous Conversations
+navigation_weight: 8
 ---
 
 # List Previous Conversations

--- a/_documentation/conversation/code-snippets/conversation/record-conversation.md
+++ b/_documentation/conversation/code-snippets/conversation/record-conversation.md
@@ -4,7 +4,7 @@ title: Record a Conversation
 
 # Record a Conversation
 
-In this code snippet you will see how to record a Conversation.
+In this code snippet you learn how to record a Conversation.
 
 ## Example
 

--- a/_documentation/conversation/code-snippets/conversation/record-conversation.md
+++ b/_documentation/conversation/code-snippets/conversation/record-conversation.md
@@ -1,5 +1,6 @@
 ---
 title: Record a Conversation
+navigation_weight: 4
 ---
 
 # Record a Conversation

--- a/_documentation/conversation/code-snippets/conversation/update-conversation.md
+++ b/_documentation/conversation/code-snippets/conversation/update-conversation.md
@@ -4,7 +4,7 @@ title: Update Conversation
 
 # Update Conversation
 
-In this code snippet you will see how to update a Conversation.
+In this code snippet you learn how to update a Conversation.
 
 ## Example
 

--- a/_documentation/conversation/code-snippets/conversation/update-conversation.md
+++ b/_documentation/conversation/code-snippets/conversation/update-conversation.md
@@ -1,5 +1,6 @@
 ---
 title: Update Conversation
+navigation_weight: 5
 ---
 
 # Update Conversation

--- a/_documentation/conversation/code-snippets/event/create-event.md
+++ b/_documentation/conversation/code-snippets/event/create-event.md
@@ -5,7 +5,7 @@ navigation_weight: 1
 
 # Create an Event
 
-In this code snippet you will see how to create an Event.
+In this code snippet you learn how to create an Event.
 
 ## Example
 

--- a/_documentation/conversation/code-snippets/event/delete-event.md
+++ b/_documentation/conversation/code-snippets/event/delete-event.md
@@ -4,7 +4,7 @@ title: Delete an Event
 
 # Delete an Event
 
-In this code snippet you will see how to delete an Event.
+In this code snippet you learn how to delete an Event.
 
 ## Example
 

--- a/_documentation/conversation/code-snippets/event/delete-event.md
+++ b/_documentation/conversation/code-snippets/event/delete-event.md
@@ -1,5 +1,6 @@
 ---
 title: Delete an Event
+navigation_weight: 3
 ---
 
 # Delete an Event

--- a/_documentation/conversation/code-snippets/event/get-event.md
+++ b/_documentation/conversation/code-snippets/event/get-event.md
@@ -1,5 +1,6 @@
 ---
 title: Get an Event
+navigation_weight: 4
 ---
 
 # Get an Event

--- a/_documentation/conversation/code-snippets/event/get-event.md
+++ b/_documentation/conversation/code-snippets/event/get-event.md
@@ -4,7 +4,7 @@ title: Get an Event
 
 # Get an Event
 
-In this code snippet you will see how to get an Event.
+In this code snippet you learn how to get an Event.
 
 ## Example
 

--- a/_documentation/conversation/code-snippets/event/list-events.md
+++ b/_documentation/conversation/code-snippets/event/list-events.md
@@ -4,7 +4,7 @@ title: List Events
 
 # List Events
 
-In this code snippet you will see how to list Events.
+In this code snippet you learn how to list Events.
 
 ## Example
 

--- a/_documentation/conversation/code-snippets/event/list-events.md
+++ b/_documentation/conversation/code-snippets/event/list-events.md
@@ -1,5 +1,6 @@
 ---
 title: List Events
+navigation_weight: 5
 ---
 
 # List Events

--- a/_documentation/conversation/code-snippets/event/list-next-events.md
+++ b/_documentation/conversation/code-snippets/event/list-next-events.md
@@ -1,5 +1,6 @@
 ---
 title: List Next Events
+navigation_weight: 6
 ---
 
 # List Next Events

--- a/_documentation/conversation/code-snippets/event/list-next-events.md
+++ b/_documentation/conversation/code-snippets/event/list-next-events.md
@@ -1,0 +1,26 @@
+---
+title: List Next Events
+---
+
+# List Next Events
+
+In this code snippet you learn how to list the next page of Events.
+
+## Example
+
+Ensure the following variables are set to your required values using any convenient method:
+
+Key | Description
+-- | --
+`CONVERSATION_ID` | The unique ID of the Conversation.
+
+```code_snippets
+source: '_examples/conversation/event/list-next-events'
+application:
+  use_existing: |
+    You will need to use an existing Application that contains a Conversation in order to be able to create Events and then list them. See the Create Conversation code snippet for information on how to create an Application and some sample Conversations.
+```
+
+## Try it out
+
+When you run the code you will retrieve the next page of Events.

--- a/_documentation/conversation/code-snippets/event/list-prev-events.md
+++ b/_documentation/conversation/code-snippets/event/list-prev-events.md
@@ -1,5 +1,6 @@
 ---
 title: List Previous Events
+navigation_weight: 7
 ---
 
 # List Previous Events

--- a/_documentation/conversation/code-snippets/event/list-prev-events.md
+++ b/_documentation/conversation/code-snippets/event/list-prev-events.md
@@ -1,0 +1,26 @@
+---
+title: List Previous Events
+---
+
+# List Previous Events
+
+In this code snippet you learn how to list the previous page of Events.
+
+## Example
+
+Ensure the following variables are set to your required values using any convenient method:
+
+Key | Description
+-- | --
+`CONVERSATION_ID` | The unique ID of the Conversation.
+
+```code_snippets
+source: '_examples/conversation/event/list-prev-events'
+application:
+  use_existing: |
+    You will need to use an existing Application that contains a Conversation in order to be able to create Events and then list them. See the Create Conversation code snippet for information on how to create an Application and some sample Conversations.
+```
+
+## Try it out
+
+When you run the code you will retrieve the previous page of Events.

--- a/_documentation/conversation/code-snippets/leg/delete-leg.md
+++ b/_documentation/conversation/code-snippets/leg/delete-leg.md
@@ -4,7 +4,7 @@ title: Delete a Leg
 
 # Delete a Leg
 
-In this code snippet you will see how to delete a Leg.
+In this code snippet you learn how to delete a Leg.
 
 ## Example
 

--- a/_documentation/conversation/code-snippets/leg/list-legs.md
+++ b/_documentation/conversation/code-snippets/leg/list-legs.md
@@ -4,7 +4,7 @@ title: List Legs
 
 # List Legs
 
-In this code snippet you will see how to list Legs.
+In this code snippet you learn how to list Legs.
 
 ```code_snippets
 source: '_examples/conversation/leg/list-legs'

--- a/_documentation/conversation/code-snippets/member/create-member.md
+++ b/_documentation/conversation/code-snippets/member/create-member.md
@@ -1,5 +1,6 @@
 ---
 title: Create a Member
+navigation_weight: 1
 ---
 
 # Create a Member

--- a/_documentation/conversation/code-snippets/member/create-member.md
+++ b/_documentation/conversation/code-snippets/member/create-member.md
@@ -4,7 +4,7 @@ title: Create a Member
 
 # Create a Member
 
-In this code snippet you will see how to create a Member. A Member can be thought of as a User who has been invited to, joined, or left a Conversation.
+In this code snippet you learn how to create a Member. A Member can be thought of as a User who has been invited to, joined, or left a Conversation.
 
 ## Example
 

--- a/_documentation/conversation/code-snippets/member/delete-member.md
+++ b/_documentation/conversation/code-snippets/member/delete-member.md
@@ -1,5 +1,6 @@
 ---
 title: Delete a Member
+navigation_weight: 2
 ---
 
 # Delete a Member

--- a/_documentation/conversation/code-snippets/member/delete-member.md
+++ b/_documentation/conversation/code-snippets/member/delete-member.md
@@ -4,7 +4,7 @@ title: Delete a Member
 
 # Delete a Member
 
-In this code snippet you will see how to delete a Member.
+In this code snippet you learn how to delete a Member.
 
 ## Example
 

--- a/_documentation/conversation/code-snippets/member/get-member.md
+++ b/_documentation/conversation/code-snippets/member/get-member.md
@@ -1,5 +1,6 @@
 ---
 title: Get a Member
+navigation_weight: 3
 ---
 
 # Get a Member

--- a/_documentation/conversation/code-snippets/member/get-member.md
+++ b/_documentation/conversation/code-snippets/member/get-member.md
@@ -4,7 +4,7 @@ title: Get a Member
 
 # Get a Member
 
-In this code snippet you will see how to get a Member.
+In this code snippet you learn how to get a Member.
 
 ## Example
 

--- a/_documentation/conversation/code-snippets/member/list-members.md
+++ b/_documentation/conversation/code-snippets/member/list-members.md
@@ -4,7 +4,7 @@ title: List Members
 
 # List Members
 
-In this code snippet you will see how to list the Members of a specified Conversation.
+In this code snippet you learn how to list the Members of a specified Conversation.
 
 ## Example
 

--- a/_documentation/conversation/code-snippets/member/list-members.md
+++ b/_documentation/conversation/code-snippets/member/list-members.md
@@ -1,5 +1,6 @@
 ---
 title: List Members
+navigation_weight: 5
 ---
 
 # List Members

--- a/_documentation/conversation/code-snippets/member/list-next-members.md
+++ b/_documentation/conversation/code-snippets/member/list-next-members.md
@@ -1,5 +1,6 @@
 ---
 title: List Next Members
+navigation_weight: 6
 ---
 
 # List Next Members

--- a/_documentation/conversation/code-snippets/member/list-next-members.md
+++ b/_documentation/conversation/code-snippets/member/list-next-members.md
@@ -1,0 +1,26 @@
+---
+title: List Next Members
+---
+
+# List Next Members
+
+In this code snippet you learn how to list the next page of Members for a specified Conversation.
+
+## Example
+
+Ensure the following variables are set to your required values using any convenient method:
+
+Key | Description
+-- | --
+`CONVERSATION_ID` | The unique ID of the Conversation.
+
+```code_snippets
+source: '_examples/conversation/member/list-next-members'
+application:
+  use_existing: |
+    You will need to use an existing Application that contains a Conversation and at least one Member in order to be able to list Members. See the Create Conversation code snippet for information on how to create an Application and some sample Conversations.
+```
+
+## Try it out
+
+When you run the code you will retrieve the next page of Members for the specified Conversation.

--- a/_documentation/conversation/code-snippets/member/list-prev-members.md
+++ b/_documentation/conversation/code-snippets/member/list-prev-members.md
@@ -1,0 +1,26 @@
+---
+title: List Previous Members
+---
+
+# List Previous Members
+
+In this code snippet you learn how to list the previous page of Members for a specified Conversation.
+
+## Example
+
+Ensure the following variables are set to your required values using any convenient method:
+
+Key | Description
+-- | --
+`CONVERSATION_ID` | The unique ID of the Conversation.
+
+```code_snippets
+source: '_examples/conversation/member/list-prev-members'
+application:
+  use_existing: |
+    You will need to use an existing Application that contains a Conversation and at least one Member in order to be able to list Members. See the Create Conversation code snippet for information on how to create an Application and some sample Conversations.
+```
+
+## Try it out
+
+When you run the code you will retrieve the previous page of Members for the specified Conversation.

--- a/_documentation/conversation/code-snippets/member/list-prev-members.md
+++ b/_documentation/conversation/code-snippets/member/list-prev-members.md
@@ -1,5 +1,6 @@
 ---
 title: List Previous Members
+navigation_weight: 7
 ---
 
 # List Previous Members

--- a/_documentation/conversation/code-snippets/member/update-member.md
+++ b/_documentation/conversation/code-snippets/member/update-member.md
@@ -4,7 +4,7 @@ title: Update a Member
 
 # Update a Member
 
-In this code snippet you will see how to update the details of a Member.
+In this code snippet you learn how to update the details of a Member.
 
 ## Example
 

--- a/_documentation/conversation/code-snippets/member/update-member.md
+++ b/_documentation/conversation/code-snippets/member/update-member.md
@@ -1,5 +1,6 @@
 ---
 title: Update a Member
+navigation_weight: 4
 ---
 
 # Update a Member

--- a/_documentation/conversation/code-snippets/user/create-user.md
+++ b/_documentation/conversation/code-snippets/user/create-user.md
@@ -1,5 +1,6 @@
 ---
 title: Create a User
+navigation_weight: 1
 ---
 
 # Create a User

--- a/_documentation/conversation/code-snippets/user/create-user.md
+++ b/_documentation/conversation/code-snippets/user/create-user.md
@@ -4,7 +4,7 @@ title: Create a User
 
 # Create a User
 
-In this code snippet you will see how to create a User.
+In this code snippet you learn how to create a User.
 
 ## Example
 

--- a/_documentation/conversation/code-snippets/user/delete-user.md
+++ b/_documentation/conversation/code-snippets/user/delete-user.md
@@ -1,5 +1,6 @@
 ---
 title: Delete a User
+navigation_weight: 2
 ---
 
 # Delete a User

--- a/_documentation/conversation/code-snippets/user/delete-user.md
+++ b/_documentation/conversation/code-snippets/user/delete-user.md
@@ -4,7 +4,7 @@ title: Delete a User
 
 # Delete a User
 
-In this code snippet you will see how to delete a User.
+In this code snippet you learn how to delete a User.
 
 ## Example
 

--- a/_documentation/conversation/code-snippets/user/get-user.md
+++ b/_documentation/conversation/code-snippets/user/get-user.md
@@ -1,5 +1,6 @@
 ---
 title: Get a User
+navigation_weight: 3
 ---
 
 # Get a User

--- a/_documentation/conversation/code-snippets/user/get-user.md
+++ b/_documentation/conversation/code-snippets/user/get-user.md
@@ -4,7 +4,7 @@ title: Get a User
 
 # Get a User
 
-In this code snippet you will see how to get a User.
+In this code snippet you learn how to get a User.
 
 ## Example
 

--- a/_documentation/conversation/code-snippets/user/list-next-user-conversations.md
+++ b/_documentation/conversation/code-snippets/user/list-next-user-conversations.md
@@ -1,0 +1,26 @@
+---
+title: List Next Page of a User's Conversations
+---
+
+# List Next Page of a User's Conversations
+
+In this code snippet you learn how to get the next page of Conversations a User is associated with.
+
+## Example
+
+Ensure the following variables are set to your required values using any convenient method:
+
+Key | Description
+-- | --
+`USER_ID` | The unique ID of the User.
+
+```code_snippets
+source: '_examples/conversation/user/list-next-user-conversations'
+application:
+  use_existing: |
+    You will need to use an existing Application containing at least one Conversation and one User in order to see a list of a User's Conversations. See the Create Conversation code snippet for information on how to create an Application and a Conversation. See also the Create User code snippet on how to create a User.
+```
+
+## Try it out
+
+When you run the code you will get the next page of Conversations associated with the specified User.

--- a/_documentation/conversation/code-snippets/user/list-next-user-conversations.md
+++ b/_documentation/conversation/code-snippets/user/list-next-user-conversations.md
@@ -1,5 +1,6 @@
 ---
 title: List Next Page of a User's Conversations
+navigation_weight: 9
 ---
 
 # List Next Page of a User's Conversations

--- a/_documentation/conversation/code-snippets/user/list-next-users.md
+++ b/_documentation/conversation/code-snippets/user/list-next-users.md
@@ -1,5 +1,6 @@
 ---
 title: List Next Users
+navigation_weight: 6
 ---
 
 # List Next Users

--- a/_documentation/conversation/code-snippets/user/list-next-users.md
+++ b/_documentation/conversation/code-snippets/user/list-next-users.md
@@ -1,0 +1,18 @@
+---
+title: List Next Users
+---
+
+# List Next Users
+
+In this code snippet you learn how to list the next page of Users associated with an Application.
+
+```code_snippets
+source: '_examples/conversation/user/list-next-users'
+application:
+  use_existing: |
+    You will need to use an existing Application containing at least one User in order to see a list of a Users. See the Create Conversation code snippet for information on how to create an Application. See also the Create User code snippet on how to create a User.
+```
+
+## Try it out
+
+When you run the code you will list the next page of Users associated with an Application.

--- a/_documentation/conversation/code-snippets/user/list-prev-user-conversations.md
+++ b/_documentation/conversation/code-snippets/user/list-prev-user-conversations.md
@@ -1,5 +1,6 @@
 ---
 title: List Previous Page of a User's Conversations
+navigation_weight: 10
 ---
 
 # List Previous Page of a User's Conversations

--- a/_documentation/conversation/code-snippets/user/list-prev-user-conversations.md
+++ b/_documentation/conversation/code-snippets/user/list-prev-user-conversations.md
@@ -1,0 +1,26 @@
+---
+title: List Previous Page of a User's Conversations
+---
+
+# List Previous Page of a User's Conversations
+
+In this code snippet you learn how to get the previous page of Conversations a User is associated with.
+
+## Example
+
+Ensure the following variables are set to your required values using any convenient method:
+
+Key | Description
+-- | --
+`USER_ID` | The unique ID of the User.
+
+```code_snippets
+source: '_examples/conversation/user/list-prev-user-conversations'
+application:
+  use_existing: |
+    You will need to use an existing Application containing at least one Conversation and one User in order to see a list of a User's Conversations. See the Create Conversation code snippet for information on how to create an Application and a Conversation. See also the Create User code snippet on how to create a User.
+```
+
+## Try it out
+
+When you run the code you will get the previous page of Conversations associated with the specified User.

--- a/_documentation/conversation/code-snippets/user/list-prev-users.md
+++ b/_documentation/conversation/code-snippets/user/list-prev-users.md
@@ -1,5 +1,6 @@
 ---
 title: List Previous Users
+navigation_weight: 7
 ---
 
 # List Previous Users

--- a/_documentation/conversation/code-snippets/user/list-prev-users.md
+++ b/_documentation/conversation/code-snippets/user/list-prev-users.md
@@ -1,0 +1,18 @@
+---
+title: List Previous Users
+---
+
+# List Previous Users
+
+In this code snippet you learn how to list the previous page of Users associated with an Application.
+
+```code_snippets
+source: '_examples/conversation/user/list-prev-users'
+application:
+  use_existing: |
+    You will need to use an existing Application containing at least one User in order to see a list of a Users. See the Create Conversation code snippet for information on how to create an Application. See also the Create User code snippet on how to create a User.
+```
+
+## Try it out
+
+When you run the code you will list the previous page of Users associated with an Application.

--- a/_documentation/conversation/code-snippets/user/list-user-conversations.md
+++ b/_documentation/conversation/code-snippets/user/list-user-conversations.md
@@ -1,5 +1,6 @@
 ---
 title: List a User's Conversations
+navigation_weight: 8
 ---
 
 # List a User's Conversations

--- a/_documentation/conversation/code-snippets/user/list-user-conversations.md
+++ b/_documentation/conversation/code-snippets/user/list-user-conversations.md
@@ -4,7 +4,7 @@ title: List a User's Conversations
 
 # List a User's Conversations
 
-In this code snippet you will see how to get a list of Conversations a User is associated with.
+In this code snippet you learn how to get a list of Conversations a User is associated with.
 
 ## Example
 

--- a/_documentation/conversation/code-snippets/user/list-users.md
+++ b/_documentation/conversation/code-snippets/user/list-users.md
@@ -4,7 +4,7 @@ title: List Users
 
 # List Users
 
-In this code snippet you will see how to get a list Users associated with an Application.
+In this code snippet you learn how to get a list Users associated with an Application.
 
 ```code_snippets
 source: '_examples/conversation/user/list-users'

--- a/_documentation/conversation/code-snippets/user/list-users.md
+++ b/_documentation/conversation/code-snippets/user/list-users.md
@@ -1,5 +1,6 @@
 ---
 title: List Users
+navigation_weight: 5
 ---
 
 # List Users

--- a/_documentation/conversation/code-snippets/user/update-user.md
+++ b/_documentation/conversation/code-snippets/user/update-user.md
@@ -1,5 +1,6 @@
 ---
 title: Update a User
+navigation_weight: 4
 ---
 
 # Update a User

--- a/_documentation/conversation/code-snippets/user/update-user.md
+++ b/_documentation/conversation/code-snippets/user/update-user.md
@@ -4,7 +4,7 @@ title: Update a User
 
 # Update a User
 
-In this code snippet you will see how to update a User's details.
+In this code snippet you learn how to update a User's details.
 
 ## Example
 

--- a/_examples/conversation/conversation/list-conversations/node.yml
+++ b/_examples/conversation/conversation/list-conversations/node.yml
@@ -2,10 +2,10 @@
 dependencies:
     - nexmo@beta
 code:
-    source: .repos/nexmo/nexmo-node-code-snippets/conversation/conversation/get-conversations.js
+    source: .repos/nexmo/nexmo-node-code-snippets/conversation/conversation/list-conversations.js
     from_line: 17
     to_line: 26
 client:
-    source: .repos/nexmo/nexmo-node-code-snippets/conversation/conversation/get-conversations.js
+    source: .repos/nexmo/nexmo-node-code-snippets/conversation/conversation/list-conversations.js
     from_line: 8
     to_line: 15

--- a/_examples/conversation/conversation/list-next-conversations/node.yml
+++ b/_examples/conversation/conversation/list-next-conversations/node.yml
@@ -7,5 +7,5 @@ code:
     to_line: 28
 client:
     source: .repos/nexmo/nexmo-node-code-snippets/conversation/conversation/list-next-conversations.js
-    from_line: 10
+    from_line: 8
     to_line: 15

--- a/_examples/conversation/conversation/list-next-conversations/node.yml
+++ b/_examples/conversation/conversation/list-next-conversations/node.yml
@@ -1,0 +1,11 @@
+---
+dependencies:
+    - nexmo@beta
+code:
+    source: .repos/nexmo/nexmo-node-code-snippets/conversation/conversation/list-next-conversations.js
+    from_line: 17
+    to_line: 28
+client:
+    source: .repos/nexmo/nexmo-node-code-snippets/conversation/conversation/list-next-conversations.js
+    from_line: 10
+    to_line: 15

--- a/_examples/conversation/conversation/list-prev-conversations/node.yml
+++ b/_examples/conversation/conversation/list-prev-conversations/node.yml
@@ -1,0 +1,11 @@
+---
+dependencies:
+    - nexmo@beta
+code:
+    source: .repos/nexmo/nexmo-node-code-snippets/conversation/conversation/list-prev-conversations.js
+    from_line: 17
+    to_line: 33
+client:
+    source: .repos/nexmo/nexmo-node-code-snippets/conversation/conversation/list-prev-conversations.js
+    from_line: 10
+    to_line: 15

--- a/_examples/conversation/conversation/list-prev-conversations/node.yml
+++ b/_examples/conversation/conversation/list-prev-conversations/node.yml
@@ -7,5 +7,5 @@ code:
     to_line: 33
 client:
     source: .repos/nexmo/nexmo-node-code-snippets/conversation/conversation/list-prev-conversations.js
-    from_line: 10
+    from_line: 8
     to_line: 15

--- a/_examples/conversation/conversation/record-conversation/node.yml
+++ b/_examples/conversation/conversation/record-conversation/node.yml
@@ -7,5 +7,5 @@ code:
     to_line: 27
 client:
     source: .repos/nexmo/nexmo-node-code-snippets/conversation/conversation/record-conversation.js
-    from_line: 11
+    from_line: 9
     to_line: 16

--- a/_examples/conversation/conversation/record-conversation/node.yml
+++ b/_examples/conversation/conversation/record-conversation/node.yml
@@ -1,0 +1,11 @@
+---
+dependencies:
+    - nexmo@beta
+code:
+    source: .repos/nexmo/nexmo-node-code-snippets/conversation/conversation/record-conversation.js
+    from_line: 18
+    to_line: 27
+client:
+    source: .repos/nexmo/nexmo-node-code-snippets/conversation/conversation/record-conversation.js
+    from_line: 11
+    to_line: 16

--- a/_examples/conversation/conversation/update-conversation/node.yml
+++ b/_examples/conversation/conversation/update-conversation/node.yml
@@ -3,9 +3,9 @@ dependencies:
     - nexmo@beta
 code:
     source: .repos/nexmo/nexmo-node-code-snippets/conversation/conversation/update-conversation.js
-    from_line: 22
-    to_line: 32
+    from_line: 20
+    to_line: 30
 client:
     source: .repos/nexmo/nexmo-node-code-snippets/conversation/conversation/update-conversation.js
     from_line: 13
-    to_line: 20
+    to_line: 18

--- a/_examples/conversation/conversation/update-conversation/node.yml
+++ b/_examples/conversation/conversation/update-conversation/node.yml
@@ -7,5 +7,5 @@ code:
     to_line: 30
 client:
     source: .repos/nexmo/nexmo-node-code-snippets/conversation/conversation/update-conversation.js
-    from_line: 13
+    from_line: 11
     to_line: 18

--- a/_examples/conversation/event/create-custom-event/node.yml
+++ b/_examples/conversation/event/create-custom-event/node.yml
@@ -7,5 +7,5 @@ code:
     to_line: 33
 client:
     source: .repos/nexmo/nexmo-node-code-snippets/conversation/event/create-custom-event.js
-    from_line: 13
+    from_line: 11
     to_line: 18

--- a/_examples/conversation/event/create-custom-event/node.yml
+++ b/_examples/conversation/event/create-custom-event/node.yml
@@ -1,0 +1,11 @@
+---
+dependencies:
+    - nexmo@beta
+code:
+    source: .repos/nexmo/nexmo-node-code-snippets/conversation/event/create-custom-event.js
+    from_line: 20
+    to_line: 33
+client:
+    source: .repos/nexmo/nexmo-node-code-snippets/conversation/event/create-custom-event.js
+    from_line: 13
+    to_line: 18

--- a/_examples/conversation/event/create-event/node.yml
+++ b/_examples/conversation/event/create-event/node.yml
@@ -1,0 +1,11 @@
+---
+dependencies:
+    - nexmo@beta
+code:
+    source: .repos/nexmo/nexmo-node-code-snippets/conversation/event/create-event.js
+    from_line: 19
+    to_line: 32
+client:
+    source: .repos/nexmo/nexmo-node-code-snippets/conversation/event/create-event.js
+    from_line: 12
+    to_line: 17

--- a/_examples/conversation/event/create-event/node.yml
+++ b/_examples/conversation/event/create-event/node.yml
@@ -7,5 +7,5 @@ code:
     to_line: 32
 client:
     source: .repos/nexmo/nexmo-node-code-snippets/conversation/event/create-event.js
-    from_line: 12
+    from_line: 10
     to_line: 17

--- a/_examples/conversation/event/delete-event/node.yml
+++ b/_examples/conversation/event/delete-event/node.yml
@@ -1,0 +1,11 @@
+---
+dependencies:
+    - nexmo@beta
+code:
+    source: .repos/nexmo/nexmo-node-code-snippets/conversation/event/delete-event.js
+    from_line: 19
+    to_line: 26
+client:
+    source: .repos/nexmo/nexmo-node-code-snippets/conversation/event/delete-event.js
+    from_line: 12
+    to_line: 17

--- a/_examples/conversation/event/delete-event/node.yml
+++ b/_examples/conversation/event/delete-event/node.yml
@@ -7,5 +7,5 @@ code:
     to_line: 26
 client:
     source: .repos/nexmo/nexmo-node-code-snippets/conversation/event/delete-event.js
-    from_line: 12
+    from_line: 10
     to_line: 17

--- a/_examples/conversation/event/get-event/node.yml
+++ b/_examples/conversation/event/get-event/node.yml
@@ -1,0 +1,11 @@
+---
+dependencies:
+    - nexmo@beta
+code:
+    source: .repos/nexmo/nexmo-node-code-snippets/conversation/event/get-event.js
+    from_line: 19
+    to_line: 27
+client:
+    source: .repos/nexmo/nexmo-node-code-snippets/conversation/event/get-event.js
+    from_line: 12
+    to_line: 17

--- a/_examples/conversation/event/get-event/node.yml
+++ b/_examples/conversation/event/get-event/node.yml
@@ -7,5 +7,5 @@ code:
     to_line: 27
 client:
     source: .repos/nexmo/nexmo-node-code-snippets/conversation/event/get-event.js
-    from_line: 12
+    from_line: 10
     to_line: 17

--- a/_examples/conversation/event/list-events/node.yml
+++ b/_examples/conversation/event/list-events/node.yml
@@ -7,5 +7,5 @@ code:
     to_line: 27
 client:
     source: .repos/nexmo/nexmo-node-code-snippets/conversation/event/list-events.js
-    from_line: 11
+    from_line: 9
     to_line: 16

--- a/_examples/conversation/event/list-events/node.yml
+++ b/_examples/conversation/event/list-events/node.yml
@@ -1,0 +1,11 @@
+---
+dependencies:
+    - nexmo@beta
+code:
+    source: .repos/nexmo/nexmo-node-code-snippets/conversation/event/list-events.js
+    from_line: 18
+    to_line: 27
+client:
+    source: .repos/nexmo/nexmo-node-code-snippets/conversation/event/list-events.js
+    from_line: 11
+    to_line: 16

--- a/_examples/conversation/event/list-next-events/node.yml
+++ b/_examples/conversation/event/list-next-events/node.yml
@@ -7,5 +7,5 @@ code:
     to_line: 31
 client:
     source: .repos/nexmo/nexmo-node-code-snippets/conversation/event/list-next-events.js
-    from_line: 11
+    from_line: 9
     to_line: 16

--- a/_examples/conversation/event/list-next-events/node.yml
+++ b/_examples/conversation/event/list-next-events/node.yml
@@ -1,0 +1,11 @@
+---
+dependencies:
+    - nexmo@beta
+code:
+    source: .repos/nexmo/nexmo-node-code-snippets/conversation/event/list-next-events.js
+    from_line: 18
+    to_line: 31
+client:
+    source: .repos/nexmo/nexmo-node-code-snippets/conversation/event/list-next-events.js
+    from_line: 11
+    to_line: 16

--- a/_examples/conversation/event/list-prev-events/node.yml
+++ b/_examples/conversation/event/list-prev-events/node.yml
@@ -1,0 +1,11 @@
+---
+dependencies:
+    - nexmo@beta
+code:
+    source: .repos/nexmo/nexmo-node-code-snippets/conversation/event/list-prev-events.js
+    from_line: 18
+    to_line: 37
+client:
+    source: .repos/nexmo/nexmo-node-code-snippets/conversation/event/list-prev-events.js
+    from_line: 11
+    to_line: 16

--- a/_examples/conversation/event/list-prev-events/node.yml
+++ b/_examples/conversation/event/list-prev-events/node.yml
@@ -7,5 +7,5 @@ code:
     to_line: 37
 client:
     source: .repos/nexmo/nexmo-node-code-snippets/conversation/event/list-prev-events.js
-    from_line: 11
+    from_line: 9
     to_line: 16

--- a/_examples/conversation/member/delete-member/node.yml
+++ b/_examples/conversation/member/delete-member/node.yml
@@ -1,0 +1,11 @@
+---
+dependencies:
+    - nexmo@beta
+code:
+    source: .repos/nexmo/nexmo-node-code-snippets/conversation/member/delete-member.js
+    from_line: 19
+    to_line: 26
+client:
+    source: .repos/nexmo/nexmo-node-code-snippets/conversation/member/delete-member.js
+    from_line: 12
+    to_line: 17

--- a/_examples/conversation/member/delete-member/node.yml
+++ b/_examples/conversation/member/delete-member/node.yml
@@ -7,5 +7,5 @@ code:
     to_line: 26
 client:
     source: .repos/nexmo/nexmo-node-code-snippets/conversation/member/delete-member.js
-    from_line: 12
+    from_line: 10
     to_line: 17

--- a/_examples/conversation/member/list-members/node.yml
+++ b/_examples/conversation/member/list-members/node.yml
@@ -3,9 +3,9 @@ dependencies:
     - nexmo@beta
 code:
     source: .repos/nexmo/nexmo-node-code-snippets/conversation/member/list-members.js
-    from_line: 19
-    to_line: 28
+    from_line: 18
+    to_line: 27
 client:
     source: .repos/nexmo/nexmo-node-code-snippets/conversation/member/list-members.js
-    from_line: 10
-    to_line: 17
+    from_line: 11
+    to_line: 16

--- a/_examples/conversation/member/list-members/node.yml
+++ b/_examples/conversation/member/list-members/node.yml
@@ -7,5 +7,5 @@ code:
     to_line: 27
 client:
     source: .repos/nexmo/nexmo-node-code-snippets/conversation/member/list-members.js
-    from_line: 11
+    from_line: 9
     to_line: 16

--- a/_examples/conversation/member/list-next-members/node.yml
+++ b/_examples/conversation/member/list-next-members/node.yml
@@ -7,5 +7,5 @@ code:
     to_line: 30
 client:
     source: .repos/nexmo/nexmo-node-code-snippets/conversation/member/list-next-members.js
-    from_line: 11
+    from_line: 9
     to_line: 16

--- a/_examples/conversation/member/list-next-members/node.yml
+++ b/_examples/conversation/member/list-next-members/node.yml
@@ -1,0 +1,11 @@
+---
+dependencies:
+    - nexmo@beta
+code:
+    source: .repos/nexmo/nexmo-node-code-snippets/conversation/member/list-next-members.js
+    from_line: 18
+    to_line: 30
+client:
+    source: .repos/nexmo/nexmo-node-code-snippets/conversation/member/list-next-members.js
+    from_line: 11
+    to_line: 16

--- a/_examples/conversation/member/list-prev-members/node.yml
+++ b/_examples/conversation/member/list-prev-members/node.yml
@@ -7,5 +7,5 @@ code:
     to_line: 36
 client:
     source: .repos/nexmo/nexmo-node-code-snippets/conversation/member/list-prev-members.js
-    from_line: 11
+    from_line: 9
     to_line: 16

--- a/_examples/conversation/member/list-prev-members/node.yml
+++ b/_examples/conversation/member/list-prev-members/node.yml
@@ -1,0 +1,11 @@
+---
+dependencies:
+    - nexmo@beta
+code:
+    source: .repos/nexmo/nexmo-node-code-snippets/conversation/member/list-prev-members.js
+    from_line: 18
+    to_line: 36
+client:
+    source: .repos/nexmo/nexmo-node-code-snippets/conversation/member/list-prev-members.js
+    from_line: 11
+    to_line: 16

--- a/_examples/conversation/member/update-member/node.yml
+++ b/_examples/conversation/member/update-member/node.yml
@@ -1,0 +1,11 @@
+---
+dependencies:
+    - nexmo@beta
+code:
+    source: .repos/nexmo/nexmo-node-code-snippets/conversation/member/update-member.js
+    from_line: 19
+    to_line: 31
+client:
+    source: .repos/nexmo/nexmo-node-code-snippets/conversation/member/update-member.js
+    from_line: 12
+    to_line: 17

--- a/_examples/conversation/member/update-member/node.yml
+++ b/_examples/conversation/member/update-member/node.yml
@@ -7,5 +7,5 @@ code:
     to_line: 31
 client:
     source: .repos/nexmo/nexmo-node-code-snippets/conversation/member/update-member.js
-    from_line: 12
+    from_line: 10
     to_line: 17

--- a/_examples/conversation/user/list-next-user-conversations/node.yml
+++ b/_examples/conversation/user/list-next-user-conversations/node.yml
@@ -1,0 +1,11 @@
+---
+dependencies:
+    - nexmo@beta
+code:
+    source: .repos/nexmo/nexmo-node-code-snippets/conversation/user/list-next-user-conversations.js
+    from_line: 18
+    to_line: 30
+client:
+    source: .repos/nexmo/nexmo-node-code-snippets/conversation/user/list-next-user-conversations.js
+    from_line: 11
+    to_line: 16

--- a/_examples/conversation/user/list-next-user-conversations/node.yml
+++ b/_examples/conversation/user/list-next-user-conversations/node.yml
@@ -7,5 +7,5 @@ code:
     to_line: 30
 client:
     source: .repos/nexmo/nexmo-node-code-snippets/conversation/user/list-next-user-conversations.js
-    from_line: 11
+    from_line: 9
     to_line: 16

--- a/_examples/conversation/user/list-next-users/node.yml
+++ b/_examples/conversation/user/list-next-users/node.yml
@@ -7,5 +7,5 @@ code:
     to_line: 29
 client:
     source: .repos/nexmo/nexmo-node-code-snippets/conversation/user/list-next-users.js
-    from_line: 10
+    from_line: 8
     to_line: 15

--- a/_examples/conversation/user/list-next-users/node.yml
+++ b/_examples/conversation/user/list-next-users/node.yml
@@ -1,0 +1,11 @@
+---
+dependencies:
+    - nexmo@beta
+code:
+    source: .repos/nexmo/nexmo-node-code-snippets/conversation/user/list-next-users.js
+    from_line: 17
+    to_line: 29
+client:
+    source: .repos/nexmo/nexmo-node-code-snippets/conversation/user/list-next-users.js
+    from_line: 10
+    to_line: 15

--- a/_examples/conversation/user/list-prev-user-conversations/node.yml
+++ b/_examples/conversation/user/list-prev-user-conversations/node.yml
@@ -1,0 +1,11 @@
+---
+dependencies:
+    - nexmo@beta
+code:
+    source: .repos/nexmo/nexmo-node-code-snippets/conversation/user/list-prev-user-conversations.js
+    from_line: 18
+    to_line: 36
+client:
+    source: .repos/nexmo/nexmo-node-code-snippets/conversation/user/list-prev-user-conversations.js
+    from_line: 11
+    to_line: 16

--- a/_examples/conversation/user/list-prev-user-conversations/node.yml
+++ b/_examples/conversation/user/list-prev-user-conversations/node.yml
@@ -7,5 +7,5 @@ code:
     to_line: 36
 client:
     source: .repos/nexmo/nexmo-node-code-snippets/conversation/user/list-prev-user-conversations.js
-    from_line: 11
+    from_line: 9
     to_line: 16

--- a/_examples/conversation/user/list-prev-users/node.yml
+++ b/_examples/conversation/user/list-prev-users/node.yml
@@ -7,5 +7,5 @@ code:
     to_line: 35
 client:
     source: .repos/nexmo/nexmo-node-code-snippets/conversation/user/list-prev-users.js
-    from_line: 10
+    from_line: 8
     to_line: 15

--- a/_examples/conversation/user/list-prev-users/node.yml
+++ b/_examples/conversation/user/list-prev-users/node.yml
@@ -1,0 +1,11 @@
+---
+dependencies:
+    - nexmo@beta
+code:
+    source: .repos/nexmo/nexmo-node-code-snippets/conversation/user/list-prev-users.js
+    from_line: 17
+    to_line: 35
+client:
+    source: .repos/nexmo/nexmo-node-code-snippets/conversation/user/list-prev-users.js
+    from_line: 10
+    to_line: 15

--- a/_examples/conversation/user/list-user-conversations/node.yml
+++ b/_examples/conversation/user/list-user-conversations/node.yml
@@ -2,10 +2,10 @@
 dependencies:
     - nexmo@beta
 code:
-    source: .repos/nexmo/nexmo-node-code-snippets/conversation/user/get-user-conversations.js
+    source: .repos/nexmo/nexmo-node-code-snippets/conversation/user/list-user-conversations.js
     from_line: 18
     to_line: 25
 client:
-    source: .repos/nexmo/nexmo-node-code-snippets/conversation/user/get-user-conversations.js
+    source: .repos/nexmo/nexmo-node-code-snippets/conversation/user/list-user-conversations.js
     from_line: 9
     to_line: 16

--- a/_examples/conversation/user/list-users/node.yml
+++ b/_examples/conversation/user/list-users/node.yml
@@ -2,10 +2,10 @@
 dependencies:
     - nexmo@beta
 code:
-    source: .repos/nexmo/nexmo-node-code-snippets/conversation/user/get-users.js
+    source: .repos/nexmo/nexmo-node-code-snippets/conversation/user/list-users.js
     from_line: 17
     to_line: 24
 client:
-    source: .repos/nexmo/nexmo-node-code-snippets/conversation/user/get-users.js
+    source: .repos/nexmo/nexmo-node-code-snippets/conversation/user/list-users.js
     from_line: 8
     to_line: 15


### PR DESCRIPTION
## Description

Adds missing Node snippets for Conversation API.

Also adds some minor changes to wording.

Adds navigation weight for snippets so they appear in a logical order.

**NOTE:** Must be handled in conjunction with https://github.com/Nexmo/nexmo-node-code-snippets/pull/74 

## Review

Check Conversation API Node code snippets.