### PR TITLE
Make Tutorials and UseCases use DocFinder to select the corresponding

### DIFF
--- a/app/controllers/tutorial_controller.rb
+++ b/app/controllers/tutorial_controller.rb
@@ -66,7 +66,7 @@ class TutorialController < ApplicationController
   end
 
   def single
-    path = "#{Rails.root}/_tutorials/#{params[:tutorial_step]}.md"
+    path = "#{Rails.root}/_tutorials/#{I18n.default_locale}/#{params[:tutorial_step]}.md"
     @content = File.read(path)
     @content = MarkdownPipeline.new({
                                       code_language: @code_language,

--- a/app/controllers/use_case_controller.rb
+++ b/app/controllers/use_case_controller.rb
@@ -1,5 +1,4 @@
 class UseCaseController < ApplicationController
-  before_action :set_document
   before_action :set_navigation
 
   def index
@@ -40,17 +39,21 @@ class UseCaseController < ApplicationController
 
   def show
     # Read document
-    # TODO: make this work with I18n fallback
-    @document_path = "_use_cases/#{I18n.default_locale}/#{@document}.md"
-    document = File.read("#{Rails.root}/#{@document_path}")
+    @document_path = DocFinder.find(
+      root: '_use_cases',
+      document: params[:document],
+      language: I18n.locale,
+      code_language: params[:code_language]
+    )
+    @document = File.read(@document_path)
 
     # Parse frontmatter
-    @frontmatter = YAML.safe_load(document)
+    @frontmatter = YAML.safe_load(@document)
 
     @document_title = @frontmatter['title']
     @product = @frontmatter['products']
 
-    @content = MarkdownPipeline.new({ code_language: @code_language }).call(document)
+    @content = MarkdownPipeline.new({ code_language: @code_language }).call(@document)
 
     @sidenav = Sidenav.new(
       namespace: params[:namespace],
@@ -65,10 +68,6 @@ class UseCaseController < ApplicationController
   end
 
   private
-
-  def set_document
-    @document = params[:document]
-  end
 
   def set_navigation
     @navigation = :use_case

--- a/app/models/tutorial.rb
+++ b/app/models/tutorial.rb
@@ -8,10 +8,12 @@ class Tutorial
       return raw[step_name]['content']
     end
 
-    # TODO: make this work with I18n fallback
-    path = "#{self.class.task_content_path}/#{I18n.default_locale}/#{step_name}.md"
+    path = DocFinder.find(
+      root: self.class.task_content_path,
+      document: step_name,
+      language: I18n.locale
+    )
 
-    raise DocFinder::MissingDoc, "Invalid step: #{step_name}" unless File.exist? path
     File.read(path)
   end
 
@@ -63,9 +65,11 @@ class Tutorial
     return [] unless prerequisites
 
     prerequisites.map do |t|
-      # TODO: make this work with I18n fallback
-      t_path = "#{task_content_path}/#{I18n.default_locale}/#{t}.md"
-
+      t_path = DocFinder.find(
+        root: task_content_path,
+        document: t,
+        language: I18n.locale
+      )
       raise "Prerequisite not found: #{t}" unless File.exist? t_path
       content = File.read(t_path)
       prereq = YAML.safe_load(content)
@@ -83,8 +87,11 @@ class Tutorial
     tasks ||= []
 
     tasks = tasks.map do |t|
-      # TODO: make this work with I18n fallback
-      t_path = "#{task_content_path}/#{I18n.default_locale}/#{t}.md"
+      t_path = DocFinder.find(
+        root: task_content_path,
+        document: t,
+        language: I18n.locale
+      )
       raise "Subtask not found: #{t}" unless File.exist? t_path
       subtask_config = YAML.safe_load(File.read(t_path))
       {
@@ -126,6 +133,6 @@ class Tutorial
   end
 
   def self.task_content_path
-    Pathname.new("#{Rails.root}/_tutorials")
+    '_tutorials'
   end
 end

--- a/config/initializers/doc_finder.rb
+++ b/config/initializers/doc_finder.rb
@@ -1,6 +1,7 @@
 DocFinder.configure do |config|
   config.paths << '_documentation'
   config.paths << '_use_cases'
+  config.paths << '_tutorials'
   config.paths << 'config/tutorials'
   config.paths << 'app/views/product-lifecycle'
   config.paths << 'app/views/contribute'

--- a/spec/models/tutorial_spec.rb
+++ b/spec/models/tutorial_spec.rb
@@ -174,10 +174,10 @@ RSpec.describe Tutorial, type: :model do
       end
 
       it 'raises if it does not exist' do
-        allow(File).to receive(:exist?).with("#{Tutorial.task_content_path}/en/missing-step.md").and_return(false)
         create_example_config
         tutorial = described_class.load('example-tutorial', 'introduction')
-        expect { tutorial.content_for('missing-step') }.to raise_error(DocFinder::MissingDoc, 'Invalid step: missing-step')
+        expect(DocFinder).to receive(:find).with(root: '_tutorials', document: 'missing-step', language: :en).and_call_original
+        expect { tutorial.content_for('missing-step') }.to raise_error(DocFinder::MissingDoc)
       end
     end
   end
@@ -261,8 +261,9 @@ def stub_task_config(path:, title:, description:, products:, tasks:, include_int
 end
 
 def create_application_content
+  path = "#{Tutorial.task_content_path}/en/application/create-voice.md"
   stub_task_content(
-    path: "#{Tutorial.task_content_path}/en/application/create-voice.md",
+    path: path,
     title: 'Create a voice application',
     description: 'Learn how to create a voice application',
     content: <<~HEREDOC
@@ -270,11 +271,15 @@ def create_application_content
       Creating a voice application is very important. Please do it
     HEREDOC
   )
+  allow(DocFinder).to receive(:find)
+    .with(root: '_tutorials', document: 'application/create-voice', language: :en)
+    .and_return(path)
 end
 
 def create_outbound_call_content
+  path = "#{Tutorial.task_content_path}/en/voice/make-outbound-call.md"
   stub_task_content(
-    path: "#{Tutorial.task_content_path}/en/voice/make-outbound-call.md",
+    path: path,
     title: 'Make an outbound call',
     description: 'Simple outbound call example',
     content: <<~HEREDOC
@@ -282,11 +287,14 @@ def create_outbound_call_content
       This is an example outbound call with Text-To-Speech
     HEREDOC
   )
+  allow(DocFinder).to receive(:find)
+    .with(root: '_tutorials', document: 'voice/make-outbound-call', language: :en)
+    .and_return(path)
 end
 
 def stub_task_content(path:, title:, description:, content:)
-  allow(File).to receive(:exist?).with(path) .and_return(true)
-  allow(File).to receive(:read).with(path) .and_return({
+  allow(File).to receive(:exist?).with(path).and_return(true)
+  allow(File).to receive(:read).with(path).and_return({
     'title' => title,
     'description' => description,
   }.to_yaml + "---\n" + content)


### PR DESCRIPTION
## Description
Make Tutorials and UseCases use DocFinder to select the corresponding files with fallback

It also fixes  `/task/client-sdk/generate-jwt`