### PR TITLE
Note on text and media sizes for WhatsApp

### DIFF
--- a/_documentation/en/messages/code-snippets/whatsapp/send-audio.md
+++ b/_documentation/en/messages/code-snippets/whatsapp/send-audio.md
@@ -5,7 +5,7 @@ meta_title: Send an audio message on WhatsApp using the Messages API
 
 # Send an Audio Message
 
-In this code snippet you will see how to send a WhatsApp audio message using the Messages API.
+In this code snippet you will see how to send a WhatsApp audio message using the Messages API. For WhatsApp the maximum outbound media size is 64MB.
 
 > **IMPORTANT:** If a customer has not messaged you first, then the first time you send a message to a user, WhatsApp requires that the message contains a template. This is explained in more detail in the [Understanding WhatsApp topic](/messages/concepts/whatsapp).
 
@@ -18,7 +18,7 @@ Key | Description
 `NEXMO_APPLICATION_ID` | The ID of the application that you created.
 `WHATSAPP_NUMBER` | The WhatsApp number that has been allocated to you by Nexmo.
 `TO_NUMBER` | The phone number you are sending the message to.
-`AUDIO_URL` | The URL of the image to send.
+`AUDIO_URL` | The URL of the audio file to send.
 
 > **NOTE:** Don't use a leading `+` or `00` when entering a phone number, start with the country code, for example, 447700900000.
 

--- a/_documentation/en/messages/code-snippets/whatsapp/send-file.md
+++ b/_documentation/en/messages/code-snippets/whatsapp/send-file.md
@@ -5,7 +5,7 @@ meta_title: Send a file message on WhatsApp using the Messages API
 
 # Send a File Message
 
-In this code snippet you will see how to send a WhatsApp file message using the Messages API.
+In this code snippet you will see how to send a WhatsApp file message using the Messages API. For WhatsApp the maximum outbound media size is 64MB.
 
 > **IMPORTANT:** If a customer has not messaged you first, then the first time you send a message to a user, WhatsApp requires that the message contains a template. This is explained in more detail in the [Understanding WhatsApp topic](/messages/concepts/whatsapp).
 

--- a/_documentation/en/messages/code-snippets/whatsapp/send-image.md
+++ b/_documentation/en/messages/code-snippets/whatsapp/send-image.md
@@ -5,7 +5,7 @@ meta_title: Send an image message on WhatsApp using the Messages API
 
 # Send an Image Message
 
-In this code snippet you will see how to send a WhatsApp image message using the Messages API.
+In this code snippet you will see how to send a WhatsApp image message using the Messages API. For WhatsApp the maximum outbound media size is 64MB.
 
 > **IMPORTANT:** If a customer has not messaged you first, then the first time you send a message to a user, WhatsApp requires that the message contains a template. This is explained in more detail in the [Understanding WhatsApp topic](/messages/concepts/whatsapp).
 

--- a/_documentation/en/messages/code-snippets/whatsapp/send-text.md
+++ b/_documentation/en/messages/code-snippets/whatsapp/send-text.md
@@ -5,7 +5,7 @@ meta_title: Send an text message on WhatsApp using the Messages API
 
 # Send a Text Message
 
-In this code snippet you will see how to send a WhatsApp message using the Messages API.
+In this code snippet you will see how to send a WhatsApp message using the Messages API. For WhatsApp the maximum text size is 4096 characters, including Unicode.
 
 For a step-by-step guide to this topic, you can read our tutorial [Sending WhatsApp messages with the Messages API](/tutorials/sending-whatsapp-messages-with-messages-api).
 

--- a/_documentation/en/messages/code-snippets/whatsapp/send-video.md
+++ b/_documentation/en/messages/code-snippets/whatsapp/send-video.md
@@ -5,7 +5,7 @@ meta_title: Send a Video message with WhatsApp
 
 # Send a Video Message
 
-In this code snippet you will see how to send a video message through WhatsApp using the Messages API.
+In this code snippet you will see how to send a video message through WhatsApp using the Messages API. For WhatsApp the maximum outbound media size is 64MB.
 
 ## Example
 


### PR DESCRIPTION
## Description

This PR adds a little note on outbound media size restriction for WhatsApp (64MB). Also added note on text size restriction and corrected a small copy and paste error.

## Review

1. Go to review app
2. Go to Messages / Code snippets / WhatsApp
3. The send media snippets should mention the 64MB size restriction. The send text snippet mention the 4096 character restriction.