### PR TITLE
Add Thai and Yue Chinese to Verify API languages page

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -353,3 +353,4 @@ PushKit
 UserNotifications
 APNs
 Keychain
+Yue

--- a/_documentation/en/verify/guides/verify-languages.md
+++ b/_documentation/en/verify/guides/verify-languages.md
@@ -43,8 +43,10 @@ Value of `lg` | Language
 `ro-ro` | Romanian
 `ru-ru` | Russian
 `sv-se` | Swedish
+`th-tha` | Thai
 `tr-tr` | Turkish
 `vi-vn` | Vietnamese
+`yue-chn` | Yeu Chinese
 `zh-cn` | Chinese (Mainland)
 `zh-tw` | Chinese (Taiwan)
 

--- a/_documentation/en/verify/guides/verify-languages.md
+++ b/_documentation/en/verify/guides/verify-languages.md
@@ -43,10 +43,10 @@ Value of `lg` | Language
 `ro-ro` | Romanian
 `ru-ru` | Russian
 `sv-se` | Swedish
-`th-tha` | Thai
+`th-th` | Thai
 `tr-tr` | Turkish
 `vi-vn` | Vietnamese
-`yue-chn` | Yeu Chinese
+`yue-cn` | Yue Chinese
 `zh-cn` | Chinese (Mainland)
 `zh-tw` | Chinese (Taiwan)
 


### PR DESCRIPTION
## Description

[DEVX-3147] Add new languages to the docs for Verify API - we are in the process of adding Thai and Yue Chinese.

[DEVX-3147]: https://nexmoinc.atlassian.net/browse/DEVX-3147