### PR TITLE
Remove backslash introduced by Smartling for some characters.

### DIFF
--- a/app/filters/i18n/smartling_converter_filter.rb
+++ b/app/filters/i18n/smartling_converter_filter.rb
@@ -1,7 +1,7 @@
 module I18n
   class SmartlingConverterFilter < Banzai::Filter
     def call(input)
-      input.gsub(/\A\*\*\* \*\* \* \*\* \*\*\*\n*(.*)\n*------------------------------------------/m) do |_frontmatter|
+      input = input.gsub(/\A\*\*\* \*\* \* \*\* \*\*\*\n*(.*)\n*------------------------------------------/m) do |_frontmatter|
         front = $1.gsub(/`(.*):`(.*)/) do |_config|
           "#{$1}:#{$2}"
         end
@@ -11,6 +11,7 @@ module I18n
           ---
         FRONTMATTER
       end
+      input.gsub('\-', '-').gsub('\|', '|')
     end
   end
 end

--- a/spec/filters/i18n/smartling_converter_spec.rb
+++ b/spec/filters/i18n/smartling_converter_spec.rb
@@ -24,4 +24,27 @@ RSpec.describe I18n::SmartlingConverterFilter do
       FRONTMATTER
     )
   end
+
+  context 'revert some encodings from smartling' do
+    let(:table) do
+      <<~TABLE
+        密钥 \| 说明
+        \-\- \| \-\-
+        `NEXMO_API_KEY` \| 您的 Nexmo API 密钥。
+        `NEXMO_API_SECRET` \| 您的 Nexmo API 密码。
+      TABLE
+    end
+
+    it 'unescapes some special characters' do
+      translated = described_class.call(table)
+      expect(translated).to include(
+        <<~TABLE
+          密钥 | 说明
+          -- | --
+          `NEXMO_API_KEY` | 您的 Nexmo API 密钥。
+          `NEXMO_API_SECRET` | 您的 Nexmo API 密码。
+        TABLE
+      )
+    end
+  end
 end


### PR DESCRIPTION
## Description

This fixes how tables are rendered. When we download translations from Smartling, some escaping is performed on their end. This removes some of them that were preventing the tables from being rendered correctly.

### Before
密钥 \| 说明
\-\- \| \-\-
`NEXMO_API_KEY` \| 您的 Nexmo API 密钥。
`NEXMO_API_SECRET` \| 您的 Nexmo API 密码。


### After
密钥 | 说明
-- | --
`NEXMO_API_KEY` | 您的 Nexmo API 密钥。
`NEXMO_API_SECRET` | 您的 Nexmo API 密码。

