### PR TITLE
Fix spelling mistake

### DIFF
--- a/app/views/api/index.html.erb
+++ b/app/views/api/index.html.erb
@@ -19,7 +19,7 @@
 
           <a href="/api/dispatch" class="Nxd-card__link">
             <h5>Dispatch API <span class="Vlt-badge Vlt-badge--green Vlt-badge--small Vlt-badge--transparent">Beta</span></h5>
-            <p>Use the Dipatch API for a multichannel messaging solution with failover.</p>
+            <p>Use the Dispatch API for a multichannel messaging solution with failover.</p>
           </a>
 
           <a href="/api/sms" class="Nxd-card__link">


### PR DESCRIPTION
## Description

Just fixes a spelling mistake. Dipatch -> Dispatch. A search 'dipatch' produced no other results. 

## Review

* [page to review](https://nexmo-developer-pr-2596.herokuapp.com/api)
