### PR TITLE
Bump octokit

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -330,7 +330,7 @@ GEM
     octicons_helper (8.5.0)
       octicons (= 8.5.0)
       rails
-    octokit (4.17.0)
+    octokit (4.18.0)
       faraday (>= 0.9)
       sawyer (~> 0.8.0, >= 0.5.3)
     oj (3.10.2)


### PR DESCRIPTION
## Description

The previous version was removed from rubygems causing our deploys to fail, See https://github.com/octokit/octokit.rb/releases/tag/v4.17.0
