### PR TITLE
Remove expiration when caching the sidenav.

### DIFF
--- a/app/views/layouts/documentation.html.erb
+++ b/app/views/layouts/documentation.html.erb
@@ -7,7 +7,7 @@
     <div id="Vlt-sidenav" class="Vlt-sidenav Vlt-sidenav--light">
       <div class="Vlt-sidenav__scroll">
         <nav class="sidenav" tabindex="0" data-active="<%= active_sidenav_item %>">
-          <% cache_unless params[:namespace].present?, 'sidenav', expires_in: 10.hours do %>
+          <% cache_unless params[:namespace].present?, 'sidenav' do %>
             <%= render partial: 'layouts/partials/sidenav' %>
           <% end %>
         </nav>


### PR DESCRIPTION
## Description

The cache is cleared in every deploy and rendering the sidenav is very
time consuming, causing a lot fo requests to queue up.

