### PR TITLE
Clarify that template must be in your namespace

### DIFF
--- a/_documentation/en/messages/code-snippets/whatsapp/send-button-link.md
+++ b/_documentation/en/messages/code-snippets/whatsapp/send-button-link.md
@@ -17,7 +17,7 @@ Key | Description
 -- | --
 `WHATSAPP_NUMBER` | The WhatsApp number that has been allocated to you by Nexmo.
 `TO_NUMBER` | The phone number you are sending the message to.
-`WHATSAPP_TEMPLATE_NAMESPACE` | The namespace ID found in your WhatsApp Business Account.
+`WHATSAPP_TEMPLATE_NAMESPACE` | The namespace ID found in your WhatsApp Business Account. Only templates created in your own namespace will work. Using an template with a namespace outside of your own results in an error code 1022 being returned.
 `WHATSAPP_TEMPLATE_NAME` | The name of the template created in your WhatsApp Business Account.
 `HEADER_IMAGE_URL` | The URL of the image to display in the template message header.
 

--- a/_documentation/en/messages/code-snippets/whatsapp/send-button-quick-reply.md
+++ b/_documentation/en/messages/code-snippets/whatsapp/send-button-quick-reply.md
@@ -17,7 +17,7 @@ Key | Description
 -- | --
 `WHATSAPP_NUMBER` | The WhatsApp number that has been allocated to you by Nexmo.
 `TO_NUMBER` | The phone number you are sending the message to.
-`WHATSAPP_TEMPLATE_NAMESPACE` | The namespace ID found in your WhatsApp Business Account.
+`WHATSAPP_TEMPLATE_NAMESPACE` | The namespace ID found in your WhatsApp Business Account. Only templates created in your own namespace will work. Using an template with a namespace outside of your own results in an error code 1022 being returned.
 `WHATSAPP_TEMPLATE_NAME` | The name of the template created in your WhatsApp Business Account.
 
 > **NOTE:** Don't use a leading `+` or `00` when entering a phone number, start with the country code, for example, 447700900000.

--- a/_documentation/en/messages/code-snippets/whatsapp/send-media-mtm.md
+++ b/_documentation/en/messages/code-snippets/whatsapp/send-media-mtm.md
@@ -26,7 +26,7 @@ Key | Description
 -- | --
 `WHATSAPP_NUMBER` | The WhatsApp number that has been allocated to you by Nexmo.
 `TO_NUMBER` | The phone number you are sending the message to.
-`WHATSAPP_TEMPLATE_NAMESPACE` | The namespace ID found in your WhatsApp Business Account.
+`WHATSAPP_TEMPLATE_NAMESPACE` | The namespace ID found in your WhatsApp Business Account. Only templates created in your own namespace will work. Using an template with a namespace outside of your own results in an error code 1022 being returned.
 `WHATSAPP_TEMPLATE_NAME` | The name of the template created in your WhatsApp Business Account.
 
 > **NOTE:** Don't use a leading `+` or `00` when entering a phone number, start with the country code, for example, 447700900000.

--- a/_documentation/en/messages/code-snippets/whatsapp/send-mtm.md
+++ b/_documentation/en/messages/code-snippets/whatsapp/send-mtm.md
@@ -18,7 +18,7 @@ Key | Description
 -- | --
 `WHATSAPP_NUMBER` | The WhatsApp number that has been allocated to you by Nexmo.
 `TO_NUMBER` | The phone number you are sending the message to.
-`WHATSAPP_TEMPLATE_NAMESPACE` | The namespace ID found in your WhatsApp Business Account.
+`WHATSAPP_TEMPLATE_NAMESPACE` | The namespace ID found in your WhatsApp Business Account. Only templates created in your own namespace will work. Using an template with a namespace outside of your own results in an error code 1022 being returned.
 `WHATSAPP_TEMPLATE_NAME` | The name of the template created in your WhatsApp Business Account.
 
 > **NOTE:** Don't use a leading `+` or `00` when entering a phone number, start with the country code, for example, 447700900000.

--- a/_documentation/en/messages/concepts/whatsapp.md
+++ b/_documentation/en/messages/concepts/whatsapp.md
@@ -6,8 +6,6 @@ description: WhatsApp messaging solution for businesses.
 
 # Understanding WhatsApp messaging
 
-> **IMPORTANT:** Please note WhatsApp will deprecate the "fallback" locale method when sending template messages on January 1st 2020. Please ensure that you are using the "deterministic" option in your requests. Starting April 8, 2020, messages will fail with a 1020 error in your message status webhook if you are not using the deterministic policy.
-
 WhatsApp Business Solution messages can only be sent by businesses that have been approved by WhatsApp. This business profile will also have a green verified label to indicate that it is a legitimate business.
 
 The advantage of WhatsApp is that the identifier of users on the platform is their mobile phone number.
@@ -28,7 +26,7 @@ Message Type | Description
 ---|---
 Text Message | A plain text message. This is the default message type.
 Media Message | A media message. Types are: image, audio, document and video.
-Message Template | Message Templates are created in the WhatsApp Manager. Outside of the Customer Care Window messages sent to a customer must be a Message Template type.
+Message Template | Message Templates are created in the WhatsApp Manager. Outside of the Customer Care Window messages sent to a customer must be a Message Template type. Only templates created in your own namespace will work. Using an template with a namespace outside of your own results in an error code 1022 being returned.
 Media Message Templates | Media message templates expand the content you can send to recipients beyond the standard message template type to include media, headers, and footers using a `components` object.
 Contacts Message | Send a contact list as a message.
 Location Message | Send a location as a message.
@@ -43,7 +41,7 @@ WhatsApp has a core concept of Messages Templates (MTM). These were previously k
 
 The MTM allows a business to send just the template identifier along with the appropriate parameters instead of the full message content.
 
-> **NOTE:** New templates need to be approved by WhatsApp. Please contact your Nexmo Account Manager to submit the templates. Over time Nexmo will also add generic templates that can be used by all businesses.
+> **NOTE:** New templates need to be approved by WhatsApp. Please contact your Nexmo Account Manager to submit the templates. Only templates created in your own namespace are valid. Using an template with a namespace outside of your own results in an error code 1022 being returned.
 
 MTMs are designed to reduce the likelihood of spam to users on WhatsApp.
 


### PR DESCRIPTION
## Description

* I've removed the note at the top of the WhatsApp topic because that was mostly for the 1st Jan, and we have the same note further down in the relevant section.
* I've added notes to be clear that your WhatsApp template needs to be one in your own namespace - you can't use a template created in someone else's namespace. 

## Review

* [WhatsApp concept](https://nexmo-developer-pr-2600.herokuapp.com/messages/concepts/whatsapp)

See also code snippets that use templates.