### PR TITLE
Define connect ncco action requirement explicitly

### DIFF
--- a/_documentation/en/voice/voice-api/ncco-reference.md
+++ b/_documentation/en/voice/voice-api/ncco-reference.md
@@ -135,7 +135,7 @@ You can use the following options to control a `connect` action:
 
 Option | Description | Required
 -- | -- | --
-`endpoint` | Array of `endpoint` objects to connect to with support for a **maximum** of 1 `endpoint` objects. [Available endpoint types](#endpoint-types-and-values) | Yes
+`endpoint` | Array of `endpoint` objects to connect to. Currently supports a **maximum** of one `endpoint` object. [Available endpoint types](#endpoint-types-and-values) | Yes
 `from` | A number in [E.164](https://en.wikipedia.org/wiki/E.164) format that identifies the caller.§§ This must be one of your Nexmo virtual numbers, another value will result in the caller ID being unknown. If the caller is an app user, this option should be omitted.| No
 `eventType` | Set to `synchronous` to: <ul class="Vlt-list Vlt-list--simple"><li>make the `connect` action synchronous</li><li>enable `eventUrl` to return an NCCO that overrides the current NCCO when a call moves to specific states.</li></ul> | No
 `timeout` |  If the call is unanswered, set the number in seconds before Nexmo stops ringing `endpoint`. The default value is `60`.

--- a/_documentation/en/voice/voice-api/ncco-reference.md
+++ b/_documentation/en/voice/voice-api/ncco-reference.md
@@ -135,7 +135,7 @@ You can use the following options to control a `connect` action:
 
 Option | Description | Required
 -- | -- | --
-`endpoint` | Connect to a single endpoint. [Available endpoint types](#endpoint-types-and-values) | Yes
+`endpoint` | Array of `endpoint` objects to connect to with support for a **maximum** of 1 `endpoint` objects. [Available endpoint types](#endpoint-types-and-values) | Yes
 `from` | A number in [E.164](https://en.wikipedia.org/wiki/E.164) format that identifies the caller.§§ This must be one of your Nexmo virtual numbers, another value will result in the caller ID being unknown. If the caller is an app user, this option should be omitted.| No
 `eventType` | Set to `synchronous` to: <ul class="Vlt-list Vlt-list--simple"><li>make the `connect` action synchronous</li><li>enable `eventUrl` to return an NCCO that overrides the current NCCO when a call moves to specific states.</li></ul> | No
 `timeout` |  If the call is unanswered, set the number in seconds before Nexmo stops ringing `endpoint`. The default value is `60`.


### PR DESCRIPTION
## Description

re: #2849 

This explicitly mentions in the `connect` action that an array of 1 `endpoint` object is required.
