### PR TITLE
[DEVX-2855] Fix spotlight form.

### DIFF
--- a/app/controllers/static_controller.rb
+++ b/app/controllers/static_controller.rb
@@ -228,6 +228,19 @@ class StaticController < ApplicationController
     render layout: 'page'
   end
 
+  def spotlight
+    response = RestClient.post(
+      'https://hooks.zapier.com/hooks/catch/1936493/oyzjr4i/',
+      params.permit(:name, :email_address, :background, :outline, :previous_content).to_h
+    )
+
+    if response.code == 200
+      head :ok
+    else
+      head :unprocessable_entity
+    end
+  end
+
   private
 
   def canonical_redirect

--- a/app/views/static/default_landing/partials/_submit_your_idea_form.html.erb
+++ b/app/views/static/default_landing/partials/_submit_your_idea_form.html.erb
@@ -3,7 +3,7 @@
     <%= local_assigns['header'].render_markdown(skip_paragraph_surround: true) %>
 </h2>
 
-<%= form_tag('https://hooks.zapier.com/hooks/catch/1936493/oyzjr4i/', authenticity_token: false, remote: true, id: 'spotlight-form') do %>
+<%= form_tag('/spotlight', remote: true, id: 'spotlight-form') do %>
   <div class="Vlt-form__element">
     <%= label_tag 'name', 'Your Name', class: 'Vlt-label' %>
     <div class="Vlt-input">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -60,6 +60,7 @@ Rails.application.routes.draw do
 
   get '/legacy', to: 'static#legacy'
   get '/team', to: 'static#team'
+  post '/spotlight', to: 'static#spotlight'
 
   get '/community/slack', to: 'slack#join'
   post '/community/slack', to: 'slack#invite'

--- a/spec/requests/static_spec.rb
+++ b/spec/requests/static_spec.rb
@@ -1,0 +1,34 @@
+require 'rails_helper'
+
+RSpec.describe 'Static', type: :request do
+  describe '#spotlight' do
+    let(:url) { 'https://hooks.zapier.com/hooks/catch/1936493/oyzjr4i/' }
+    let(:params) do
+      {
+        'name' => 'test',
+        'email_address' => 'test@test.com',
+        'background' => 'test',
+        'outline' => 'test',
+        'previous_content' => '',
+      }
+    end
+
+    context 'makes a request to zapier' do
+      it 'returns success if 200' do
+        expect(RestClient).to receive(:post).with(url, params).and_return(double(RestClient::Response, code: 200))
+
+        post '/spotlight', params: params
+
+        expect(response).to have_http_status(:ok)
+      end
+
+      it 'returns 422 otherwise' do
+        expect(RestClient).to receive(:post).with(url, params).and_return(double(RestClient::Response, code: 422))
+
+        post '/spotlight', params: params
+
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Description

When we moved from jquery_ujs to rails-ujs, the form stopped working
because the browser started preventing the request due to `CORS policy`.
The reason why it started to fail is because of an upstream issue caused
by rails-ujs.
It is including the `x-csrf-token` header even if the domain is
different. Making the request server-side will prevent this issue from
happening again.
