### PR TITLE
Fix links in dispatch tutorial

### DIFF
--- a/_tutorials/en/olympus/prereqs.md
+++ b/_tutorials/en/olympus/prereqs.md
@@ -1,5 +1,0 @@
----
-title: Check prerequisites
-description: You may already have many of these prerequisites in place if you have used the Nexmo APIs before. This list is provided for your convenience to ensure you have the necessary tools installed to complete this tutorial.
----
-

--- a/config/tutorials/en/sending-facebook-message-with-failover.yml
+++ b/config/tutorials/en/sending-facebook-message-with-failover.yml
@@ -34,4 +34,4 @@ conclusion:
     # What's next?
     You can do a lot more with the Dispatch API.
 
-    See [Dispatch API documentation](/en/dispatch/overview) and [a multi-user, multi-channel workflow Dispatch use case](/en/use-cases/dispatch-user-fallback).
+    See [Dispatch API documentation](/dispatch/overview) and [a multi-user, multi-channel workflow Dispatch use case](/use-cases/dispatch-user-fallback).


### PR DESCRIPTION
## Description

Fix links in tutorial 'What's Next?'.

## Review

* [Tutorial What's Next](https://developer.nexmo.com/dispatch/tutorials/sending-facebook-message-with-failover/conclusion)