### PR TITLE
ASR NCCO and Webhook reference updates

### DIFF
--- a/_documentation/en/voice/voice-api/ncco-reference.md
+++ b/_documentation/en/voice/voice-api/ncco-reference.md
@@ -248,7 +248,7 @@ The following NCCO example shows how to configure an IVR endpoint:
       "maxDigits": 1
     },
     "speech": {
-      "uuid": "aaaaaaaa-bbbb-cccc-dddd-0123456789ab"
+      "uuid": ["aaaaaaaa-bbbb-cccc-dddd-0123456789ab"]
     }
   }
 ]
@@ -272,7 +272,7 @@ The following NCCO example shows how to use `bargeIn` to allow a user to interru
       "maxDigits": 1
     },
     "speech": {
-      "uuid": "aaaaaaaa-bbbb-cccc-dddd-0123456789ab"
+      "uuid": ["aaaaaaaa-bbbb-cccc-dddd-0123456789ab"]
     }
   }
 ]

--- a/_documentation/en/voice/voice-api/ncco-reference.md
+++ b/_documentation/en/voice/voice-api/ncco-reference.md
@@ -282,8 +282,8 @@ The following options can be used to control an `input` action:
 
 Option | Description | Required
 -- | -- | --
-`dtmf` | [DTMF settings](#dtmf-input-settings). Should be specified to enable DTMF input. If all the DTMF input settings will have default values, it should be specified as empty object: `dtmf: { }`. | No
-`speech` | [Speech recognition settings](#speech-recognition-settings). Should be specified to enable speech input. | No
+`dtmf` | [DTMF settings](#dtmf-input-settings). Required if `speech` is not provided. Should be specified to enable DTMF input. If all the DTMF input settings will have default values, it should be specified as empty object: `dtmf: { }`. | No
+`speech` | [Speech recognition settings](#speech-recognition-settings). Required if `dtmf` is not provided. Should be specified to enable speech input. | No
 `eventUrl` | Nexmo sends the digits pressed by the callee to this URL 1) after `timeOut` pause in activity or when *#* is pressed for DTMF or 2) after user stops speaking or `30` seconds of speech for speech input.  | No
 `eventMethod` | The HTTP method used to send event information to `event_url` The default value is `POST`.| No
 

--- a/_documentation/en/voice/voice-api/ncco-reference.md
+++ b/_documentation/en/voice/voice-api/ncco-reference.md
@@ -299,7 +299,7 @@ Option | Description | Required
 
 Option | Description | Required
 -- | -- | --
-`uuid` | The unique ID of the Call leg for the user to capture the speech of. | Yes
+`uuid` | The unique ID of the Call leg for the user to capture the speech of, defined as an array with a single element. | Yes
 `endOnSilence` | Controls how long the system will wait after user stops speaking to decide the input is completed. The default value is `2` (seconds). The range of possible values is between 1 second and 10 seconds. | No
 `language` | Expected language of the user's speech. Format: BCP-47. Default: `en-US`. [List of supported languages](/voice/voice-api/guides/asr#language). | No
 `context` | Array of hints (strings) to improve recognition quality if certain words are expected from the user. | No

--- a/_documentation/en/voice/voice-api/webhook-reference.md
+++ b/_documentation/en/voice/voice-api/webhook-reference.md
@@ -360,5 +360,6 @@ The event endpoint will also receive webhooks in the event of an error. This can
 Field | Example | Description
  -- | -- | --
 `reason` | `Syntax error in NCCO. Invalid value type or action.` | Information about the nature of the error
+`error` | `ERR1: Failed to analyze audio` | This field present for automatic speech recognition
 `conversation_uuid` | `CON-aaaaaaaa-bbbb-cccc-dddd-0123456789ab` | The unique identifier for this conversation
 `timestamp` | `2020-01-01T12:00:00.000Z` | Timestamp (ISO 8601 format)

--- a/_documentation/en/voice/voice-api/webhook-reference.md
+++ b/_documentation/en/voice/voice-api/webhook-reference.md
@@ -308,6 +308,7 @@ Field | Example | Description
 `from` | `447700900000` | The number the call came from
 `to` | `447700900000` | The number the call was made to
 `dtmf` | `42` | The buttons pressed by the user
+`speech` | `sales` | The text spoken by the user, a complete example payload shown in [NCCO Reference](/voice/voice-api/ncco-reference#speech-recognition-settings)
 `timed_out` | `true` | Whether the input action timed out: `true` if it did, `false` if not
 `uuid` | `aaaaaaaa-bbbb-cccc-dddd-0123456789ab` | The unique identifier for this call
 `conversation_uuid` | `CON-aaaaaaaa-bbbb-cccc-dddd-0123456789ab` | The unique identifier for this conversation


### PR DESCRIPTION
* Note that either `speech` or `dtmf` is required in the `input` NCCO action
* Include `speech` in example of fields sent back in event webhook for `input`
