### PR TITLE
Fix link to /account/secret-management.

### DIFF
--- a/_documentation/en/account/overview.md
+++ b/_documentation/en/account/overview.md
@@ -29,5 +29,5 @@ product: account
 
 ## See also
 
-* [Secret Management overview](/accounts/secret-management/overview)
+* [Secret Management overview](/account/secret-management)
 


### PR DESCRIPTION
## Description

The previous link had a typo, it pointed to `/accountS/secret-management/overview` and using a [redirect](https://github.com/Nexmo/nexmo-developer/blob/master/config/redirects.yml#L222) causing a 404.

