### PR TITLE
Update Android SDK v2.6.4 release notes

### DIFF
--- a/_documentation/en/client-sdk/sdk-documentation/android/release-notes.md
+++ b/_documentation/en/client-sdk/sdk-documentation/android/release-notes.md
@@ -6,6 +6,12 @@ navigation_weight: 0
 
 # Release Notes
 
+## Version 2.6.4 - May 19, 2020
+
+### Internal
+
+- Improved user-agent SDK version reporting.
+
 ## Version 2.6.3 - May 4, 2020
 
 ### Fixed


### PR DESCRIPTION
Android SDK v2.6.4 notes added to `release-notes.md`.