### PR TITLE
Messages API Sandbox Callback retry behavior documentation

### DIFF
--- a/_documentation/en/messages/concepts/messages-api-sandbox.md
+++ b/_documentation/en/messages/concepts/messages-api-sandbox.md
@@ -83,6 +83,10 @@ The procedure for whitelisting yourself differs slightly depending on the sandbo
 
 ![Configure webhooks](/assets/images/messages/config-webhooks.png)
 
+### Webhook Retries
+
+Inbound and Status webhooks are retried on a per-notification basis in the Messages API Sandbox. Any non 200 response to a webhook will prompt Vonage to retry periodically at intervals of increasing length: 5, 10, 20, 40, 80, 160, 320, 640, and then every 900 seconds for 24 hours.
+
 ## Send a test message via the Messages API Sandbox
 
 Once your number or recipient ID is added to the whitelist, you will use a Messages API Sandbox endpoint to send your test messages. The `from` value in the request should be the ID or number associated with the specific Vonage Sandbox external account. For your testing purposes, the value in the `from` field is already populated in the code snippets provided in the [Dashboard](https://dashboard.nexmo.com/messages/sandbox). It is important to note that you will need to replace the value in the `to` field with your number or Recipient ID that is whitelisted on the specific Vonage Sandbox external account.


### PR DESCRIPTION
## Description

The new Messages API Callback service is live for the messages sandbox, so I'm adding a note about retries the messages API Sandbox section: https://developer.nexmo.com/messages/concepts/messages-api-sandbox