### PR TITLE
Set rubygems version to 3.0.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ services:
 addons:
   postgresql: '9.4'
 before_install:
-  - gem update --system
+  - gem update --system 3.0.3
   - gem update bundler
   - nvm install
 install: bundle install --deployment --path vendor/bundle && yarn install


### PR DESCRIPTION
## Description

Rubygems version 3.1.3 comes with bundler v2.1.0 bundled (see
https://blog.rubygems.org/2019/12/16/3.1.1-released.html) which
conflicts with the one installed for ruby 2.5.7.

