### PR TITLE
Refer to Knowledge Base for list of IPs to whitelist

### DIFF
--- a/_documentation/en/voice/sip/overview.md
+++ b/_documentation/en/voice/sip/overview.md
@@ -53,7 +53,7 @@ The following codecs are supported:
 
 **Media traffic**
 
-Visit [https://api.nexmo.com/ips-v4](https://api.nexmo.com/ips-v4) to obtain a list of the IP ranges to open traffic for on all ports.
+Visit [the Nexmo Knowledge Base](https://help.nexmo.com/hc/en-us/articles/115004859247-Which-IP-addresses-should-I-whitelist-in-order-to-receive-voice-traffic-from-Nexmo-) to obtain a list of the IP ranges to open traffic for on all ports.
 
 **DTMF**
 
@@ -93,7 +93,7 @@ To configure for SIP forwarding:
   This field supports comma-separated entries for failover capabilities. For example: `sip:1234@example.com,sip:1234@example.net,sip:1234@example.org`. If you set more than one endpoint in *Forward to SIP* the call is initially forwarded to the first endpoint in the list. If this fails, the call is forwarded to the second endpoint in the list, and so on.
   Calls failover for the whole 5xx class of HTTP errors. The timeout is 486.
 5. You can specify a timeout for non responding SIP endpoints, by appending a `;timeout=xxxxx` to the related URI. For example: `sip:1234@example.com;timeout=2000,sip:1234@example.net` will attempt to forward to the first URI, and in case of no response within 2 seconds it will try the second one. Timeouts are expressed in milliseconds and can range from 2000 to 20000. This is useful to quickly fail over when an endpoint is temporarily unavailable. The default value is 5000 ms.
-6. Ensure that the traffic generated from Nexmo IP addresses can pass your firewall. Visit [https://api.nexmo.com/ips-v4](https://api.nexmo.com/ips-v4) to obtain the current list of IP addresses.
+6. Ensure that the traffic generated from Nexmo IP addresses can pass your firewall. Visit [the Nexmo Knowledge Base](https://help.nexmo.com/hc/en-us/articles/115004859247-Which-IP-addresses-should-I-whitelist-in-order-to-receive-voice-traffic-from-Nexmo-) to obtain the current list of IP addresses.
 
 > **Note**: Nexmo supports TLS on inbound connections. To enable this, enter a valid URI in the format sip:user@(IP|domain);transport=tls. For example, *sip:1234@example.com;transport=tls*. By default, traffic is sent to port 5061. To use a different port, add it at the end of your domain or IP address: *sip:1234@example.com:5062;transport=tls*.
 

--- a/_documentation/en/voice/sip/overview.md
+++ b/_documentation/en/voice/sip/overview.md
@@ -53,13 +53,7 @@ The following codecs are supported:
 
 **Media traffic**
 
-Open traffic for all ports for the following IP ranges:
-
-  * 169.50.120.160/28
-  * 169.54.106.32/27
-  * 161.202.24.16/28
-  * 169.48.97.80/28
-  * 169.47.144.176/28
+Visit [https://api.nexmo.com/ips-v4](https://api.nexmo.com/ips-v4) to obtain a list of the IP ranges to open traffic for on all ports.
 
 **DTMF**
 
@@ -99,14 +93,7 @@ To configure for SIP forwarding:
   This field supports comma-separated entries for failover capabilities. For example: `sip:1234@example.com,sip:1234@example.net,sip:1234@example.org`. If you set more than one endpoint in *Forward to SIP* the call is initially forwarded to the first endpoint in the list. If this fails, the call is forwarded to the second endpoint in the list, and so on.
   Calls failover for the whole 5xx class of HTTP errors. The timeout is 486.
 5. You can specify a timeout for non responding SIP endpoints, by appending a `;timeout=xxxxx` to the related URI. For example: `sip:1234@example.com;timeout=2000,sip:1234@example.net` will attempt to forward to the first URI, and in case of no response within 2 seconds it will try the second one. Timeouts are expressed in milliseconds and can range from 2000 to 20000. This is useful to quickly fail over when an endpoint is temporarily unavailable. The default value is 5000 ms.
-6. Ensure that the traffic generated from the following IP addresses can pass your firewall:
-
-  * 5.10.112.121
-  * 5.10.112.122
-  * 119.81.44.6
-  * 119.81.44.7
-  * 169.60.141.29
-  * 169.60.141.30
+6. Ensure that the traffic generated from Nexmo IP addresses can pass your firewall. Visit [https://api.nexmo.com/ips-v4](https://api.nexmo.com/ips-v4) to obtain the current list of IP addresses.
 
 > **Note**: Nexmo supports TLS on inbound connections. To enable this, enter a valid URI in the format sip:user@(IP|domain);transport=tls. For example, *sip:1234@example.com;transport=tls*. By default, traffic is sent to port 5061. To use a different port, add it at the end of your domain or IP address: *sip:1234@example.com:5062;transport=tls*.
 


### PR DESCRIPTION
## Description

The Knowledge base article (https://help.nexmo.com/hc/en-us/articles/115004859247-Which-IP-addresses-should-I-whitelist-in-order-to-receive-voice-traffic-from-Nexmo-) has been updated to contain the full list of IP addresses to be whitelisted, this is the source of truth, and NDP should refer to it.
