### PR TITLE
Describe getEvents paging

### DIFF
--- a/_partials/stitch/guides/utilizing-events/javascript.md
+++ b/_partials/stitch/guides/utilizing-events/javascript.md
@@ -31,7 +31,7 @@ We will use the `getEvents` method to retrieve all the events that occurred in t
 
 The `getEvents` method returns a subset or "page" of events with each invocation. The number of events it returns is based on the `page_size` parameter. The default is 10 results, the maximum is 100.
 
-> **Note**: See the [EventsPage](/sdk/stitch/javascript/EventsPage.html) documentation for helper methods you can use to work with this paginated data.
+> **Note**: See the [documentation](/sdk/stitch/javascript/EventsPage.html) for helper methods you can use to work with this paginated data.
 
 ```javascript
 showConversationHistory(conversation) {

--- a/_partials/stitch/guides/utilizing-events/javascript.md
+++ b/_partials/stitch/guides/utilizing-events/javascript.md
@@ -25,7 +25,13 @@ We will use the application we already created for [the second getting started g
 
 ### 1.1 - Add conversation history
 
-The first thing we're going to do is add history to the existing conversation. We're going to add a method that gets all the events that happened in the conversation and displays conversation history in the message feed.
+The first thing we're going to do is add history to the existing conversation. 
+
+We will use the `getEvents` method to retrieve all the events that occurred in the context of the conversation and display this history in the message feed.
+
+The `getEvents` method returns a subset or "page" of events with each invocation. The number of events it returns is based on the `page_size` parameter. The default is 10 results, the maximum is 100.
+
+> **Note**: See the [EventsPage](/sdk/stitch/javascript/EventsPage.html) documentation for helper methods you can use to work with this paginated data.
 
 ```javascript
 showConversationHistory(conversation) {


### PR DESCRIPTION
## Description

The docs are missing info on how to work with paginated results from the `getEvents` method. Adding this to the "Utilizing Events" guide. Will also add this information to the OAS under a separate PR.

https://nexmoinc.atlassian.net/browse/DEVX-1786


## Deploy Notes

Client SDK > In-app Messaging > Guides > Utilizing Events. See section 1.1: Add conversation history.
