### PR TITLE
WhatsApp deterministic language policy

### DIFF
--- a/_documentation/en/messages/concepts/whatsapp.md
+++ b/_documentation/en/messages/concepts/whatsapp.md
@@ -38,7 +38,7 @@ The parameters are an array. The first value being `{{1}}` in the MTM.
 
 Below is an example API call:
 
-```
+``` shell
 curl -X POST \
   https://api.nexmo.com/beta/messages \
   -H 'Authorization: Bearer' $JWT \
@@ -75,8 +75,7 @@ curl -X POST \
         "locale": "en-GB"
       }
    }
-}
-'
+}'
 ```
 
 ## WhatsApp deterministic language policy

--- a/_documentation/en/messages/concepts/whatsapp.md
+++ b/_documentation/en/messages/concepts/whatsapp.md
@@ -84,7 +84,7 @@ curl -X POST \
 
 When a message template is sent with the deterministic language policy, the receiving device will query its cache for a *language pack* for the language and locale specified in the message. If not available in the cache, the device will query the server for the required language pack. With the deterministic language policy the target device language and locale settings are ignored. If the language pack specified for the message is not available an error will be logged.
 
-Further information is available oin the [WhatsApp documentation](https://developers.facebook.com/docs/whatsapp/message-templates/sending/#language).
+Further information is available in the [WhatsApp documentation](https://developers.facebook.com/docs/whatsapp/message-templates/sending/#language).
 
 ## Important WhatsApp Rules
 

--- a/_documentation/en/messages/concepts/whatsapp.md
+++ b/_documentation/en/messages/concepts/whatsapp.md
@@ -79,8 +79,20 @@ curl -X POST \
 '
 ```
 
+## WhatsApp deterministic language policy
+
+> **NOTE:** From January 2020 the *deterministic* language policy will be the default and the *fallback* language policy will be deprecated.
+
+When a message template is sent with the deterministic language policy, the receiving device will query its cache for a *language pack* for the language and locale specified in the message. If not available in the cache, the device will query the server for the required language pack. With the deterministic language policy the target device language and locale settings are ignored. If the language pack specified for the message is not available an error will be logged.
+
+Further information is available oin the [WhatsApp documentation](https://developers.facebook.com/docs/whatsapp/message-templates/sending/#language).
+
 ## Important WhatsApp Rules
 
 If your customer initiates messaging with you, you will not be charged for any messages (including MTMs) that you send back to the customer, for up to 24 hours following the last message that your customer sent you. This 24 hour period is known as the Customer Care Window. Any additional message you send to that customer beyond the Customer Care Window must be an MTM, for which you will be charged.
 
 > **IMPORTANT**: The WhatsApp Business Solution may not be used to send any messages to or receive messages from the following countries or regions: Crimea, Cuba, Iran, North Korea, and Syria.
+
+## Further information
+
+* [WhatsApp Developer documentation](https://developers.facebook.com/docs/whatsapp)


### PR DESCRIPTION
## Description

Adds some brief notes on WhatsApp deterministic language policy, which from Jan 2020 will be the only (default) language policy as fallback will be deprecated.

## Review

[Review topic](https://nexmo-developer-pr-2268.herokuapp.com/messages/concepts/whatsapp#whatsapp-deterministic-language-policy)