### PR TITLE
Use new version of nexmo-markdown-renderer.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -129,7 +129,7 @@ gem 'lograge'
 gem 'countries'
 gem 'country_select', '~> 4.0'
 
-gem 'nexmo_markdown_renderer', git: 'https://github.com/Nexmo/nexmo-markdown-renderer', branch: 'fix-voice-snippets'
+gem 'nexmo_markdown_renderer', '~> 0.2'
 
 gem 'nexmo-oas-renderer', '~> 0.9', require: false
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,18 +1,4 @@
 GIT
-  remote: https://github.com/Nexmo/nexmo-markdown-renderer
-  revision: 50976c4fd7b5dc7312c56f93d31de316bbe9804a
-  branch: fix-voice-snippets
-  specs:
-    nexmo_markdown_renderer (0.2.0)
-      activemodel (~> 6.0)
-      banzai (~> 0.1.2)
-      i18n (~> 1.7)
-      nokogiri (~> 1.10)
-      octicons_helper (~> 8.2)
-      redcarpet (~> 3.4)
-      rouge (~> 2.0.7)
-
-GIT
   remote: https://github.com/oscardelben/rawler.git
   revision: f2909b135fce7d35167f98026ac481926c94423e
   specs:
@@ -317,6 +303,14 @@ GEM
       sass (~> 3.1)
       shotgun (~> 0.9)
       sinatra (~> 2.0)
+    nexmo_markdown_renderer (0.2.1)
+      activemodel (~> 6.0)
+      banzai (~> 0.1.2)
+      i18n (~> 1.7)
+      nokogiri (~> 1.10)
+      octicons_helper (~> 8.2)
+      redcarpet (~> 3.4)
+      rouge (~> 2.0.7)
     nio4r (2.5.2)
     nokogiri (1.10.9)
       mini_portile2 (~> 2.4.0)
@@ -584,7 +578,7 @@ DEPENDENCIES
   neatjson
   newrelic_rpm
   nexmo-oas-renderer (~> 0.9)
-  nexmo_markdown_renderer!
+  nexmo_markdown_renderer (~> 0.2)
   nokogiri (~> 1.10.9)
   octokit
   pg (~> 1.2)


### PR DESCRIPTION
## Description

The branch that was previously being used was merged and version `0.2.1` was released. This just  points the gem to that version.