### PR TITLE
Fixed the PHP JWT example to something that would work

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -325,3 +325,4 @@ DocStrap
 whitelisting
 unmuting
 earmuffing
+Keypair

--- a/_documentation/en/conversation/guides/jwt-acl.md
+++ b/_documentation/en/conversation/guides/jwt-acl.md
@@ -117,15 +117,17 @@ Nexmo.generateJwt(PRIVATE_KEY, {
 
 ### PHP
 
-The current version of the [Nexmo PHP](https://github.com/Nexmo/nexmo-php) library can also create a JWT including the appropriate claims.
+The current version of the [Nexmo PHP](https://github.com/Nexmo/nexmo-php) library can also create a JWT including the appropriate claims when using the Keypair authentication.
 
 ```php
-Nexmo::generateJwt([
-        'application_id': "aaaaaaaa-bbbb-cccc-dddd-0123456789ab",
-        'exp' => time() + 86400,
-        'sub' => "jamie",
-        'acl' => ["paths" => ["/*/sessions/**" => (object)[], "/*/users/**" => (object)[], "/*/conversations/**" => (object)[], "/*/devices/**" => (object)[], "/*/image/**" => (object)[], "/*/media/**" => (object)[], "/*/applications/**" => (object)[], "/*/push/**" => (object)[], "/*/knocking/**" => (object)[]]],
-    ])
+$keypair = new \Nexmo\Client\Credentials\Keypair(
+    file_get_contents('/path/to/private.key'),
+    'aaaaaaaa-bbbb-cccc-dddd-0123456789ab'
+);
+$client = new \Nexmo\Client($keypair);
+
+$token = $client->generateJwt();
+$tokenString = (string) $token;
 ```
 
 ### Other languages


### PR DESCRIPTION
## Description

The original PHP JWT code wasn't valid code, and would never have generated a JWT with our library. This shows a way to generate a JWT which should actually go back at least part way on the 1.x branch even.

## Deploy Notes

There are no additional deploy steps other than build and push.
