### PR TITLE
Media template character limit update

### DIFF
--- a/_documentation/en/messages/code-snippets/whatsapp/send-media-mtm.md
+++ b/_documentation/en/messages/code-snippets/whatsapp/send-media-mtm.md
@@ -14,9 +14,9 @@ To send the Media Message Template you need to use the Messages custom object. T
 
 ## Message format and length restrictions
 
-WhatsApp Media Message Templates consist of a Header, Body and Footer structure. The Header contains the media, which can be text, location, video, image or file. The Body contains the text message. **This is currently limited to 160 characters when displayed to the end user, so as to avoid the need for scrolling.** The Footer is optional and contains static text only.
+WhatsApp Media Message Templates consist of a Header, Body and Footer structure. The Header contains the media, which can be text, location, video, image or file. The Body contains the text message. **This is currently limited to 1024 characters when displayed to the end user, so as to avoid the need for scrolling.** The Footer is optional and contains static text only.
 
-> **NOTE:** Message body length is currently limited to 160 characters.
+> **NOTE:** The Header and Footer lengths are currently limited to 60 characters each and the Message body length is limited to 1024 characters.
 
 ## Example
 

--- a/_documentation/en/messages/code-snippets/whatsapp/send-mtm.md
+++ b/_documentation/en/messages/code-snippets/whatsapp/send-mtm.md
@@ -10,6 +10,8 @@ In this code snippet you learn how to send a WhatsApp Message Template Message (
 
 > **IMPORTANT:** If a customer messages you, you have 24 hours to respond to the customer with a free-form message. After this period you must use a message template (MTM). If a customer has not messaged you first, then the first time you send a message to a user, WhatsApp requires that the message contains a template. This is explained in more detail in the [Understanding WhatsApp topic](/messages/concepts/whatsapp).
 
+> **NOTE:** The Header and Footer lengths are currently limited to 60 characters each and the Message body length is limited to 1024 characters.
+
 ## Example
 
 Ensure the following variables are set to your required values using any convenient method:

--- a/_documentation/en/messages/concepts/whatsapp.md
+++ b/_documentation/en/messages/concepts/whatsapp.md
@@ -43,6 +43,8 @@ The MTM allows a business to send just the template identifier along with the ap
 
 > **NOTE:** New templates need to be approved by WhatsApp. Please contact your Nexmo Account Manager to submit the templates. Only templates created in your own namespace are valid. Using an template with a namespace outside of your own results in an error code 1022 being returned.
 
+> **NOTE:** Templates are subject to a restriction of 60 characters in their header and footer, and 1024 characters in their body. 
+
 MTMs are designed to reduce the likelihood of spam to users on WhatsApp.
 
 For the purpose of testing Nexmo provides a template, `whatsapp:hsm:technology:nexmo:verify`, that you can use:


### PR DESCRIPTION
## Description

Docs for Messages needs to be updated to reflect the new character restrictions on templates - these restrictions have been lifted from 160 chars total - to 60 chars in header / footer and 1024 chars in the body: https://developers.facebook.com/docs/whatsapp/business-management-api/message-templates/

## Deploy Notes

N/A
