### PR TITLE
Fix dependency tab and upgrade SDK version `2.5.0` -> `2.5.1`

### DIFF
--- a/_documentation/en/client-sdk/setup/add-sdk-to-your-app/android.md
+++ b/_documentation/en/client-sdk/setup/add-sdk-to-your-app/android.md
@@ -22,7 +22,7 @@ Open your Android project codebase in your IDE.
 To add the Nexmo Client SDK to your project, add the following dependency in your app level `build.gradle` file (typically `app/build.gradle`):
 
  ```tabbed_content
-source: '_tutorials_tabbed_content/client-sdk/setup/add-sdk/android/build-client'
+source: '_tutorials_tabbed_content/client-sdk/setup/add-sdk/android/dependencies'
 ``` 
 
 ### Add permissions

--- a/_tutorials_tabbed_content/client-sdk/setup/add-sdk/android/dependencies/groovy.md
+++ b/_tutorials_tabbed_content/client-sdk/setup/add-sdk/android/dependencies/groovy.md
@@ -5,6 +5,6 @@ language: groovy
 
 ```groovy
 dependencies {
-    implementation 'com.nexmo.android:client-sdk:2.5.0'
+    implementation 'com.nexmo.android:client-sdk:2.5.1'
 }
 ```

--- a/_tutorials_tabbed_content/client-sdk/setup/add-sdk/android/dependencies/kotlin.md
+++ b/_tutorials_tabbed_content/client-sdk/setup/add-sdk/android/dependencies/kotlin.md
@@ -5,6 +5,6 @@ language: kotlin
 
 ```kotlin
 dependencies {
-    implementation("com.nexmo.android:client-sdk:2.5.0")
+    implementation("com.nexmo.android:client-sdk:2.5.1")
 }   
 ```


### PR DESCRIPTION
## Description

- Fix "dependency" tab content
- Upgrade SDK version `2.5.0` -> `2.5.1`

## Deploy Notes

https://nexmo-developer-pr-2707.herokuapp.com/client-sdk/setup/add-sdk-to-your-app/android

