### PR TITLE
[DEVX-2685] Group bugnsag exceptions into `Missing Document` and `404…

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -14,12 +14,12 @@ class ApplicationController < ActionController::Base
   before_action :set_feedback_author
   before_action :set_locale
 
-  def not_found
+  def not_found(exception = nil)
     redirect = Redirector.find(request)
     if redirect
       redirect_to redirect
     else
-      NotFoundNotifier.notify(request)
+      NotFoundNotifier.notify(request, exception)
       not_found_search_results if search_enabled?
       render_not_found
     end

--- a/app/services/not_found_notifier.rb
+++ b/app/services/not_found_notifier.rb
@@ -1,11 +1,11 @@
 IGNORED_FORMATS = %w[php action swf].freeze
 
 class NotFoundNotifier
-  def self.notify(request)
+  def self.notify(request, exception)
     return if ignored_format?(request.params['format'])
     return if crawler?(request.user_agent)
 
-    Bugsnag.notify('404 - Not Found') do |notification|
+    Bugsnag.notify(notification_name(exception)) do |notification|
       notification.add_tab(:request, {
         params: request.params,
         path: request.path,
@@ -22,5 +22,13 @@ class NotFoundNotifier
 
   def self.crawler?(user_agent)
     Woothee.parse(user_agent)[:category] == :crawler
+  end
+
+  def self.notification_name(exception)
+    if exception.instance_of? Nexmo::Markdown::DocFinder::MissingDoc
+      'Missing Document'
+    else
+      '404 - Not Found'
+    end
   end
 end

--- a/spec/requests/markdown_spec.rb
+++ b/spec/requests/markdown_spec.rb
@@ -71,6 +71,17 @@ RSpec.describe 'Markdown', type: :request do
         expect(response).to redirect_to('/messaging/sms/overview')
       end
     end
+
+    context 'requesting a missing doc' do
+      it 'notifies bugsnag about the exception' do
+        expect(Nexmo::Markdown::DocFinder).to receive(:find).and_raise(Nexmo::Markdown::DocFinder::MissingDoc).twice
+        expect(NotFoundNotifier).to receive(:notify).with(kind_of(ActionDispatch::Request), Nexmo::Markdown::DocFinder::MissingDoc)
+
+        get '/messages/overview'
+
+        expect(response).to have_http_status(:not_found)
+      end
+    end
   end
 
   describe '#api' do

--- a/spec/services/not_found_notifier_spec.rb
+++ b/spec/services/not_found_notifier_spec.rb
@@ -25,4 +25,12 @@ RSpec.describe NotFoundNotifier do
       expect(NotFoundNotifier.ignored_format?('foobar')).to eq(false)
     end
   end
+
+  context '#notification_name' do
+    it { expect(described_class.notification_name(ActiveRecord::RecordNotFound.new)).to eq('404 - Not Found') }
+
+    it { expect(described_class.notification_name(Errno::ENOENT.new)).to eq('404 - Not Found') }
+
+    it { expect(described_class.notification_name(Nexmo::Markdown::DocFinder::MissingDoc.new)).to eq('Missing Document') }
+  end
 end


### PR DESCRIPTION
… - Not Found`.


## Description

This allows to easily identify exceptions releated to missing files.