### PR TITLE
rename duplicate titles to language specific

### DIFF
--- a/_use_cases/en/voice-call-websocket-node.md
+++ b/_use_cases/en/voice-call-websocket-node.md
@@ -1,12 +1,12 @@
 ---
-title: Call a Websocket
+title: Call a Websocket with Node.js
 products: voice/voice-api
 description: In this tutorial, you will learn how to connect a call to a websocket endpoint that echoes the call audio back to the caller.
 languages:
     - Node
 ---
 
-# Call a Websocket
+# Call a Websocket with Node.js
 
 You can use the Nexmo Voice API to connect a call to a [WebSocket](/voice/voice-api/guides/websockets), giving you a two-way stream of the call audio delivered over the WebSocket protocol in real-time. This enables you to process the call audio to perform tasks such as sentiment analysis, real-time transcription and decision-making using artificial intelligence.
 

--- a/_use_cases/en/voice-call-websocket-python.md
+++ b/_use_cases/en/voice-call-websocket-python.md
@@ -1,12 +1,12 @@
 ---
-title: Call a Websocket
+title: Call a Websocket with Python
 products: voice/voice-api
 description: In this tutorial, you will learn how to connect a call to a websocket endpoint that echoes the call audio back to the caller.
 languages:
     - Python
 ---
 
-# Call a Websocket
+# Call a Websocket with Python
 
 You can use the Nexmo Voice API to connect a call to a [WebSocket](/voice/voice-api/guides/websockets), giving you a two-way stream of the call audio delivered over the WebSocket protocol in real-time. This enables you to process the call audio to perform tasks such as sentiment analysis, real-time transcription and decision-making using artificial intelligence.
 


### PR DESCRIPTION
The `Call a Websocket` Use Cases were both duplicative in their titles. This adds the language specificity to each title to make it clearer.