### PR TITLE
Display `Kotlin` tab before `Java` tab

### DIFF
--- a/config/code_languages.yml
+++ b/config/code_languages.yml
@@ -28,8 +28,15 @@ languages:
       - 'nexmo'
     run_command: 'node {filename}'
 
-  java:
+  kotlin:
     weight: 3
+    label: Kotlin
+    lexer: java
+    icon: android
+    dependencies: []
+
+  java:
+    weight: 4
     label: Java
     lexer: java
     unindent: true
@@ -38,7 +45,7 @@ languages:
       - 'com.nexmo:client:@latest'
 
   dotnet:
-    weight: 4
+    weight: 5
     label: .NET
     lexer: c#
     unindent: true
@@ -46,7 +53,7 @@ languages:
     dependencies:
       - 'Nexmo.Csharp.Client'
   csharp:
-    weight: 4
+    weight: 5
     label: .NET
     lexer: c#
     unindent: true
@@ -55,7 +62,7 @@ languages:
       - 'Nexmo.Csharp.Client'
 
   php:
-    weight: 5
+    weight: 6
     label: PHP
     lexer: php
     icon: php
@@ -64,7 +71,7 @@ languages:
     run_command: 'php {filename}'
 
   python:
-    weight: 6
+    weight: 7
     label: Python
     lexer: python
     icon: python
@@ -73,20 +80,13 @@ languages:
     run_command: 'python {filename}'
 
   ruby:
-    weight: 7
+    weight: 8
     label: Ruby
     lexer: ruby
     icon: ruby
     dependencies:
       - 'nexmo'
     run_command: 'ruby {filename}'
-
-  kotlin:
-    weight: 8
-    label: Kotlin
-    lexer: java
-    icon: android
-    dependencies: []
 
   android:
     weight: 9


### PR DESCRIPTION
## Description

Improve language sorting, so `Kotlin` tab will be displayed before `Java` tab (`Kotlin` is much popular language for Android nowadays than `Java`)

## Deploy Notes

Any page where `Kotlin` & `Java` tabs are visible eg.
https://nexmo-developer-pr-2660.herokuapp.com/client-sdk/in-app-voice/getting-started/app-to-app-call

