### PR TITLE
remove extraneous Copy text in copy to clipboard action

### DIFF
--- a/app/webpacker/javascript/code_snippet_events/index.js
+++ b/app/webpacker/javascript/code_snippet_events/index.js
@@ -5,7 +5,7 @@ export default () => {
     // Track copy to clipboard usage
     var clipboard = new Clipboard('.copy-button',{
         text: function(trigger) {
-            return $(trigger).next().text();
+            return $(trigger).next().text().replace('Copy', '');
         }
     });
 

--- a/app/webpacker/javascript/code_snippet_events/index.js
+++ b/app/webpacker/javascript/code_snippet_events/index.js
@@ -5,7 +5,7 @@ export default () => {
     // Track copy to clipboard usage
     var clipboard = new Clipboard('.copy-button',{
         text: function(trigger) {
-            return $(trigger).next().text().replace('Copy', '');
+            return $(trigger).next().find('.main-code').text();
         }
     });
 


### PR DESCRIPTION
## Description

Remove the additional "Copy" word added to each copy to clipboard action
