### PR TITLE
Fix search when using the form without js.

### DIFF
--- a/app/views/layouts/partials/_header.html.erb
+++ b/app/views/layouts/partials/_header.html.erb
@@ -37,7 +37,7 @@
     </div>
 
     <% if search_enabled? %>
-      <%= form_tag '/search' do %>
+      <%= form_tag '/search', method: :get do %>
         <div id="search-app">
           <input type="text" id="searchbox" name="query" placeholder="Search" name="query" autocomplete="off" value="<%= @search_term || '' %>">
         </div>


### PR DESCRIPTION
## Description

When using `POST` we were getting an `invalid authenticity token` error,
for some reason Rails and Sinatra no longer get along well, using `GET`
instead prevents the error from happening and semantically it's also
correct.
