### PR TITLE
Fix Messages API tutorial intros

### DIFF
--- a/config/tutorials/en/send-facebook-message-with-failover.yml
+++ b/config/tutorials/en/send-facebook-message-with-failover.yml
@@ -8,7 +8,11 @@ introduction:
   description: This task shows you how to use the failover functionality of the Dispatch API.
   content: |
     # Introduction
-    The Dispatch API features workflows with automatic failover. In this task you see how to send a Facebook Messenger message with automatic failover to SMS.
+    The [Dispatch API](/dispatch/overview) features workflows with automatic failover. In this tutorial you see how to send a Facebook Messenger message with automatic failover to SMS.
+
+    This tutorial provides a step-by-step guide to installing the required tools, building your application, writing the code and testing. The message sent is plain text.
+
+    For further background information on Facebook messaging see our [supporting documentation](/messages/concepts/facebook).
 
     > **NOTE:** This task assumes you have already created a Facebook Profile and a Facebook Page.
 

--- a/config/tutorials/en/send-fbm-message.yml
+++ b/config/tutorials/en/send-fbm-message.yml
@@ -8,7 +8,11 @@ introduction:
   description: This tutorial shows you how to send a Facebook Messenger message with Messages API.
   content: |
     # Introduction
-    The Messages API allows you to send a Facebook Messenger message. In this tutorial you learn how to receive a Messenger message and then return a message.
+    The [Messages API](/messages/overview) allows you to send a Facebook Messenger message. In this tutorial you learn how to receive a Messenger message and then return a message.
+
+    This tutorial provides a step-by-step guide to installing the required tools, building your application, writing the code and testing. The message sent is plain text.
+
+    For further background information on WhatsApp messaging see our [supporting documentation](/messages/concepts/facebook).
 
     > **NOTE:** This task assumes you have already created a Facebook Profile and a Facebook Page.
 

--- a/config/tutorials/en/send-sms-with-messages.yml
+++ b/config/tutorials/en/send-sms-with-messages.yml
@@ -8,7 +8,9 @@ introduction:
   description: This tutorial shows you how to send an SMS message with Messages API.
   content: |
     # Introduction
-    The Messages API allows you to send an SMS message. In this tutorial you learn how to send an SMS message.
+    The Messages API allows you to send an SMS message. In this tutorial you learn how to send an SMS message. 
+    
+    This tutorial provides a step-by-step guide to installing the required tools, building your application, writing the code and testing. The message sent is plain text.
 
     > **NOTE:** Please carefully review the prerequisites.
 

--- a/config/tutorials/en/send-sms-with-messages.yml
+++ b/config/tutorials/en/send-sms-with-messages.yml
@@ -8,7 +8,7 @@ introduction:
   description: This tutorial shows you how to send an SMS message with Messages API.
   content: |
     # Introduction
-    The Messages API allows you to send an SMS message. In this tutorial you learn how to send an SMS message. 
+    The [Messages API](/messages/overview) allows you to send an SMS message. In this tutorial you learn how to send an SMS message. 
     
     This tutorial provides a step-by-step guide to installing the required tools, building your application, writing the code and testing. The message sent is plain text.
 

--- a/config/tutorials/en/send-viber-message.yml
+++ b/config/tutorials/en/send-viber-message.yml
@@ -8,7 +8,11 @@ introduction:
   description: This tutorial shows you how to send a Viber message with Messages API.
   content: |
     # Introduction
-    The Messages API allows you to send a Viber message. In this tutorial you learn how to send a Viber message.
+    The [Messages API](/messages/overview) allows you to send a Viber message. In this tutorial you learn how to send a Viber message. 
+    
+    This tutorial provides a step-by-step guide to installing the required tools, building your application, writing the code and testing. The message sent is plain text.
+
+    For further background information on Viber messaging see our [supporting documentation](/messages/concepts/viber).
 
     > **NOTE:** Please carefully review the prerequisites.
 

--- a/config/tutorials/en/send-whatsapp-message.yml
+++ b/config/tutorials/en/send-whatsapp-message.yml
@@ -8,7 +8,11 @@ introduction:
   description: This tutorial shows you how to send a WhatsApp message with Messages API.
   content: |
     # Introduction
-    The Messages API allows you to send a WhatsApp message. In this tutorial you learn how to send a WhatsApp message.
+    The [Messages API](/messages/overview) allows you to send a WhatsApp message. In this tutorial you learn how to send a WhatsApp message. 
+    
+    This tutorial provides a step-by-step guide to installing the required tools, building your application, writing the code and testing. The message sent is plain text.
+
+    For further background information on WhatsApp messaging see our [supporting documentation](/messages/concepts/whatsapp).
 
     > **NOTE:** Please carefully review the prerequisites.
 


### PR DESCRIPTION
## Description

Tutorial intros were placeholder. Expanded text and added some supporting links. The idea is that if people drop onto the tutorial page without context, they can reference the conceptual info we provide elsewhere.

## Review

* [Dispatch](https://nexmo-developer-pr-2837.herokuapp.com/dispatch/tutorials/send-facebook-message-with-failover/introduction)
* [Viber](https://nexmo-developer-pr-2837.herokuapp.com/messages/tutorials/send-viber-message/introduction)
* [SMS](https://nexmo-developer-pr-2837.herokuapp.com/messages/tutorials/send-sms-with-messages/introduction)
* [WhatsApp](https://nexmo-developer-pr-2837.herokuapp.com/messages/tutorials/send-whatsapp-message/introduction)
* [Facebook](https://nexmo-developer-pr-2837.herokuapp.com/messages/tutorials/send-fbm-message/introduction)
