### PR TITLE
Add NCCO and VAPI to glossary

### DIFF
--- a/_documentation/en/concepts/guides/glossary.md
+++ b/_documentation/en/concepts/guides/glossary.md
@@ -240,7 +240,7 @@ A [Delivery Receipt](#delivery-receipt).
 
 ## Nexmo Application
 
-An application object that you create in the [Nexmo Dashboard](#nexmo-dashboard), or using the [CLI](#cli), [client libraries](#client-libraries) or [REST APIs](https://developer.nexmo.com).
+An application object that you create in the [Nexmo Dashboard](#nexmo-dashboard), or using the [CLI](#cli), [Server SDKs](#server-sdks) or [REST APIs](https://developer.nexmo.com).
 
 ## Nexmo Dashboard
 

--- a/_documentation/en/concepts/guides/glossary.md
+++ b/_documentation/en/concepts/guides/glossary.md
@@ -224,6 +224,12 @@ Mobile Station International Subscriber Directory Number (MSISDN) is a number us
 
 Mobile Terminated. That is, sent by a customer to a phone number through the Platform. For example, requests to deliver an SMS are MT, they go to a phone number.
 
+## NCCO
+
+A Nexmo Call Control Object (NCCO) is a JSON array that you use to control the flow of a Voice API call. For your NCCO to execute correctly, the JSON objects must be valid.
+
+While developing and testing NCCOs, you can use the Voice Playground to try out NCCOs interactively. You can [read more about it in the Voice API Overview](/voice/voice-api/overview#voice-playground) or [go directly to the Voice Playground in the Dashboard](https://dashboard.nexmo.com/voice/playground).
+
 ## Network
 
 A Telecommunications Service Provider.
@@ -530,7 +536,7 @@ Voice includes:
 * SIP Trunking
 * Voice Enabled Numbers (LVNs)
 
-## Voice API
+## Voice API, VAPI
 
 This [Voice](#voice) product provides a simple and affordable personalized voice communication experience.
 


### PR DESCRIPTION
## Description

* Add NCCO and VAPI to glossary.
* Update reference to Client Libraries to Server SDK.

## Review

* [NCCO](https://nexmo-developer-pr-2413.herokuapp.com/concepts/guides/glossary#ncco)
* [VAPI](https://nexmo-developer-pr-2413.herokuapp.com/concepts/guides/glossary#voice-api-vapi)