### PR TITLE
Add Conversion API Reference to TOC

### DIFF
--- a/_documentation/en/messaging/conversion-api/api-reference.md
+++ b/_documentation/en/messaging/conversion-api/api-reference.md
@@ -1,0 +1,8 @@
+---
+title: API Reference
+---
+
+# API Reference
+
+This page is never rendered, it is used as a placeholder to generate
+the necessary navigation item.

--- a/config/redirects.yml
+++ b/config/redirects.yml
@@ -40,6 +40,7 @@
 "/messaging/us-short-codes": "/messaging/us-short-codes/overview"
 "/messaging/us-short-codes/guides": "/messaging/us-short-codes/guides/campaign-subscription-management"
 "/messaging/conversion-api": "/messaging/conversion-api/overview"
+"/messaging/conversion-api/api-reference": "/api/conversion"
 "/messaging/sms/code-snippets": "/messaging/sms/code-snippets/send-an-sms"
 "/messaging/sms/code-snippets/receive-a-delivery-receipt": "/messaging/sms/guides/delivery-receipts"
 "/messaging/sms/guides": "/messaging/sms/overview#sms-api-features"


### PR DESCRIPTION
## Description

Adds API Reference to sidebar for Conversion. Adds stub file and redirect.

## Review

In [review app](https://nexmo-developer-pr-2397.herokuapp.com/documentation) open up sidebar and navigate down to Messaging and Conversion. API entry should now be present in sidebar. Click on this to be taken to `/api/conversion`.