### PR TITLE
[DEVX-2848] Fix <title> and reword it.

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,8 @@
 class ApplicationController < ActionController::Base
   include ApplicationHelper
 
+  helper_method :page_title
+
   rescue_from Errno::ENOENT, with: :not_found
   rescue_from Nexmo::Markdown::DocFinder::MissingDoc, with: :not_found
   rescue_from ActiveRecord::RecordNotFound, with: :not_found
@@ -86,5 +88,9 @@ class ApplicationController < ActionController::Base
     else
       I18n.default_locale
     end
+  end
+
+  def page_title
+    @page_title ||= PageTitle.new(@product, @document_title).title
   end
 end

--- a/app/controllers/markdown_controller.rb
+++ b/app/controllers/markdown_controller.rb
@@ -14,6 +14,8 @@ class MarkdownController < ApplicationController
       set_canonical_url
     end
 
+    @document_title = @frontmatter['meta_title'] || @frontmatter['title']
+
     @sidenav = Sidenav.new(
       namespace: params[:namespace],
       locale: params[:locale],
@@ -91,8 +93,6 @@ class MarkdownController < ApplicationController
   def content_from_folder
     frontmatter = YAML.safe_load(File.read(folder_config_path))
     path = folder_config_path.chomp('/.config.yml')
-
-    @document_title = frontmatter['meta_title'] || frontmatter['title']
 
     content = Nexmo::Markdown::Renderer.new({
       code_language: @code_language,

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -9,16 +9,6 @@ module ApplicationHelper
     "theme--#{ENV['THEME']}"
   end
 
-  def title
-    if @product && @document_title
-      "Nexmo Developer | #{@product.titleize} > #{@document_title}"
-    elsif @document_title
-      "Nexmo Developer | #{@document_title}"
-    else
-      'Nexmo Developer'
-    end
-  end
-
   def active_sidenav_item
     if params[:tutorial_name]
       url_for(controller: :tutorial, action: :index, product: params[:product], tutorial_name: params[:tutorial_name])

--- a/app/presenters/page_title.rb
+++ b/app/presenters/page_title.rb
@@ -1,0 +1,18 @@
+class PageTitle
+  DEFAULT = 'Vonage API Developer'.freeze
+
+  def initialize(product, document_title)
+    @product        = product
+    @document_title = document_title
+  end
+
+  def title
+    if @product && @document_title
+      "#{@product.titleize} > #{@document_title} | #{DEFAULT}"
+    elsif @document_title
+      "#{@document_title} | #{DEFAULT}"
+    else
+      DEFAULT
+    end
+  end
+end

--- a/app/views/layouts/partials/_head.html.erb
+++ b/app/views/layouts/partials/_head.html.erb
@@ -2,10 +2,10 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
-  <title><%= title %></title>
+  <title><%= page_title %></title>
 
-  <% if @frontmatter && @frontmatter['description'] %>
-    <meta name="description" content="<%= @frontmatter['description'] %>">
+  <% if @frontmatter && (@frontmatter['meta_description'] || @frontmatter['description']) %>
+    <meta name="description" content="<%= @frontmatter['meta_description'] || @frontmatter['description'] %>">
   <% end %>
   <meta name="google-site-verification" content="_DNZpugW9Fl4BUMbPsepvc_2McwbRvNBHHuI99MZH7c" />
 
@@ -104,7 +104,7 @@
 
   <meta property="og:url" content="<%= request.base_url + request.fullpath %>" />
   <meta property="og:type" content="article" />
-  <meta property="og:title" content="<%= title %>" />
+  <meta property="og:title" content="<%= page_title %>" />
 
   <meta property="og:image" content="<%= request.base_url %>/assets/images/nexmo-developer-card.png" />
   <meta property="og:image:width" content="835" />

--- a/spec/presenters/page_title_spec.rb
+++ b/spec/presenters/page_title_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+
+RSpec.describe PageTitle, type: :model do
+  let(:product) { nil }
+
+  subject { described_class.new(product, title) }
+
+  describe '#title' do
+    context 'with title' do
+      let(:title) { 'Metadata Example Title' }
+
+      context 'with product' do
+        let(:product) { 'Example Product' }
+
+        it 'returns the product and title with the default appended' do
+          expect(subject.title).to eq('Example Product > Metadata Example Title | Vonage API Developer')
+        end
+      end
+
+      context 'without one' do
+        it 'returns the title with the default appended' do
+          expect(subject.title).to eq('Metadata Example Title | Vonage API Developer')
+        end
+      end
+    end
+
+    context 'without title' do
+      let(:title) { nil }
+
+      it 'returns the default' do
+        expect(subject.title).to eq('Vonage API Developer')
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Description

Fix <title> tag to use the `@document_title`
In case of markdown files, it tries to use `meta_title` first, and fallback to `title` if it is not present.
