### PR TITLE
Bring back `Improve this page` link for docs.

### DIFF
--- a/app/controllers/markdown_controller.rb
+++ b/app/controllers/markdown_controller.rb
@@ -53,16 +53,18 @@ class MarkdownController < ApplicationController
     helpers.dashboard_cookie(params[:product])
   end
 
-  def document
-    @document ||= File.read(
-      DocFinder.find(
-        root: root_folder,
-        document: params[:document],
-        language: I18n.locale,
-        product: params[:product],
-        code_language: params[:code_language]
-      )
+  def document_path
+    @document_path ||= DocFinder.find(
+      root: root_folder,
+      document: params[:document],
+      language: I18n.locale,
+      product: params[:product],
+      code_language: params[:code_language]
     )
+  end
+
+  def document
+    @document ||= File.read(document_path)
   end
 
   def root_folder

--- a/spec/smoke_spec.rb
+++ b/spec/smoke_spec.rb
@@ -70,7 +70,9 @@ RSpec.describe 'Smoke Tests', type: :request do
 
   it 'markdown page contains the expected text' do
     get '/voice/voice-api/guides/numbers'
+
     expect(response.body).to include('Numbers are a key concept to understand when working with the Nexmo Voice API. The following points should be considered before developing your Nexmo Application.')
+    expect(response.body).to include('github_url')
   end
 
   it 'markdown page has default code_language' do


### PR DESCRIPTION
## Description
The Feedback Vue component depends on the `github_url` property which
needs a @document_path in order to render the `Improve this page` link.
