### PR TITLE
Send all feedback with a comment to a new channel

### DIFF
--- a/app/models/feedback/feedback.rb
+++ b/app/models/feedback/feedback.rb
@@ -96,6 +96,12 @@ module Feedback
         }
       end
 
+      # Send all comments to #documentation-feedbot
+      notifier.post options
+
+      # And to a separate, comments only channel
+      return if comment.blank?
+      options[:channel] = '#documentation-feedbot-comments'
       notifier.post options
     end
   end


### PR DESCRIPTION
## Description

Send feedback items with comments to a new channel so that they're easier to track. I've tested this locally using the production webhook URL as it won't work in a review app.

## Deploy Notes

N/A
