### PR TITLE
[DEVX-2838] Fix tutorials' dropdown.

### DIFF
--- a/app/controllers/tutorial_controller.rb
+++ b/app/controllers/tutorial_controller.rb
@@ -7,12 +7,14 @@ class TutorialController < ApplicationController
 
   def list
     @product = params['product']
+    @code_language = params['code_language']
 
     if @product
       @tutorials = TutorialList.tasks_for_product(@product)
     else
       @tutorials = TutorialList.all
     end
+    @tutorials = @tutorials.select { |t| t.languages.include?(@code_language) } if @code_language
 
     @document_title = 'Tutorials'
 

--- a/app/views/layouts/partials/_programming_languages_dropdown.html.erb
+++ b/app/views/layouts/partials/_programming_languages_dropdown.html.erb
@@ -9,7 +9,7 @@
           <li>
             <a
               class="Vlt-dropdown__link"
-              href="<%= url_for(controller: :use_case, action: :index, product: params[:product], code_language: lang.key)%>"
+              href="<%= url_for(controller: controller_name, action: action_name, product: params[:product], code_language: lang.key)%>"
               >
               <svg class="Vlt-dropdown__link__icon" style="height: 20px; width: 20px;" ><use xlink:href="/assets/images/brands/<%= lang.icon %>.svg#<%= lang.icon %>"></use></svg><span><%= lang.label %></span>
             </a>

--- a/app/views/tutorial/list.html.erb
+++ b/app/views/tutorial/list.html.erb
@@ -3,7 +3,7 @@
 <div class="Nxd-use-cases--filters">
   <strong>Filter: &nbsp;&nbsp;</strong>
 
-  <%= render partial: 'layouts/partials/programming_languages_dropdown' %>
+  <%= render partial: 'layouts/partials/programming_languages_dropdown', controller_name: :tutorial, action_name: :list %>
 
   <div class="Vlt-dropdown">
     <button class="Vlt-dropdown__btn">

--- a/app/views/use_case/index.html.erb
+++ b/app/views/use_case/index.html.erb
@@ -3,7 +3,7 @@
 <div class="Nxd-use-cases--filters">
   <strong>Filter: &nbsp;&nbsp;</strong>
 
-  <%= render partial: 'layouts/partials/programming_languages_dropdown' %>
+  <%= render partial: 'layouts/partials/programming_languages_dropdown', controller_name: :use_case, action_name: :index %>
 
   <div class="Vlt-dropdown">
     <button class="Vlt-dropdown__btn">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -91,8 +91,7 @@ Rails.application.routes.draw do
   resources :careers, only: [:index]
 
   get '/task/(*tutorial_step)', to: 'tutorial#single'
-  get '/(*product)/tutorials', to: 'tutorial#list', constraints: DocumentationConstraint.documentation
-  get '/tutorials', to: 'tutorial#list', constraints: DocumentationConstraint.documentation
+  get '/(*product)/tutorials(/:code_language)', to: 'tutorial#list', constraints: DocumentationConstraint.documentation.merge(Nexmo::Markdown::CodeLanguage.route_constraint)
   get '/(*product)/tutorials/(:tutorial_name)(/*tutorial_step)(/:code_language)', to: 'tutorial#index', constraints: DocumentationConstraint.documentation
   get '/tutorials/(:tutorial_name)(/*tutorial_step)(/:code_language)', to: 'tutorial#index', constraints: Nexmo::Markdown::CodeLanguage.route_constraint
 

--- a/spec/routing/tutorials_spec.rb
+++ b/spec/routing/tutorials_spec.rb
@@ -37,4 +37,21 @@ RSpec.describe 'tutorials routes', type: :routing do
       end
     end
   end
+
+  describe 'tutorial#list' do
+    it 'supports product and code_language' do
+      expect(get('/client-sdk/tutorials/javascript'))
+        .to route_to(controller: 'tutorial', action: 'list', product: 'client-sdk', code_language: 'javascript')
+    end
+
+    it 'supports a product' do
+      expect(get('/client-sdk/tutorials'))
+        .to route_to(controller: 'tutorial', action: 'list', product: 'client-sdk')
+    end
+
+    it 'supports a code_language' do
+      expect(get('/tutorials/javascript'))
+        .to route_to(controller: 'tutorial', action: 'list', code_language: 'javascript')
+    end
+  end
 end


### PR DESCRIPTION
## Description

Fixes dropdown in `/tutorials`, it nows point to `tutorials` instead of `use-cases`.