### PR TITLE
[DEVX-2473] Fix issue when a page has multiple code snippets tabs.

### DIFF
--- a/app/webpacker/javascript/volta/volta.js
+++ b/app/webpacker/javascript/volta/volta.js
@@ -1370,7 +1370,6 @@ Volta.tab = function () {
 
 			this._activeLink.setAttribute('tabindex', '0');
 			this._activeLink.setAttribute('aria-selected', 'true');
-			this._activeLink.focus();
 			if (this._activePanel) {
 				this._activePanel.removeAttribute('hidden');
 			}


### PR DESCRIPTION

## Description

It's an upstream issue with volta that was previously fixed, that we lost
with the upgrade. It causes pages with multiple code snippets tabs to be scrolled.
