### PR TITLE
Link to API docs for message status format

### DIFF
--- a/_documentation/en/messages/code-snippets/inbound-message.md
+++ b/_documentation/en/messages/code-snippets/inbound-message.md
@@ -22,4 +22,4 @@ application:
 
 ## Try it out
 
-The webhook is invoked on receipt of an inbound message and the message details and data are printed to the console.
+The webhook is invoked on receipt of an [inbound message](https://developer.nexmo.com/api/messages-olympus#inbound-message) and the message details and data are printed to the console.

--- a/_documentation/en/messages/code-snippets/inbound-message.md
+++ b/_documentation/en/messages/code-snippets/inbound-message.md
@@ -22,4 +22,4 @@ application:
 
 ## Try it out
 
-The webhook is invoked on receipt of an [inbound message](/messages/code-snippets/sms/send-sms) and the message details and data are printed to the console.
+The webhook is invoked on receipt of an inbound message and the message details and data are printed to the console.

--- a/_documentation/en/messages/code-snippets/inbound-message.md
+++ b/_documentation/en/messages/code-snippets/inbound-message.md
@@ -22,4 +22,4 @@ application:
 
 ## Try it out
 
-The webhook is invoked on receipt of an [inbound message](https://developer.nexmo.com/api/messages-olympus#inbound-message) and the message details and data are printed to the console.
+The webhook is invoked on receipt of an [inbound message](/api/messages-olympus#inbound-message) and the message details and data are printed to the console.

--- a/_documentation/en/messages/code-snippets/inbound-message.md
+++ b/_documentation/en/messages/code-snippets/inbound-message.md
@@ -22,4 +22,4 @@ application:
 
 ## Try it out
 
-The webhook is invoked on inbound message and the message details and data printed to the console.
+The webhook is invoked on receipt of an [inbound message](/messages/code-snippets/sms/send-sms) and the message details and data are printed to the console.

--- a/_documentation/en/messages/code-snippets/message-status.md
+++ b/_documentation/en/messages/code-snippets/message-status.md
@@ -22,4 +22,6 @@ application:
 
 ## Try it out
 
-The webhook is invoked on a change in status for the [sent message](/messages/code-snippets/sms/send-sms). The message status is also printed to the console.
+The webhook is invoked on a change in status for an outbound message sent from Nexmo. The message status is also printed to the console.
+
+The format of the message status `POST` request can be found in the [Message Status](https://developer.nexmo.com/api/messages-olympus#message-status) section of the [API reference](https://developer.nexmo.com/api/messages-olympus#overview).

--- a/_documentation/en/messages/code-snippets/message-status.md
+++ b/_documentation/en/messages/code-snippets/message-status.md
@@ -22,4 +22,4 @@ application:
 
 ## Try it out
 
-The webhook is invoked on change in [inbound message](/messages/code-snippets/sms/send-sms) status and the message status is printed to the console.
+The webhook is invoked on change in the [sent message](/messages/code-snippets/sms/send-sms) status and the message status is printed to the console.

--- a/_documentation/en/messages/code-snippets/message-status.md
+++ b/_documentation/en/messages/code-snippets/message-status.md
@@ -22,4 +22,4 @@ application:
 
 ## Try it out
 
-The webhook is invoked on change in the [sent message](/messages/code-snippets/sms/send-sms) status and the message status is printed to the console.
+The webhook is invoked on a change in status for the [sent message](/messages/code-snippets/sms/send-sms). The message status is also printed to the console.

--- a/_documentation/en/messages/code-snippets/message-status.md
+++ b/_documentation/en/messages/code-snippets/message-status.md
@@ -24,4 +24,4 @@ application:
 
 The webhook is invoked on a change in status for an outbound message sent from Nexmo. The message status is also printed to the console.
 
-The format of the message status `POST` request can be found in the [Message Status](https://developer.nexmo.com/api/messages-olympus#message-status) section of the [API reference](https://developer.nexmo.com/api/messages-olympus#overview).
+The format of the message status `POST` request can be found in the [Message Status](/api/messages-olympus#message-status) section of the [API reference](/api/messages-olympus#overview).

--- a/_documentation/en/messages/code-snippets/message-status.md
+++ b/_documentation/en/messages/code-snippets/message-status.md
@@ -22,4 +22,4 @@ application:
 
 ## Try it out
 
-The webhook is invoked on changing message status and details printed to the console.
+The webhook is invoked on change in [inbound message](/messages/code-snippets/sms/send-sms) status and the message status is printed to the console.


### PR DESCRIPTION
## Description

Modify topics based on feedback.

For reference the feedback for message status topic was "The example should show the json format of the post request so it's possible to write the handler without having to implement a dummy version just to log the output to see this."

## Review

Pages to review (test links in 'Try it out' section):

* [Inbound Message](https://nexmo-developer-pr-2391.herokuapp.com/messages/code-snippets/inbound-message)
* [Message Status](https://nexmo-developer-pr-2391.herokuapp.com/messages/code-snippets/message-status)
