### PR TITLE
Add DevEd cookie route

### DIFF
--- a/app/controllers/static_controller.rb
+++ b/app/controllers/static_controller.rb
@@ -241,6 +241,25 @@ class StaticController < ApplicationController
     end
   end
 
+  def blog_cookie
+    # This is the first touch time so we only want to set it if it's not already set
+    set_utm_cookie('ft', Time.now.getutc.to_i) unless cookies[:ft]
+
+    # Clear out old values that might not be set
+    cookies.delete('utm_campaign', domain: :all)
+    cookies.delete('utm_term', domain: :all)
+    cookies.delete('utm_content', domain: :all)
+
+    # These are the things we'll be tracking through the customer dashboard
+    set_utm_cookie('utm_medium', 'dev_education')
+    set_utm_cookie('utm_source', 'blog')
+    set_utm_cookie('utm_campaign', params['c']) if params['c']
+    set_utm_cookie('utm_content', params['ct']) if params['ct']
+    set_utm_cookie('utm_term', params['t']) if params['t']
+
+    redirect_to 'https://dashboard.nexmo.com/sign-up'
+  end
+
   private
 
   def canonical_redirect

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -106,6 +106,8 @@ Rails.application.routes.draw do
 
   get '(/:locale)/*product/*document(/:code_language)', to: 'markdown#show', constraints: DocumentationConstraint.documentation.merge(locale: LocaleConstraint.available_locales)
 
+  get '/ed', to: 'static#blog_cookie'
+
   get '*unmatched_route', to: 'application#not_found'
 
   root 'static#landing'


### PR DESCRIPTION
## Description

Adds UTM tracking cookies for the dashboard to attribute signups to blog content

Example link to be used in blog posts:

```
https://developer.nexmo.com/ed?c=campaign&ct=content&t=term
```

## Deploy Notes

N/A
