### PR TITLE
Use sassc-rails instead of  sass-rails.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ gem 'pg', '~> 1.2'
 # Use Puma as the app server
 gem 'puma', '~> 4.3'
 # Use SCSS for stylesheets
-gem 'sass-rails', '~> 6.0'
+gem 'sassc-rails', '~> 2.1'
 # Use Uglifier as compressor for JavaScript assets
 gem 'uglifier', '>= 4.1.20'
 # Use CoffeeScript for .coffee assets and views

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -455,9 +455,7 @@ GEM
     sass-listen (4.0.0)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
-    sass-rails (6.0.0)
-      sassc-rails (~> 2.1, >= 2.1.1)
-    sassc (2.2.1)
+    sassc (2.3.0)
       ffi (~> 1.9)
     sassc-rails (2.1.2)
       railties (>= 4.0.0)
@@ -605,7 +603,7 @@ DEPENDENCIES
   rubocop (~> 0.83.0)
   rubocop-rails (~> 2.5)
   ruby-progressbar
-  sass-rails (~> 6.0)
+  sassc-rails (~> 2.1)
   simplecov
   slack-notifier (= 2.3.2)
   smartling


### PR DESCRIPTION

## Description

Sass-rails is just a wrapper of sassc-rails and was causing some issues
because it was using an old version of sassc-ruby. See github.com/sass/sassc-ruby/issues/146

## Deploy Notes

Notes regarding deployment the contained body of work. These should note any db migrations, etc.
