### PR TITLE
Update fallback_answer_url behavior

### DIFF
--- a/_documentation/en/application/overview.md
+++ b/_documentation/en/application/overview.md
@@ -66,7 +66,7 @@ The webhook URLs you provide when creating an application depend on the applicat
 
 Capability | API used | Webhooks available
 --- | --- | ---
-`voice` | Voice | `answer_url`, `fallback_answer_url`, `event_url`
+`voice` | Voice | `answer_url`, `fallback_url`, `event_url`
 `messages` | Messages and Dispatch | `inbound_url`, `status_url`
 `rtc` | Client SDK | `event_url`
 `vbc` | VBC | None
@@ -78,7 +78,7 @@ The following table describes webhooks available per capability:
 Capability | Webhook | API | Example | Description
 --- | --- | --- | --- | --- |
 `voice` | `answer_url` | [Voice](/voice/voice-api/overview) | https://example.com/webhooks/answer | The URL that Nexmo make a request to when a call is placed/received. Must return an NCCO.
-`voice` | `fallback_answer_url` | [Voice](/voice/voice-api/overview) | https://example.com/webhooks/fallback | If the `fallback_answer_url` is set, Nexmo makes a request to it if the `answer_url` is offline or returns an HTTP error code or the `event_url` is offline or returns an error code and an event is expected to return an NCCO. The `fallback_answer_url` must return an NCCO. If your `fallback_answer_url` fails after two attempts for an initial NCCO, the call is ended. If your `fallback_answer_url` fails after two attempts for a call in progress, the call flow is continued.
+`voice` | `fallback_url` | [Voice](/voice/voice-api/overview) | https://example.com/webhooks/fallback | If the `fallback_url` is set, Nexmo makes a request to it if the `answer_url` is offline or returns an HTTP error code or the `event_url` is offline or returns an error code and an event is expected to return an NCCO. The `fallback_url` must return an NCCO. If your `fallback_url` fails after two attempts for an initial NCCO, the call is ended. If your `fallback_url` fails after two attempts for a call in progress, the call flow is continued.
 `voice` | `event_url` | [Voice](/voice/voice-api/overview) | https://example.com/webhooks/event | Nexmo will send call events (e.g. ringing, answered) to this URL.
 `messages` | `inbound_url` | [Messages](/messages/overview), [Dispatch](/dispatch/overview) | https://example.com/webhooks/inbound | Nexmo will forward inbound messages to this URL.
 `messages` | `status_url` | [Messages](/messages/overview), [Dispatch](/dispatch/overview) | https://example.com/webhooks/status | Nexmo will send message status updates (for example, `delivered`, `seen`) to this URL.

--- a/_documentation/en/application/overview.md
+++ b/_documentation/en/application/overview.md
@@ -66,7 +66,7 @@ The webhook URLs you provide when creating an application depend on the applicat
 
 Capability | API used | Webhooks available
 --- | --- | ---
-`voice` | Voice | `answer_url`, `fallback_url`, `event_url`
+`voice` | Voice | `answer_url`, `fallback_answer_url`, `event_url`
 `messages` | Messages and Dispatch | `inbound_url`, `status_url`
 `rtc` | Client SDK | `event_url`
 `vbc` | VBC | None
@@ -78,7 +78,7 @@ The following table describes webhooks available per capability:
 Capability | Webhook | API | Example | Description
 --- | --- | --- | --- | --- |
 `voice` | `answer_url` | [Voice](/voice/voice-api/overview) | https://example.com/webhooks/answer | The URL that Nexmo make a request to when a call is placed/received. Must return an NCCO.
-`voice` | `fallback_url` | [Voice](/voice/voice-api/overview) | https://example.com/webhooks/fallback | If the `fallback_url` is set, Nexmo makes a request to it if the `answer_url` is offline or returns an HTTP error code or the `event_url` is offline or returns an error code and an event is expected to return an NCCO. The `fallback_url` must return an NCCO. If your `fallback_url` fails after two attempts for an initial NCCO, the call is ended. If your `fallback_url` fails after two attempts for a call in progress, the call flow is continued.
+`voice` | `fallback_answer_url` | [Voice](/voice/voice-api/overview) | https://example.com/webhooks/fallback | If the `fallback_answer_url` is set, Nexmo makes a request to it if the `answer_url` is offline or returns an HTTP error code or the `event_url` is offline or returns an error code and an event is expected to return an NCCO. The `fallback_answer_url` must return an NCCO. If your `fallback_answer_url` fails after two attempts for an initial NCCO, the call is ended. If your `fallback_answer_url` fails after two attempts for a call in progress, the call flow is continued.
 `voice` | `event_url` | [Voice](/voice/voice-api/overview) | https://example.com/webhooks/event | Nexmo will send call events (e.g. ringing, answered) to this URL.
 `messages` | `inbound_url` | [Messages](/messages/overview), [Dispatch](/dispatch/overview) | https://example.com/webhooks/inbound | Nexmo will forward inbound messages to this URL.
 `messages` | `status_url` | [Messages](/messages/overview), [Dispatch](/dispatch/overview) | https://example.com/webhooks/status | Nexmo will send message status updates (for example, `delivered`, `seen`) to this URL.

--- a/_documentation/en/voice/voice-api/webhook-reference.md
+++ b/_documentation/en/voice/voice-api/webhook-reference.md
@@ -326,13 +326,13 @@ The fallback webhook is accessed when either the answer webhook or the event web
 
 If there was a connection closed or reset, timeout or an HTTP status code of `429`, `503` or `504` during the initial NCCO the `answer_url` is attempted twice, then:
 
-1. Go to `fallback_url`
+1. Go to `fallback_answer_url`
 2. Attempt to reach the fallback URL twice
 3. If no success, then the call is terminated
 
 If there was a connection closed or reset, timeout or an HTTP status code of `429`, `503` or `504` during a call in progress the `event_url` for events that are expected to return an NCCO (e.g. return for an `input` or `notify` action) is attempted twice, then:
 
-1. Go to `fallback_url`
+1. Go to `fallback_answer_url`
 2. Attempt to reach the fallback URL twice
 3. If no success, continue the call flow
 

--- a/_documentation/en/voice/voice-api/webhook-reference.md
+++ b/_documentation/en/voice/voice-api/webhook-reference.md
@@ -289,6 +289,8 @@ This webhook is sent by Nexmo when an NCCO with an action of "input" has finishe
 
 Field | Example | Description
  -- | -- | --
+`from` | `447700900000` | The number the call came from
+`to` | `447700900000` | The number the call was made to
 `dtmf` | `42` | The buttons pressed by the user
 `timed_out` | `true` | Whether the input action timed out: `true` if it did, `false` if not
 `uuid` | `aaaaaaaa-bbbb-cccc-dddd-0123456789ab` | The unique identifier for this call

--- a/_documentation/en/voice/voice-api/webhook-reference.md
+++ b/_documentation/en/voice/voice-api/webhook-reference.md
@@ -316,13 +316,13 @@ The fallback answer webhook is accessed when either the answer webhook or the ev
 
 If there was a connection closed or reset, timeout or an HTTP status code of `429`, `503` or `504` during the initial NCCO the `answer_url` is attempted twice, then:
 
-1. Go to `fallback_answer_url`
+1. Go to `fallback_url`
 2. Attempt to reach the fallback URL twice
 3. If no success, then the call is terminated
 
 If there was a connection closed or reset, timeout or an HTTP status code of `429`, `503` or `504` during a call in progress the `event_url` for events that are expected to return an NCCO (e.g. return for an `input` or `notify` action) is attempted twice, then:
 
-1. Go to `fallback_answer_url`
+1. Go to `fallback_url`
 2. Attempt to reach the fallback URL twice
 3. If no success, continue the call flow
 

--- a/_documentation/en/voice/voice-api/webhook-reference.md
+++ b/_documentation/en/voice/voice-api/webhook-reference.md
@@ -10,7 +10,7 @@ Nexmo uses webhooks alongside its Voice API to enable your application to intera
 
 * [Answer webhook](#answer-webhook) is sent when a call is answered. This is for both incoming and outgoing calls.
 * [Event webhook](#event-webhook) is sent for all the events that occur during a call. Your application can log, react to or ignore each event type.
-* [Fallback Answer URL](#fallback-answer-url) is used when either the Answer or Event webhook fails or returns an HTTP error status. 
+* [Fallback URL](#fallback-url) is used when either the Answer or Event webhook fails or returns an HTTP error status.
 * [Errors](#errors) are also delivered to the event webhook endpoint if they occur.
 
 For more general information, check out our [webhooks guide](/concepts/guides/webhooks).
@@ -310,9 +310,19 @@ Field | Example | Description
 
 [Back to event webhooks list](#event-webhook)
 
-## Fallback Answer URL
+## Fallback URL
 
-The fallback answer webhook is accessed when either the answer webhook or the event webhook, when the event is expected to respond with an NCCO, returns an HTTP error status or is unreachable. The data that is returned from the fallback answer URL is the same as would be received in the original answer URL or event URL.
+The fallback webhook is accessed when either the answer webhook or the event webhook, when the event is expected to respond with an NCCO, returns an HTTP error status or is unreachable. The data that is returned from the fallback URL is the same as would be received in the original answer URL or event URL, with the addition two new parameters, `reason` and `original_request`:
+
+```
+{
+  "reason": "Connection closed.",
+  "original_request": {
+    "url": "https://api.example.com/webhooks/event",
+    "type": "event"
+  }
+}
+```
 
 If there was a connection closed or reset, timeout or an HTTP status code of `429`, `503` or `504` during the initial NCCO the `answer_url` is attempted twice, then:
 

--- a/_documentation/en/voice/voice-api/webhook-reference.md
+++ b/_documentation/en/voice/voice-api/webhook-reference.md
@@ -312,7 +312,7 @@ Field | Example | Description
 
 ## Fallback URL
 
-The fallback webhook is accessed when either the answer webhook or the event webhook, when the event is expected to respond with an NCCO, returns an HTTP error status or is unreachable. The data that is returned from the fallback URL is the same as would be received in the original answer URL or event URL, with the addition two new parameters, `reason` and `original_request`:
+The fallback webhook is accessed when either the answer webhook or the event webhook, when the event is expected to respond with an NCCO, returns an HTTP error status or is unreachable. The data that is returned from the fallback URL is the same as would be received in the original answer URL or event URL, with the addition of two new parameters, `reason` and `original_request`:
 
 ```
 {

--- a/_examples/concepts/guides/webhooks-setup/voice.md
+++ b/_examples/concepts/guides/webhooks-setup/voice.md
@@ -7,7 +7,7 @@ For Voice API requests, webhooks can be set at an application level, when creati
 
 ### Application-level webhooks
 
-Nexmo numbers that are linked to Nexmo applications will use the `answer_url` to retrieve an NCCO, and the `event_url` to send call status information to you. The `fallback_url` can optionally be configured. This is used when `answer_url` is offline or returning an HTTP error code. It is also used when an event is expected to deliver an NCCO on `event_url`, but `event_url` is offline or returning an HTTP Status code.
+Nexmo numbers that are linked to Nexmo applications will use the `answer_url` to retrieve an NCCO, and the `event_url` to send call status information to you. The `fallback_answer_url` can optionally be configured. This is used when `answer_url` is offline or returning an HTTP error code. It is also used when an event is expected to deliver an NCCO on `event_url`, but `event_url` is offline or returning an HTTP Status code.
 
 You can set these using the [Application API](/api/application), in the [Nexmo Dashboard](https://dashboard.nexmo.com) or using the [Nexmo CLI](https://github.com/nexmo/nexmo-cli) tool.
 

--- a/_examples/concepts/guides/webhooks-setup/voice.md
+++ b/_examples/concepts/guides/webhooks-setup/voice.md
@@ -7,7 +7,7 @@ For Voice API requests, webhooks can be set at an application level, when creati
 
 ### Application-level webhooks
 
-Nexmo numbers that are linked to Nexmo applications will use the `answer_url` to retrieve an NCCO, and the `event_url` to send call status information to you. The `fallback_answer_url` can optionally be configured. This is used when `fallback_answer_url` is offline or returning an HTTP error code. It is also used when an event is expected to deliver an NCCO on `event_url`, but `event_url` is offline or returning an HTTP Status code.
+Nexmo numbers that are linked to Nexmo applications will use the `answer_url` to retrieve an NCCO, and the `event_url` to send call status information to you. The `fallback_url` can optionally be configured. This is used when `answer_url` is offline or returning an HTTP error code. It is also used when an event is expected to deliver an NCCO on `event_url`, but `event_url` is offline or returning an HTTP Status code.
 
 You can set these using the [Application API](/api/application), in the [Nexmo Dashboard](https://dashboard.nexmo.com) or using the [Nexmo CLI](https://github.com/nexmo/nexmo-cli) tool.
 


### PR DESCRIPTION
## Description

The `fallback_answer_url` has changed in behavior:

```
Name | Type | Description
-- | -- | --
reason | string | Error message, one of“Connection closed.”“Connection reset.”“Socket timeout.”“Invalid NCCO.”“Invalid response code.”
original_request | struct | Original request info.
original_request.url | string | Originally requested URL.
original_request.type | enum | One of  { answer, event }
```