### PR TITLE
Webhook URLs - Port should not be specified in these URLs

### DIFF
--- a/_partials/reusable/configure-webhook-urls.md
+++ b/_partials/reusable/configure-webhook-urls.md
@@ -19,12 +19,12 @@ From [Nexmo Dashboard](https://dashboard.nexmo.com) go to [Messages and Dispatch
 
 Enter your Webhook URLs in the fields labeled **Status URL** and **Inbound URL**.
 
-The values you enter for webhook URLs depends on where your webhook server is located. If your server was running on port 3000 on `example.com` your webhook URLs might be:
+The values you enter for webhook URLs depends on where your webhook server is located.
 
 Webhook | URL
 ---|---
-Status URL | `https://www.example.com:3000/webhooks/message-status`
-Inbound URL | `https://www.example.com:3000/webhooks/inbound-message`
+Status URL | `https://www.example.com/webhooks/message-status`
+Inbound URL | `https://www.example.com/webhooks/inbound-message`
 
 > **NOTE:** The default method of `POST` should be used for both of the webhook URLs.
 
@@ -40,11 +40,11 @@ See our information on [Using Ngrok for local development](/concepts/guides/test
 
 If using Ngrok in this manner you would use the Ngrok URLs for your webhook URLs:
 
-* `https://abcdef1.ngrok.io:3000/webhooks/inbound-message`
-* `https://abcdef1.ngrok.io:3000/webhooks/message-status`
+* `https://abcdef1.ngrok.io/webhooks/inbound-message`
+* `https://abcdef1.ngrok.io/webhooks/message-status`
 
 ### Callback queue
 
 Please note that callbacks emanating from Nexmo, such as those on your Message Status webhook URL and Inbound Message URL, are queued by Nexmo on a per-account basis, **not** a per-application basis.
 
-To avoid callbacks stalling the callback queue, please ensure that all applications acknowledge callbacks with a 200 response. Further, it is advisable to cease activity on a test application 24 hours before deleting it, or removing webhook configuration, otherwise it could potentially leave callbacks in your callback queue that will not be acknowledged, and therefore result in delays on callbacks destined for your production applications.
+**NOTE:** To avoid callbacks stalling the callback queue, please ensure that all applications acknowledge callbacks with a 200 response. Further, it is advisable to cease activity on a test application 24 hours before deleting it, or removing webhook configuration, otherwise it could potentially leave callbacks in your callback queue that will not be acknowledged, and therefore result in delays on callbacks destined for your production applications.

--- a/_tutorials/en/olympus/configure-webhooks.md
+++ b/_tutorials/en/olympus/configure-webhooks.md
@@ -22,12 +22,12 @@ From [Nexmo Dashboard](https://dashboard.nexmo.com) go to [Messages and Dispatch
 
 Enter your Webhook URLs in the fields labeled **Status URL** and **Inbound URL**.
 
-The values you enter for webhook URLs depends on where your webhook server is located. If your server was running on port 3000 on `example.com` your webhook URLs might be:
+The values you enter for webhook URLs depends on where your webhook server is located, for example:
 
 Webhook | URL
 ---|---
-Status URL | `https://www.example.com:3000/webhooks/message-status`
-Inbound URL | `https://www.example.com:3000/webhooks/inbound-message`
+Status URL | `https://www.example.com/webhooks/message-status`
+Inbound URL | `https://www.example.com/webhooks/inbound-message`
 
 > **NOTE:** The default method of `POST` should be used for both of the webhook URLs.
 

--- a/_tutorials/en/olympus/test-webhook-server.md
+++ b/_tutorials/en/olympus/test-webhook-server.md
@@ -9,5 +9,5 @@ See our information on [Using Ngrok for local development](/concepts/guides/test
 
 If using Ngrok in this manner you would use the Ngrok URLs for your webhook URLs:
 
-* `https://abcdef1.ngrok.io:3000/webhooks/inbound-message`
-* `https://abcdef1.ngrok.io:3000/webhooks/message-status`
+* `https://abcdef1.ngrok.io/webhooks/inbound-message`
+* `https://abcdef1.ngrok.io/webhooks/message-status`

--- a/_use_cases/en/retrieve-conversation-details.md
+++ b/_use_cases/en/retrieve-conversation-details.md
@@ -48,7 +48,7 @@ So, if you are ready to continue...
 First you will need to create a Nexmo Application if you have not already done so:
 
 ``` bash
-nexmo app:create "Conversation App" http://demo.ngrok.io:3000/webhooks/answer http://demo.ngrok.io:3000/webhooks/event --keyfile private.key
+nexmo app:create "Conversation App" http://demo.ngrok.io/webhooks/answer http://demo.ngrok.io/webhooks/event --keyfile private.key
 ```
 
 In this previous command you will need to replace `demo` by what applies to your setup.


### PR DESCRIPTION
## Description

Port does not need to be specified in webhooks for Ngrok testing. 

## Review

Pages to be reviewed:

- [ ] [Configure webhooks](https://nexmo-developer-pr-2379.herokuapp.com/messages/code-snippets/configure-webhooks)
- [ ] [Configure webhooks prereq](https://nexmo-developer-pr-2379.herokuapp.com/dispatch/tutorials/sending-facebook-message-with-failover/prerequisites)
- [ ] [Create app](https://nexmo-developer-pr-2379.herokuapp.com/use-cases/retrieve-conversation-details#create-a-nexmo-application)