### PR TITLE
Add redirects for old Stitch guides

### DIFF
--- a/config/stitch-redirects.yml
+++ b/config/stitch-redirects.yml
@@ -35,8 +35,17 @@
 "/stitch/in-app-video/guides/2-enable-screenshare": "/stitch/in-app-video/guides/1-enable-video/javascript"
 "/stitch/in-app-voice/ncco-guide": "/voice/voice-api/ncco-reference"
 "/stitch/in-app-voice/inbound-pstn": "/client-sdk/in-app-voice/guides/receive-call"
-"/stitch/in-app-messaging/guides/simple-conversation": /client-sdk/tutorials/in-app-messaging/introduction
+"/stitch/in-app-messaging/guides/simple-conversation": "/client-sdk/tutorials/in-app-messaging/introduction"
 "/stitch/in-app-messaging/guides/inviting-members": "/client-sdk/in-app-messaging/guides/inviting-members"
+
+"/stitch/in-app-messaging/guides/simple-conversation/javascript": "/client-sdk/tutorials/in-app-messaging/introduction"
+"/stitch/in-app-messaging/guides/inviting-members/javascript": "/client-sdk/in-app-messaging/guides/inviting-members"
+"/stitch/in-app-messaging/guides/utilizing-events/javascript": "/client-sdk/in-app-messaging/guides/utilizing-events"
+"/stitch/in-app-voice/guides/enable-audio/javascript": "/client-sdk/in-app-voice/guides/enable-audio"
+"/stitch/in-app-voice/guides/calling-users/javascript": "/client-sdk/in-app-voice/guides/make-call"
+"/stitch/in-app-voice/guides/outbound-pstn/javascript": "/client-sdk/in-app-voice/guides/make-call"
+"/stitch/in-app-video/guides/enable-video/javascript": "https://tokbox.com/developer/guides/basics/"
+"/stitch/in-app-video/guides/enable-screenshare/javascript": "https://tokbox.com/developer/guides/basics/"
 
 # Client SDK 
 


### PR DESCRIPTION
## Description

Problem is [Quickstart code repo]( https://github.com/Nexmo/stitch-js-quickstart) links to the Quickstart guides that no longer exist.

From Slack:
----
also, looks like every link listed here https://github.com/Nexmo/stitch-js-quickstart#run-through-the-quick-start-guides (edited) 
Nexmo/stitch-js-quickstart
A repository containing everything you need when getting started with the Nexmo Stitch API and the JavaScript SDKs
<https://github.com/Nexmo/stitch-js-quickstart|Nexmo/stitch-js-quickstart>Nexmo/stitch-js-quickstart | Mar 28th, 2017 | Added by GitHub
08:22
is broken, we need to add some redirects, @tony.bedford can you take a look ^^
* https://developer.nexmo.com/stitch/in-app-messaging/guides/simple-conversation/javascript
* https://developer.nexmo.com/stitch/in-app-messaging/guides/inviting-members/javascript
* https://developer.nexmo.com/stitch/in-app-messaging/guides/utilizing-events/javascript
* https://developer.nexmo.com/stitch/in-app-voice/guides/enable-audio/javascript
* https://developer.nexmo.com/stitch/in-app-voice/guides/calling-users/javascript
* https://developer.nexmo.com/stitch/in-app-voice/guides/outbound-pstn/javascript
* https://developer.nexmo.com/stitch/in-app-video/guides/enable-video/javascript
* https://developer.nexmo.com/stitch/in-app-video/guides/enable-screenshare/javascript

I guess we can update that repo’s README as well, but those links could be out in the wild too

----

## Review

**In the [review app](https://nexmo-developer-pr-2501.herokuapp.com/)**, test the following path parts:

* /stitch/in-app-messaging/guides/simple-conversation/javascript
* /stitch/in-app-messaging/guides/inviting-members/javascript
* /stitch/in-app-messaging/guides/utilizing-events/javascript
* /stitch/in-app-voice/guides/enable-audio/javascript
* /stitch/in-app-voice/guides/calling-users/javascript
* /stitch/in-app-voice/guides/outbound-pstn/javascript
* /stitch/in-app-video/guides/enable-video/javascript
* /stitch/in-app-video/guides/enable-screenshare/javascript
