### PR TITLE
Update delivery receipt docs

### DIFF
--- a/_documentation/en/messaging/sms/code-snippets/delivery-receipts.md
+++ b/_documentation/en/messaging/sms/code-snippets/delivery-receipts.md
@@ -8,9 +8,7 @@ navigation_weight: 4
 
 You can verify that a message you sent using Nexmo's SMS API reached your customer by requesting a [delivery receipt](/messaging/sms/guides/delivery-receipts) from the carrier.
 
-> **NOTE:** Not all networks and countries support delivery receipts. You can check our knowledge base for some further information on what you [might receive](https://help.nexmo.com/hc/en-us/articles/204014863) if the network does not support delivery receipts.
-
-For detailed information on delivery receipts see our [documentation](/messaging/sms/guides/delivery-receipts).
+> **NOTE:** Not all networks and countries support delivery receipts. You can check our knowledge base for some further information on what you [might receive](https://help.nexmo.com/hc/en-us/articles/204014863) if your network does not support delivery receipts. For detailed information on delivery receipts see our [documentation](/messaging/sms/guides/delivery-receipts).
 
 To access the delivery receipt, you need to:
 

--- a/_documentation/en/messaging/sms/code-snippets/delivery-receipts.md
+++ b/_documentation/en/messaging/sms/code-snippets/delivery-receipts.md
@@ -10,6 +10,8 @@ You can verify that a message you sent using Nexmo's SMS API reached your custom
 
 > **NOTE:** Not all networks and countries support delivery receipts. You can check our knowledge base for some further information on what you [might receive](https://help.nexmo.com/hc/en-us/articles/204014863) if the network does not support delivery receipts.
 
+For detailed information on delivery receipts see our [documentation](/messaging/sms/guides/delivery-receipts).
+
 To access the delivery receipt, you need to:
 
 * [Create a webhook endpoint](/messaging/sms/code-snippets/before-you-begin#webhooks) using one of the code examples shown below
@@ -51,3 +53,7 @@ image: public/assets/screenshots/smsDLRsettings.png
 ```
 
 > **NOTE:** After you send a message there may be a delay before you receive the delivery receipt.
+
+## More information
+
+* [SMS Delivery Receipt documentation](/messaging/sms/guides/delivery-receipts)

--- a/_documentation/en/messaging/sms/guides/delivery-receipts.md
+++ b/_documentation/en/messaging/sms/guides/delivery-receipts.md
@@ -8,7 +8,9 @@ navigation_weight: 4
 
 When you make a successful request to the SMS API, it returns an array of `message` objects, one for each message. Ideally these will have a `status` of `0`, indicating success. But this does not mean that your message has reached your recipients. It only means that your message has been successfully queued for sending.
 
-Nexmo's [adaptive routing](https://help.nexmo.com/hc/en-us/articles/218435987-What-is-Nexmo-Adaptive-Routing-) then identifies the best carrier for your message. When the selected carrier has delivered the message, it returns a *delivery receipt* (DLR). To receive DLRs in your application, you must provide a [webhook](/concepts/guides/webhooks) for Nexmo to send them to.
+Nexmo's [adaptive routing](https://help.nexmo.com/hc/en-us/articles/218435987-What-is-Nexmo-Adaptive-Routing-) then identifies the best carrier for your message. When the selected carrier has delivered the message, it returns a *delivery receipt* (DLR).
+
+To receive DLRs in your application, you must provide a [webhook](/concepts/guides/webhooks) for Nexmo to send them to. Alternatively, you could use the [Reports API](/reports/overview) to periodically download your records, including per-message delivery status.
 
 > **Note**: In most situations, a DLR is a reliable indicator that a message was delivered. However, it is not an absolute guarantee. See [how delivery receipts work](#how-delivery-receipts-work).
 


### PR DESCRIPTION
## Description

This PR makes two changes:

- [x] Cross reference our comprehensive delivery receipt docs from delivery receipt code snippet. 
- [x] Add a cross-reference to Reports API as an alternative to delivery receipts where DLRs are not supported.

## Review

* Check [code snippet](https://nexmo-developer-pr-2222.herokuapp.com/messaging/sms/code-snippets/delivery-receipts) for delivery receipt. Should now link back to delivery receipt docs.
* Check delivery receipt [docs](https://nexmo-developer-pr-2222.herokuapp.com/messaging/sms/guides/delivery-receipts) - should now cross-reference Reports API.
