### PR TITLE
Remove implementation detail from Team spec count

### DIFF
--- a/spec/features/team_spec.rb
+++ b/spec/features/team_spec.rb
@@ -29,7 +29,7 @@ RSpec.feature 'Team' do
       end
 
       within('.Vlt-grid:nth-of-type(1)') do
-        expect(page).to have_css('.Nxd-profile', count: 25)
+        expect(page).to have_css('.Nxd-profile').at_least(1).times
       end
 
       expect(page).to have_css('h2', text: 'Contributors')


### PR DESCRIPTION
Remove the exact count as an implementation detail in the spec for the team view spec. This often serves as an unnecessary hurdle for updating the team page, and updating a spec for each minor change to a view detail doesn't reflect well on the test design.
