### PR TITLE
Connect an inbound call - Fix code snippet config

### DIFF
--- a/_examples/voice/connect-an-inbound-call/python.yml
+++ b/_examples/voice/connect-an-inbound-call/python.yml
@@ -5,7 +5,7 @@ dependencies:
     - '''flask>=1.0'''
 code:
     source: .repos/nexmo/nexmo-python-code-snippets/voice/connect-an-inbound-call.py
-    from_line: 4
+    from_line: 6
     to_line: 21
 client:
     source: .repos/nexmo/nexmo-python-code-snippets/voice/connect-an-inbound-call.py


### PR DESCRIPTION
## Description

Fix Python code snippet config for Connect inbound call.

## Review

* [Page to review](https://nexmo-developer-pr-2473.herokuapp.com/voice/voice-api/code-snippets/connect-an-inbound-call/python) - just check that Flask app creation step is not duplicated.