### PR TITLE
[DEVX-2718] Bump volta.

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "@babel/preset-env": "^7.0.0",
     "@rails/ujs": "^6.0.2-1",
     "@rails/webpacker": "^4.0.2",
-    "@vonagevolta/volta2": "^0.0.30",
+    "@vonagevolta/volta2": "^0.0.38",
     "algoliasearch": "^3.24.9",
     "autoprefixer": "^7.1.2",
     "babel-loader": "^8.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1570,10 +1570,10 @@
   dependencies:
     "@types/yargs-parser" "*"
 
-"@vonagevolta/volta2@^0.0.30":
-  version "0.0.30"
-  resolved "https://registry.yarnpkg.com/@vonagevolta/volta2/-/volta2-0.0.30.tgz#61300bef5eebc2f97aaf60eb7370f02cbefee173"
-  integrity sha512-nKi+wRL0OAFJ6VAObrBIvDYm1Nuo4Nn/sbdnKP6Widym2tkHZBW6Ppptspyu65VT43i4O0zr8sAeXeTZU0l9Qg==
+"@vonagevolta/volta2@^0.0.38":
+  version "0.0.38"
+  resolved "https://registry.yarnpkg.com/@vonagevolta/volta2/-/volta2-0.0.38.tgz#592477a5f3bf54a805a11c7a40b11ceead66cdb7"
+  integrity sha512-Md5RQE0uhvPUGUbVy8QPb/7vOWocsbPRhuyRghdpAg7d1X9BQwnfmoDjLcGjiCs1yfB8+U7Tv7iCoCbM2wi+jg==
   dependencies:
     marked "^0.7.0"
     marked-sanitizer-github "^1.0.0"


### PR DESCRIPTION
## Description

Fixes issues with missing programming languages support for code snippets.

## Note

Objective-c code snippets are not being picked up by prism because we need to add some custom code to map the key that prism expects.