### PR TITLE
Add unavailable-legal to API Errors

### DIFF
--- a/app/views/api_errors/_error_example.html.erb
+++ b/app/views/api_errors/_error_example.html.erb
@@ -1,4 +1,4 @@
-<pre class="highlight plaintext"><code>HTTP/1.1 403 Forbidden
+<pre class="Vlt-prism language-bash"><code>HTTP/1.1 403 Forbidden
 Content-Type: application/problem+json
 Content-Language: en
 {

--- a/config/api-errors.yml
+++ b/config/api-errors.yml
@@ -91,14 +91,26 @@ generic_errors:
 
   accept-header:
     description: Invalid Accept header provided
-    resolution: Most Nexmo APIs only send back application/json. Check the API documentation for the API that you're working with for a complete list of supported data types
+    resolution: Most Vonage APIs only send back application/json. Check the API documentation for the API that you're working with for a complete list of supported data types
     link:
       text: API documentation
       url: /api
 
   content-type-header:
     description: Invalid Content-Type header provided
-    resolution: Most Nexmo APIs only accept application/json. Check the API documentation for the API that you're working with for a complete list of supported data types
+    resolution: Most Vonage APIs only accept application/json. Check the API documentation for the API that you're working with for a complete list of supported data types
     link:
       text: API documentation
       url: /api
+
+  unavailable-legal:
+    description: Unavailable For Legal Reasons
+    resolution: |
+        Vonage APIs are unavailable in the following areas due to international sanctions
+
+        * Sudan
+        * Syria
+        * Crimea
+        * North Korea
+        * Iran
+        * Cuba


### PR DESCRIPTION
## Description

Add URL that will be returned when API requests are blocked for legal reasons

## Deploy Notes

N/A
