### PR TITLE
Queuing for Messages API

### DIFF
--- a/_partials/reusable/configure-webhook-urls.md
+++ b/_partials/reusable/configure-webhook-urls.md
@@ -45,9 +45,13 @@ If using Ngrok in this manner you would use the Ngrok URLs for your webhook URLs
 
 ### Callback queue
 
-Please note that callbacks emanating from Nexmo, such as those on your Message Status webhook URL and Inbound Message URL, are queued by Nexmo on a per-account basis, **not** a per-application basis.
+Please note that callbacks emanating from Nexmo, such as those on your Message Status webhook URL and Inbound Message URL, are queued by Nexmo on a per-message basis.
 
-**NOTE:** To avoid callbacks stalling the callback queue, please ensure that all applications acknowledge callbacks with a 200 response. Further, it is advisable to cease activity on a test application 24 hours before deleting it, or removing webhook configuration, otherwise it could potentially leave callbacks in your callback queue that will not be acknowledged, and therefore result in delays on callbacks destined for your production applications.
+Please ensure that all applications acknowledge callbacks with a 200 response.
+
+### Signed webhooks
+
+In order to validate the origin of your webhooks, you can validate the signature of the webhooks, see instructions [here](https://developer.nexmo.com/messages/concepts/signed-webhooks)
 
 ### Webhooks in production use
 

--- a/_partials/reusable/configure-webhook-urls.md
+++ b/_partials/reusable/configure-webhook-urls.md
@@ -43,11 +43,11 @@ If using Ngrok in this manner you would use the Ngrok URLs for your webhook URLs
 * `https://abcdef1.ngrok.io/webhooks/inbound-message`
 * `https://abcdef1.ngrok.io/webhooks/message-status`
 
-### Callback queue
+### Webhook queue
 
-Please note that callbacks emanating from Nexmo, such as those on your Message Status webhook URL and Inbound Message URL, are queued by Nexmo on a per-message basis.
+Please note that webhooks emanating from Nexmo, such as those on your Message Status webhook URL and Inbound Message URL, are queued by Nexmo on a per-message basis.
 
-Please ensure that all applications acknowledge callbacks with a 200 response.
+Please ensure that all applications acknowledge webhooks with a 200 response.
 
 ### Signed webhooks
 

--- a/_tutorials/en/messages-dispatch/configure-webhooks.md
+++ b/_tutorials/en/messages-dispatch/configure-webhooks.md
@@ -12,7 +12,7 @@ When messages status updates are generated, such as `delivered`, `rejected` or `
 
 When an inbound message is received, a callback with message payload is invoked on the _Inbound Message_ webhook URL.
 
-> **IMPORTANT:** Both webhook URLs should be configured. At the very least your webhook handlers should return 200 responses for both Inbound Message and Message Status callbacks. This ensures potential [callback queuing](#callback-queue) issues are avoided.
+> **IMPORTANT:** Both webhook URLs should be configured. At the very least your webhook handlers should return 200 responses for both Inbound Message and Message Status callbacks.
 
 ### To configure the webhook URLs
 
@@ -37,6 +37,10 @@ Messages API does not support inbound SMS message and SMS delivery receipt callb
 
 ### Callback queue
 
-Please note that callbacks emanating from Nexmo, such as those on your Message Status webhook URL and Inbound Message URL, are queued by Nexmo on a per-account basis, **not** a per-application basis.
+Please note that callbacks emanating from Nexmo, such as those on your Message Status webhook URL and Inbound Message URL, are queued by Nexmo on a per-message basis.
 
-To avoid callbacks stalling the callback queue, please ensure that all applications acknowledge callbacks with a 200 response. Further, it is advisable to cease activity on a test application 24 hours before deleting it, or removing webhook configuration, otherwise it could potentially leave callbacks in your callback queue that will not be acknowledged, and therefore result in delays on callbacks destined for your production applications.
+Please ensure that all applications acknowledge callbacks with a 200 response.
+
+### Signed webhooks
+
+In order to validate the origin of your webhooks, you can validate the signature of the webhooks, see instructions [here](https://developer.nexmo.com/messages/concepts/signed-webhooks)

--- a/_tutorials/en/messages-dispatch/configure-webhooks.md
+++ b/_tutorials/en/messages-dispatch/configure-webhooks.md
@@ -35,11 +35,11 @@ Inbound URL | `https://www.example.com/webhooks/inbound-message`
 
 Messages API does not support inbound SMS message and SMS delivery receipt callbacks via the application-specific webhooks described in the previous section. In order to receive callbacks for SMS message and SMS delivery receipts you need to set the [account-level webhooks for SMS](https://dashboard.nexmo.com/settings).
 
-### Callback queue
+### Webhook queue
 
-Please note that callbacks emanating from Nexmo, such as those on your Message Status webhook URL and Inbound Message URL, are queued by Nexmo on a per-message basis.
+Please note that webhooks emanating from Nexmo, such as those on your Message Status webhook URL and Inbound Message URL, are queued by Nexmo on a per-message basis.
 
-Please ensure that all applications acknowledge callbacks with a 200 response.
+Please ensure that all applications acknowledge webhooks with a 200 response.
 
 ### Signed webhooks
 

--- a/_use_cases/en/dispatch-user-fallback.md
+++ b/_use_cases/en/dispatch-user-fallback.md
@@ -85,8 +85,6 @@ Note that the following conditions apply:
 
 The Python source code for this project is available in the Nexmo Community [GitHub repository](https://github.com/nexmo-community/dispatch-user-fallback). Three use cases are actually included in the codebase, but this tutorial only describes `case-2`. The code for `case-2` specifically can be found [here](https://github.com/nexmo-community/dispatch-user-fallback/tree/master/case-2). There are just two files - the sample configuration file, `sample.json` and the application, `app.py`.
 
-> **IMPORTANT:** You should also run a webhook server to ensure that webhooks are acknowledged - this prevents clogging the callback queue with unacknowledged webhook retries. The code for this is given later in this tutorial.
-
 ## Prerequisites
 
 1. [Create a Nexmo Account](https://dashboard.nexmo.com/sign-in)


### PR DESCRIPTION
## Description

Updates the queuing notes to note that messages are now queued on a per-message rather than a per-account basis. 

## Deploy Notes

This PR is dependant on #2848 as it refers to the signed callback doc directly and links to it.