### PR TITLE
Updated fallback note with error info

### DIFF
--- a/_documentation/en/messages/concepts/whatsapp.md
+++ b/_documentation/en/messages/concepts/whatsapp.md
@@ -6,7 +6,7 @@ description: WhatsApp messaging solution for businesses.
 
 # Understanding WhatsApp messaging
 
-> **IMPORTANT:** Please note WhatsApp will deprecate the "fallback" locale method when sending template messages on January 1st 2020. Please ensure that you are using the "deterministic" option in your requests. 
+> **IMPORTANT:** Please note WhatsApp will deprecate the "fallback" locale method when sending template messages on January 1st 2020. Please ensure that you are using the "deterministic" option in your requests. Starting April 8, 2020, messages will fail with a 1020 error in your callback if you are not using the deterministic policy.
 
 WhatsApp Business Solution messages can only be sent by businesses that have been approved by WhatsApp. This business profile will also have a green verified label to indicate that it is a legitimate business.
 
@@ -99,7 +99,7 @@ curl -X POST \
 
 ## WhatsApp deterministic language policy
 
-> **NOTE:** From January 2020 the *deterministic* language policy will be the default and the *fallback* language policy will be deprecated. Starting April 8, 2020, messages will fail with a 1020 error in your callback if you are not using the deterministic policy.
+> **NOTE:** WhatsApp will deprecate the "fallback" locale method when sending template messages on January 1st 2020. Please ensure that you are using the "deterministic" option in your requests. Starting April 8, 2020, messages will fail with a 1020 error in your callback if you are not using the deterministic policy.
 
 When a message template is sent with the deterministic language policy, the receiving device will query its cache for a *language pack* for the language and locale specified in the message. If not available in the cache, the device will query the server for the required language pack. With the deterministic language policy the target device language and locale settings are ignored. If the language pack specified for the message is not available an error will be logged.
 

--- a/_documentation/en/messages/concepts/whatsapp.md
+++ b/_documentation/en/messages/concepts/whatsapp.md
@@ -6,7 +6,7 @@ description: WhatsApp messaging solution for businesses.
 
 # Understanding WhatsApp messaging
 
-> **IMPORTANT:** Please note WhatsApp will deprecate the "fallback" locale method when sending template messages on January 1st 2020. Please ensure that you are using the "deterministic" option in your requests. Starting April 8, 2020, messages will fail with a 1020 error in your callback if you are not using the deterministic policy.
+> **IMPORTANT:** Please note WhatsApp will deprecate the "fallback" locale method when sending template messages on January 1st 2020. Please ensure that you are using the "deterministic" option in your requests. Starting April 8, 2020, messages will fail with a 1020 error in your message status webhook if you are not using the deterministic policy.
 
 WhatsApp Business Solution messages can only be sent by businesses that have been approved by WhatsApp. This business profile will also have a green verified label to indicate that it is a legitimate business.
 
@@ -99,7 +99,7 @@ curl -X POST \
 
 ## WhatsApp deterministic language policy
 
-> **NOTE:** WhatsApp will deprecate the "fallback" locale method when sending template messages on January 1st 2020. Please ensure that you are using the "deterministic" option in your requests. Starting April 8, 2020, messages will fail with a 1020 error in your callback if you are not using the deterministic policy.
+> **NOTE:** WhatsApp will deprecate the "fallback" locale method when sending template messages on January 1st 2020. Please ensure that you are using the "deterministic" option in your requests. Starting April 8, 2020, messages will fail with a 1020 error in your message status webhook if you are not using the deterministic policy.
 
 When a message template is sent with the deterministic language policy, the receiving device will query its cache for a *language pack* for the language and locale specified in the message. If not available in the cache, the device will query the server for the required language pack. With the deterministic language policy the target device language and locale settings are ignored. If the language pack specified for the message is not available an error will be logged.
 

--- a/_documentation/en/messages/concepts/whatsapp.md
+++ b/_documentation/en/messages/concepts/whatsapp.md
@@ -99,7 +99,7 @@ curl -X POST \
 
 ## WhatsApp deterministic language policy
 
-> **NOTE:** From January 2020 the *deterministic* language policy will be the default and the *fallback* language policy will be deprecated.
+> **NOTE:** From January 2020 the *deterministic* language policy will be the default and the *fallback* language policy will be deprecated. Starting April 8, 2020, messages will fail with a 1020 error in your callback if you are not using the deterministic policy.
 
 When a message template is sent with the deterministic language policy, the receiving device will query its cache for a *language pack* for the language and locale specified in the message. If not available in the cache, the device will query the server for the required language pack. With the deterministic language policy the target device language and locale settings are ignored. If the language pack specified for the message is not available an error will be logged.
 


### PR DESCRIPTION
## Description

Added to note in Whatsapp section with error info that will be returned if users have not switched to deterministic policy by April 8, 2020.

Note: To view the updated content, scroll down to note in the **Whatsapp deterministic language policy** section.

Please describe what the changes are made in this pull request and why the change was necessary.

## Review

[Page to review](https://nexmo-developer-pr-2528.herokuapp.com/messages/concepts/whatsapp)
