### PR TITLE
NCCO - start and end date format is ISO 8601

### DIFF
--- a/_documentation/en/voice/voice-api/ncco-reference.md
+++ b/_documentation/en/voice/voice-api/ncco-reference.md
@@ -90,8 +90,8 @@ Possible return parameters are:
  -- | --
  `recording_uuid` | The unique ID for the Call. <br>**Note**: `recording_uuid` is not the same as the file uuid in *recording_url*.
  `recording_url` | The  URL to the file containing the Call recording
- `start_time`  | The time the recording started in the following format: `YYYY-MM-DD HH:MM:SS`. For example `2020-01-01 12:00:00`
- `end_time`  | The time the recording finished in the following format: `YYYY-MM-DD HH:MM:SS`. For example `2020-01-01 12:00:00`
+ `start_time`  | The time the recording started in ISO 8601 format: `YYYY-MM-DDTHH:MM:SSZ`. For example `2020-01-01T12:00:00Z`
+ `end_time`  | The time the recording finished in ISO 8601 format: `YYYY-MM-DDTHH:MM:SSZ`. For example `2020-01-01T12:00:00Z`
  `size` | The size of the recording at *recording_url* in bytes. For example: `603423`
  `conversation_uuid` | The unique ID for this Call.
 


### PR DESCRIPTION
## Description

See https://nexmoinc.atlassian.net/browse/DEVX-2555

start and end date format should be ISO 8601.

## Review

Check the second table here for correct date-time formats:

* [NCCO Ref / Record](https://nexmo-developer-pr-2746.herokuapp.com/voice/voice-api/ncco-reference#record)
