### PR TITLE
Add US Short Code API to sidebar

### DIFF
--- a/_documentation/en/messaging/us-short-codes/alerts-sending-api.md
+++ b/_documentation/en/messaging/us-short-codes/alerts-sending-api.md
@@ -1,0 +1,8 @@
+---
+title: Alerts - Sending API Reference
+---
+
+# Alerts - Sending API Reference
+
+This page is never rendered, it is used as a placeholder to generate
+the necessary navigation item.

--- a/_documentation/en/messaging/us-short-codes/alerts-subscribing-api.md
+++ b/_documentation/en/messaging/us-short-codes/alerts-subscribing-api.md
@@ -1,0 +1,8 @@
+---
+title: Alerts - Subscribing API Reference
+---
+
+# Alerts - Subscribing API Reference
+
+This page is never rendered, it is used as a placeholder to generate
+the necessary navigation item.

--- a/_documentation/en/messaging/us-short-codes/two-factor-api.md
+++ b/_documentation/en/messaging/us-short-codes/two-factor-api.md
@@ -1,0 +1,9 @@
+---
+title: Two-factor Authentication API Reference
+navigation_weight: 1
+---
+
+# Two-factor Authentication API Reference
+
+This page is never rendered, it is used as a placeholder to generate
+the necessary navigation item.

--- a/config/redirects.yml
+++ b/config/redirects.yml
@@ -262,3 +262,6 @@
 "/client-sdk/in-app-voice/guides/start-and-receive-calls/javascript": "/client-sdk/in-app-voice/guides/make-call/javascript"
 "/client-sdk/tutorials/ios-in-app-messaging": "/client-sdk/tutorials/ios-in-app-messaging-chat"
 "/client-sdk/in-app-messaging/guides/simple-conversation": "/client-sdk/tutorials/in-app-messaging/introduction"
+"/messaging/us-short-codes/two-factor-api": "/api/sms/us-short-codes/2fa"
+"/messaging/us-short-codes/alerts-subscribing-api": "/api/sms/us-short-codes/alerts/subscription"
+"/messaging/us-short-codes/alerts-sending-api": "/api/sms/us-short-codes/alerts/sending"


### PR DESCRIPTION
## Description

Add US Short Code API References to sidebar.

## Review

Go to [review app](https://nexmo-developer-pr-2410.herokuapp.com/documentation)

Check Messaging / US Short Codes. Present in Sidebar are the following:

1. Two factor API Reference
2. Alerts subscription API Reference
3. Alerts sending API Reference
