### PR TITLE
Client SDK v2 create application

### DIFF
--- a/_tutorials/en/client-sdk/create-application.md
+++ b/_tutorials/en/client-sdk/create-application.md
@@ -1,26 +1,54 @@
 ---
-title: Create a Client SDK Application
-description: In this step you learn how to create a Client SDK Application.
+title: Create a Nexmo Application
+description: In this step you learn how to create a Nexmo Application.
 ---
 
-# Create your Nexmo Client SDK Application
+# Create your Nexmo Application
 
-Make sure you have changed into your project directory, which is also where you installed the Nexmo Client SDK.
+You now need to create a Nexmo application. In this step you create an application capable of handling both in-app Voice and in-app Messaging use cases.
 
-Use the CLI to create your Nexmo application:
+> **NOTE:** In the following procedure you need to change the webhook URLs to suit your local setup. For more information on using Ngrok for local testing please see [testing with Ngrok](/concepts/guides/testing-with-ngrok). Any requests that Nexmo makes to the webhook URLs *must* be acknowledged by returning a HTTP `200` or `204` response.
+
+1) First create your project directory if you've not already done so.
+
+2) Change into the project directory.
+
+3) Create a Nexmo application [interactively](/application/nexmo-cli#interactive-mode). The following command enters interactive mode:
 
 ``` shell
-nexmo app:create "My Client SDK App" https://abcd1234.ngrok.io/webhooks/answer https://abcd1234.ngrok.io/webhooks/event --keyfile=private.key --type=voice
+nexmo app:create
 ```
 
-> **NOTE:** You need to change the webhook URLs to suit your local setup. For more information on using Ngrok for local testing please see [testing with Ngrok](/concepts/guides/testing-with-ngrok).
+4) Specify your application name. Press Enter to continue.
 
-Make a note of the generated Application ID, as you'll need it in the future. You can also check this in the [Nexmo Dashboard](https://dashboard.nexmo.com/voice/your-applications).
+5) You can now select your application capabilities using the arrow keys and then pressing spacebar to select the capabilities your application needs. For the purposes of this example select both Voice and RTC capabilities using the arrow keys and spacebar to select. Once you have selected both Voice and RTC capabilities press Enter to continue.
+
+> **NOTE:** If your application will be in-app voice only you can just select Voice capabilities. If you want in-app messaging select only RTC capabilities. If your app will have both in-app voice and in-app messaging select both capabilities.
+
+6) For "Use the default HTTP methods?" press Enter to select the default.
+
+7) For "Voice Answer URL" enter `https://example.ngrok.io/webhooks/answer` or other suitable URL (this depends on how you are testing).
+
+8) You are next prompted for the "Voice Fallback Answer URL". This is an optional fallback URL should your main Voice Answer URL fail for some reason. In this case just press Enter. If later you need the fallback URL you can add it in the [Dashboard](https://dashboard.nexmo.com/sign-in), or using the Nexmo CLI.
+
+9) You are now required to enter the "Voice Event URL". Enter `https://example.ngrok.io/webhooks/event`.
+
+10) For " RTC Event URL" enter `https://example.ngrok.io/webhooks/rtc`.
+
+11) For "Public Key path" press Enter to select the default. If you want to use your own public-private key pair refer to [this documentation](/application/nexmo-cli#creating-an-application-with-your-own-public-private-key-pair).
+
+12) For "Private Key path" type in `private.key` and press Enter.
+
+The application is then created.
+
+The file `.nexmo-app` is created in your project directory. This file contains the Nexmo Application ID and the private key. A private key file `private.key` is also created.
+
+Creating an application and application capabilities are covered in detail in the [documentation](/application/overview).
+
+Make a note of the generated Application ID, as you'll need it in the future. 
+
+## Nexmo Dashboard
+
+You can obtain information about your application, including Application ID, in the [Nexmo Dashboard](https://dashboard.nexmo.com/voice/your-applications).
 
 ![Nexmo Developer Dashboard Applications screenshot](/assets/screenshots/tutorials/app-to-phone/nexmo-dashboard-applications.png "Nexmo Developer Dashboard Applications screenshot")
-
-This command also creates a private key `private.key` in your current directory, which will be used to generate authentication credentials for your application.
-
-This command also configures the answer and event webhook endpoints. Nexmo makes a request to the answer webhook when a call is placed or received, and sends useful information to the event webhook over the lifetime of the call.
-
-Any requests that Nexmo makes to these URLs must be acknowledged by returning a HTTP `200` or `204` response.


### PR DESCRIPTION
## Description

This PR updates the shared step topic "create application" to use App V2 capabilities. 

Note that, at the moment, the same topic is used for both in-app voice and in-app messaging tutorials. For this reason the procedure shows you how to select for RTC capabilities, or Voice capabilities if you want to make calls using NCCOs (talk, record etc.). It also mentions you can apply both capabilities if you require that.

## Review

[Review link](https://nexmo-developer-pr-2244.herokuapp.com/client-sdk/tutorials/phone-to-app/client-sdk/create-application)