### PR TITLE
link to NCCO guide in ASR doc

### DIFF
--- a/_documentation/en/voice/voice-api/guides/asr.md
+++ b/_documentation/en/voice/voice-api/guides/asr.md
@@ -47,6 +47,8 @@ Typically, ASR is used in conjunction with an audio message playing to the user.
 ]
 ```
 
+The [NCCO Reference Guide](/voice/voice-api/ncco-reference#speech-recognition-settings) contains information on all the possible parameters that can be used in conjunction with the ASR `input` NCCO action.
+
 ### Call ID
 
 ASR action (`input` with `speech`) cannot be executed for the whole conversation; it’s performed against the call (leg), so the call identifier should be explicitly specified in the NCCO as the `speech.uuid` parameter.


### PR DESCRIPTION
## Description

Per conversation brought up on Slack, it was recommended that the ASR guide contain a link to the NCCO reference guide for further information on all the possible options to include in the `speech` `input` NCCO action,
