### PR TITLE
Bump nexmo-markdown-renderer.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -129,7 +129,7 @@ gem 'lograge'
 gem 'countries'
 gem 'country_select', '~> 4.0'
 
-gem 'nexmo_markdown_renderer', github: 'nexmo/nexmo-markdown-renderer', branch: 'import-dependencies'
+gem 'nexmo_markdown_renderer', '~> 0.4'
 
 gem 'nexmo-oas-renderer', '~> 0.11', require: false
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,18 +1,4 @@
 GIT
-  remote: https://github.com/nexmo/nexmo-markdown-renderer.git
-  revision: fc5ea768fd62acb498929bb3163675028a1086cb
-  branch: import-dependencies
-  specs:
-    nexmo_markdown_renderer (0.3.1)
-      activemodel (~> 6.0)
-      banzai (~> 0.1.2)
-      i18n (~> 1.7)
-      nokogiri (~> 1.10)
-      octicons_helper (~> 8.2)
-      redcarpet (~> 3.4)
-      rouge (~> 2.0.7)
-
-GIT
   remote: https://github.com/oscardelben/rawler.git
   revision: f2909b135fce7d35167f98026ac481926c94423e
   specs:
@@ -316,6 +302,14 @@ GEM
       sass (~> 3.1)
       shotgun (~> 0.9)
       sinatra (~> 2.0)
+    nexmo_markdown_renderer (0.4.0)
+      activemodel (~> 6.0)
+      banzai (~> 0.1.2)
+      i18n (~> 1.7)
+      nokogiri (~> 1.10)
+      octicons_helper (~> 8.2)
+      redcarpet (~> 3.4)
+      rouge (~> 2.0.7)
     nio4r (2.5.2)
     nokogiri (1.10.9)
       mini_portile2 (~> 2.4.0)
@@ -589,7 +583,7 @@ DEPENDENCIES
   neatjson
   newrelic_rpm
   nexmo-oas-renderer (~> 0.11)
-  nexmo_markdown_renderer!
+  nexmo_markdown_renderer (~> 0.4)
   nokogiri (~> 1.10.9)
   octokit
   pg (~> 1.2)


### PR DESCRIPTION
## Description

Bump renderer, the new version contains:
* kotlin icon
* import dependencies block