### PR TITLE
make clear that regional domains are required for SIP

### DIFF
--- a/_documentation/en/voice/sip/concepts/programmable-sip.md
+++ b/_documentation/en/voice/sip/concepts/programmable-sip.md
@@ -34,7 +34,7 @@ IP addresses of your devices and endpoints can be configured to reach your Nexmo
 
 ## Domain Based Routing
 
-Calls made to a Programmable SIP domain must be handled at a regional level. You must use a R-URI with a regional domain. Please be aware that a R-URI without a regional component in the domain will fail the call.
+Calls made to a Programmable SIP domain must be handled at a regional level. You must use a Request URI with a regional domain. Please be aware that a Request URI without a regional component in the domain will fail the call.
 
 The following code will indicate to Nexmo that you want this SIP call to be handled in the EU:
 

--- a/_documentation/en/voice/sip/concepts/programmable-sip.md
+++ b/_documentation/en/voice/sip/concepts/programmable-sip.md
@@ -34,7 +34,7 @@ IP addresses of your devices and endpoints can be configured to reach your Nexmo
 
 ## Domain Based Routing
 
-If you require your call to be handled by a specific Nexmo region, then you can specify that by using R-URI with such information in the domain part.
+Calls made to a Programmable SIP domain must be handled at a regional level. You must use a R-URI with a regional domain. Please be aware that a R-URI without a regional component in the domain will fail the call.
 
 The following code will indicate to Nexmo that you want this SIP call to be handled in the EU:
 


### PR DESCRIPTION
## Description

DEVX-2852 Regional domain usage must be made abundantly clear that they are required for programmable SIP and not an option.
