### PR TITLE
Update customizing-tts.md

### DIFF
--- a/_documentation/en/voice/voice-api/guides/customizing-tts.md
+++ b/_documentation/en/voice/voice-api/guides/customizing-tts.md
@@ -145,7 +145,7 @@ Value of `interpret-as`  | Effect on spoken text
 `ordinal` | Pronounces the number as an ordinal. For example, "1" would be pronounced "first" and "33" would be pronounced "thirty-third".
 `digits` | Reads the specified numbers out as digits. For example, "747" would be pronounced "seven four seven" and not "seven hundred and forty seven".
 `fraction` | Reads the numbers out as a fraction. For example, "1/3" would be pronounced "one third" and "2 4/10" would be pronounced "two and four tenths".
-`unit` | Reads the specified number out as a unit. The value must be a number followed by a unit of measure with no space between the two. For example: "1meter".
+`unit` | Reads the specified number out as a unit. The value must be a number followed by a unit of measure with no space between the two. For example: "1m".
 `date` | Specify how to pronounce dates. See the section below on [date formatting](#date-formatting).
 `time` | Pronounces time durations in minutes and seconds. For example: `1'30"` is read as "one minute and thirty seconds".
 `address` | Reads out a street address with appropriate breaks.


### PR DESCRIPTION
## Description

"1meter" doesn't work properly with say-as: unit: it doesn't switch to plural (e.g. with "5meter"), however "5m" works (it says "5 meters").