### PR TITLE
Fix tutorial step

### DIFF
--- a/app/models/tutorial.rb
+++ b/app/models/tutorial.rb
@@ -11,7 +11,7 @@ class Tutorial
     # TODO: make this work with I18n fallback
     path = "#{self.class.task_content_path}/#{I18n.default_locale}/#{step_name}.md"
 
-    raise "Invalid step: #{step_name}" unless File.exist? path
+    raise DocFinder::MissingDoc, "Invalid step: #{step_name}" unless File.exist? path
     File.read(path)
   end
 

--- a/config/redirects.yml
+++ b/config/redirects.yml
@@ -252,3 +252,4 @@
 "/vonage-business-cloud/vbc-apis/getting-started": "/vonage-business-cloud/vbc-apis/getting-started/create-application"
 "/send-an-sms": "/messaging/sms/code-snippets/send-an-sms"
 "/api/developer/pricing": "/api/pricing"
+"/client-sdk/tutorials/in-app-messaging/client-sdk/create-ui-ip-messaging": "/client-sdk/tutorials/in-app-messaging/client-sdk/ip-messaging/create-ui"

--- a/spec/models/tutorial_spec.rb
+++ b/spec/models/tutorial_spec.rb
@@ -177,7 +177,7 @@ RSpec.describe Tutorial, type: :model do
         allow(File).to receive(:exist?).with("#{Tutorial.task_content_path}/en/missing-step.md").and_return(false)
         create_example_config
         tutorial = described_class.load('example-tutorial', 'introduction')
-        expect { tutorial.content_for('missing-step') }.to raise_error('Invalid step: missing-step')
+        expect { tutorial.content_for('missing-step') }.to raise_error(DocFinder::MissingDoc, 'Invalid step: missing-step')
       end
     end
   end


### PR DESCRIPTION
## Description

Invalid tutorial steps will no longer return a 500 (404 instead).
In the future the files lookup will be handled by the `DocFinder` (Jira tickets pending) so these 500s shouldn't happen.
This also adds a missing redirect