### PR TITLE
Add check to make sure .ruby-version, Gemfile and Docker are in sync

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,6 +78,7 @@ jobs:
         bundle exec rake ci:verify_oas_reference
         bundle exec rake ci:verify_error_urls_resolve
         bundle exec rake ci:check_word_blocklist
+        bundle exec rake ci:check_ruby_version
         RAILS_ENV=test bundle exec rake webpacker:compile
         ./node_modules/.bin/mdspell -r -n -a --en-us '_documentation/en/**/*.md' '_partials/*.md' '_partials/**/*.md' '_modals/**/*.md' '_tutorials/**.md'
         yarn test


### PR DESCRIPTION
## Description

When we updated from Ruby `2.5.7` to `2.5.8` we updated `.ruby-version` and `Gemfile.lock` but missed the `Dockerfile`. This PR adds a CI check that makes sure all three are in sync.

CI will fail for this PR until #2742 is merged and this PR is rebased

## Deploy Notes

N/A
