### PR TITLE
Fix tooltip.

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -14,6 +14,8 @@
 //= require jquery_ujs
 //= require jquery-scrolltofixed
 //= require volta/volta.core.js
+//= require volta/popper.min.js
+//= require volta/tooltip.min.js
 //= require volta/components/volta.accordion.js
 //= require volta/components/volta.tab.js
 //= require volta/components/volta.tooltip.js


### PR DESCRIPTION
## Description

Volta's tooltips require two extra libraries in order to be loaded,
popper.js and tooltip.js which were not being included in the bundle
causing the tooltips not to work.

For an example, visit `/messaging/sms/guides/custom-sender-id#valid` and hover over the `?` icon