### PR TITLE
Enable review apps for forks

### DIFF
--- a/.github/workflows/pull_request-pr-edited.yml
+++ b/.github/workflows/pull_request-pr-edited.yml
@@ -1,5 +1,6 @@
 name: PR Edited
 on:
+  repository_dispatch: {}
   pull_request:
     types: [opened, synchronize, labeled]
 jobs:


### PR DESCRIPTION
## Description

By triggering on `repository_dispatch` secrets are available to the workflow run. This means that we can create review apps for forks

## Deploy Notes

N/A
