### PR TITLE
Callback service documentation for Messages API Sandbox

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -109,7 +109,7 @@ GEM
     bugsnag (6.13.0)
       concurrent-ruby (~> 1.0)
     builder (3.2.4)
-    byebug (11.1.2)
+    byebug (11.1.3)
     capybara (3.32.1)
       addressable
       mini_mime (>= 0.1.3)

--- a/_documentation/en/messages/concepts/messages-api-sandbox.md
+++ b/_documentation/en/messages/concepts/messages-api-sandbox.md
@@ -83,6 +83,10 @@ The procedure for whitelisting yourself differs slightly depending on the sandbo
 
 ![Configure webhooks](/assets/images/messages/config-webhooks.png)
 
+### Webhook Retries
+
+Inbound and Status webhooks are retried on a per-notification basis in the Messages API Sandbox. Any non-2xx response to the webhook will prompt Vonage to retry periodically at intervals of increasing length: 5s, 10s, 20s, 40s, 80s, 160s, 320s, 640s, and then every 900s(15 min) for 24 hours.
+
 ## Send a test message via the Messages API Sandbox
 
 Once your number or recipient ID is added to the whitelist, you will use a Messages API Sandbox endpoint to send your test messages. The `from` value in the request should be the ID or number associated with the specific Vonage Sandbox external account. For your testing purposes, the value in the `from` field is already populated in the code snippets provided in the [Dashboard](https://dashboard.nexmo.com/messages/sandbox). It is important to note that you will need to replace the value in the `to` field with your number or Recipient ID that is whitelisted on the specific Vonage Sandbox external account.

--- a/_documentation/en/messages/concepts/messages-api-sandbox.md
+++ b/_documentation/en/messages/concepts/messages-api-sandbox.md
@@ -85,7 +85,7 @@ The procedure for whitelisting yourself differs slightly depending on the sandbo
 
 ### Webhook Retries
 
-Inbound and Status webhooks are retried on a per-notification basis in the Messages API Sandbox. Any non-2xx response to the webhook will prompt Vonage to retry periodically at intervals of increasing length: 5s, 10s, 20s, 40s, 80s, 160s, 320s, 640s, and then every 900s(15 min) for 24 hours.
+Inbound and Status webhooks are retried on a per-notification basis in the Messages API Sandbox. Any non 200 response to a webhook will prompt Vonage to retry periodically at intervals of increasing length: 5, 10, 20, 40, 80, 160, 320, 640, and then every 900 seconds for 24 hours.
 
 ## Send a test message via the Messages API Sandbox
 


### PR DESCRIPTION
## Description

The new Messages API Callback service is live for the messages sandbox, so I'm adding a note about retries the messages API Sandbox section: https://developer.nexmo.com/messages/concepts/messages-api-sandbox

## Deploy Notes

NA
