### PR TITLE
Fixed some copy that was still using Nexmo name

### DIFF
--- a/_documentation/en/client-sdk/troubleshooting.md
+++ b/_documentation/en/client-sdk/troubleshooting.md
@@ -17,8 +17,8 @@ Since you can create multiple Nexmo applications, the commands you run refer to 
 cat .nexmo-app
 ```
 
-* If you need to change the setup application, run: 
-    
+* If you need to change the setup application, run:
+
 ``` sh
 nexmo app:setup YOU_APPLICATION_ID YOUR_PRIVATE_KEY_FILE
 ```
@@ -32,7 +32,7 @@ nexmo app:setup abababa-ababa-123123-123123-abababa private.key
 ### No response to commands
 
 It you run a command and don't get a response:
-    
+
 * Try making sure that all the JSON objects in you command are closed objects, and not missing any `}` or `'` for example.
 
 ## JWTs
@@ -50,12 +50,12 @@ It you run a command and don't get a response:
 * Make sure the JWT hasn't expired:
 
     * You can find the expiration date on `"exp"`, in Unix time, which is seconds since Jan 01 1970(UTC).
-    
+
     * You can [convert it to human time](https://www.epochconverter.com/).
-    
+
     * Make sure the expiration time is the future, meaning the JWT hasn't expired yet.
 
-### Connection error or Connection Timeout 
+### Connection error or Connection Timeout
 
 Getting Connection error or Connection Timeout while trying to login to the SDK:
 
@@ -66,13 +66,13 @@ Getting Connection error or Connection Timeout while trying to login to the SDK:
 ### Errors while generating to JWT
 
 * Make sure the private key file exists. It is generated on the machine you created the application on.
-    
+
 * In our docs, while using the CLI, we suggest using the path `./private.key`.
-    
+
 * Make sure your private key exists on the machine you are generating the JWT with, and that the path is correct.
-    
+
 * If you need an new private key:
-    
+
     * You can obtain one from the [Dashboard](https://dashboard.nexmo.com/voice/your-applications). On the left hand side menu select Voice → Your Applications → select the application → Edit. On the bottom click on `Generate public / private key pair`. Remember to click `Save changes`.
 
     * Save the file on you machine, and update the path to it when generating the JWT.
@@ -87,4 +87,4 @@ Getting Connection error or Connection Timeout while trying to login to the SDK:
 
 # Have more Questions?
 
-Should you have any further questions, issues or feedback, please contact us on `support@nexmo.com` or at [Nexmo community Slack](https://developer.nexmo.com/community/slack).
+Should you have any further questions, issues or feedback, please contact us on `support@nexmo.com` or at [Vonage Developer Community Slack](https://developer.nexmo.com/community/slack).

--- a/app/views/slack/join.html.erb
+++ b/app/views/slack/join.html.erb
@@ -1,6 +1,6 @@
 <center>
   <%= image_tag 'slack.svg', id: 'join-slack-logo' %>
-  <h1>Join the Nexmo Community Slack</h1>
+  <h1>Join the Vonage Developer Community Slack</h1>
 
   <% unless @success %>
     <%= form_tag community_slack_path do %>
@@ -21,5 +21,5 @@
   <hr class="hr--tall">
 
   <h2>Already a member?</h2>
-  <%= link_to "Go to Nexmo Community on Slack", "https://#{ENV['SLACK_SUBDOMAIN']}.slack.com", class: "Vlt-btn Vlt-btn--secondary" %>
+  <%= link_to "Go to Vonage Developer Community on Slack", "https://#{ENV['SLACK_SUBDOMAIN']}.slack.com", class: "Vlt-btn Vlt-btn--secondary" %>
 </center>

--- a/app/views/static/_slack.html.erb
+++ b/app/views/static/_slack.html.erb
@@ -1,2 +1,2 @@
 
-  <h2 class="Vlt-title--nomargin Vlt-center"><%= image_tag 'slack.svg', id: 'community-slack-image' %> Join the <%= link_to "Nexmo Community Slack", community_slack_path, { :class=>"Vlt-text-btn" } %></h2>
+  <h2 class="Vlt-title--nomargin Vlt-center"><%= image_tag 'slack.svg', id: 'community-slack-image' %> Join the <%= link_to "Vonage Developer Community Slack", community_slack_path, { :class=>"Vlt-text-btn" } %></h2>

--- a/app/views/static/community.html.erb
+++ b/app/views/static/community.html.erb
@@ -26,7 +26,7 @@
 <hr>
 
 <% if @sessions.any? %>
-  
+
   <div class="Vlt-card">
     <div class="Vlt-grid">
       <% @sessions.each do |session| %>
@@ -47,6 +47,6 @@
 <hr>
 
 <center class="spacious">
-  <h2><%= image_tag 'slack.svg', width: 40, id: 'community-slack-image' %> Join the <%= link_to "Nexmo Community Slack", community_slack_path, { :class=>"Vlt-text-btn" } %></h2>
+  <h2><%= image_tag 'slack.svg', width: 40, id: 'community-slack-image' %> Join the <%= link_to "Vonage Developer Community Slack", community_slack_path, { :class=>"Vlt-text-btn" } %></h2>
 </center>
 </div>

--- a/spec/smoke_spec.rb
+++ b/spec/smoke_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe 'Smoke Tests', type: :request do
 
   it '/community/slack contains the expected text' do
     get '/community/slack'
-    expect(response.body).to include('Join the Nexmo Community Slack')
+    expect(response.body).to include('Join the Vonage Developer Community Slack')
   end
 
   it '/contribute/overview contains the expected text' do


### PR DESCRIPTION
## Description

On the Join Community Slack page, was still reading as Nexmo rather than Vonage. Also noticed in the troubleshooting.md there was still reference to Nexmo. 

Please describe what the changes are made in this pull request and why the change was necessary.

## Deploy Notes

Notes regarding deployment the contained body of work. These should note any db migrations, etc.
