### PR TITLE
Switch to ruby/setup-ruby

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
       run: |
         yarn install --pure-lockfile
     - name: Set up Ruby 2.5.7
-      uses: actions/setup-ruby@v1
+      uses: ruby/setup-ruby@v1
       with:
         ruby-version: 2.5.7
     - name: Ruby gem cache


### PR DESCRIPTION
## Description

`actions/setup-ruby` deletes old minor versions of Ruby as new versions are released. This breaks the build with no warning. This switches to `ruby/setup-ruby` which is slightly slower, but should allow us to use minor versions without breakage

## Deploy Notes

N/A