### PR TITLE
Only render 404 results view if there are any results hits

### DIFF
--- a/app/views/static/404.html.erb
+++ b/app/views/static/404.html.erb
@@ -2,7 +2,7 @@
   <img src="/assets/images/lost.svg" alt="" width="120">
   <br><br>
   <h2>This page can't be found!</h2>
-  <% if @results[0].hits && @results[0].hits.length > 0 %>
+  <% if @results && @results[0].hits %>
     <p>Perhaps you were looking for one of these?</p>
     <div class="Vlt-grid">
     <% @results.each do |index| %>

--- a/app/views/static/404.html.erb
+++ b/app/views/static/404.html.erb
@@ -2,7 +2,7 @@
   <img src="/assets/images/lost.svg" alt="" width="120">
   <br><br>
   <h2>This page can't be found!</h2>
-  <% if @results && @results.length > 0 %> 
+  <% if @results[0].hits && @results[0].hits.length > 0 %>
     <p>Perhaps you were looking for one of these?</p>
     <div class="Vlt-grid">
     <% @results.each do |index| %>

--- a/app/views/static/404.html.erb
+++ b/app/views/static/404.html.erb
@@ -2,7 +2,7 @@
   <img src="/assets/images/lost.svg" alt="" width="120">
   <br><br>
   <h2>This page can't be found!</h2>
-  <% if @results && @results[0].hits %>
+  <% if @results && @results.map(&:hits).flatten.any? %>
     <p>Perhaps you were looking for one of these?</p>
     <div class="Vlt-grid">
     <% @results.each do |index| %>


### PR DESCRIPTION
## Description

The 404 view was rendering the results presentation even if there were no results because the check for `if @results && @results.length > 0` was always `true`, because the check needed to be actually on the `.hits` of `@results`, not on the entire array.