### PR TITLE
SMS delivery receipts depend on Auth

### DIFF
--- a/_documentation/en/messages/code-snippets/sms/send-sms.md
+++ b/_documentation/en/messages/code-snippets/sms/send-sms.md
@@ -9,6 +9,17 @@ In this code snippet you will see how to send an SMS using the Messages API.
 
 For a step-by-step guide to this topic, you can read our tutorial [Sending SMS messages with the Messages API](/tutorials/sending-sms-messages-with-messages-api).
 
+## Delivery receipts
+
+The webhook used for the delivery receipt will depend on the type of authentication used:
+
+Authentication type used | Webhook used for delivery receipt
+----|----
+Basic Auth | [account-level webhook](https://dashboard.nexmo.com/settings) is used for delivery receipt.
+JWT Auth | [application-level webhook](https://dashboard.nexmo.com/applications) is used for delivery receipt / status.
+
+> Reception of delivery receipts depends on availability of network support.
+
 ## Example
 
 Ensure the following variables are set to your required values using any convenient method:


### PR DESCRIPTION
## Description

See [DEVX-2813](https://nexmoinc.atlassian.net/browse/DEVX-2813)

When sending SMSs using the Messages API the webhook used for the delivery receipt depends on Authentication type used when making the API call.

## Review

* [Send an SMS using Messages API](https://nexmo-developer-pr-2778.herokuapp.com/messages/code-snippets/sms/send-sms)