### PR TITLE
Update android release notes 2.6.4

### DIFF
--- a/_documentation/en/client-sdk/sdk-documentation/android/release-notes.md
+++ b/_documentation/en/client-sdk/sdk-documentation/android/release-notes.md
@@ -10,7 +10,8 @@ navigation_weight: 0
 
 ### New
 
-- We have split our artifacts from this version, so custom maven repository has to be added to the project
+- We have split our artifacts from this version, so custom maven repository has to be added to the project:
+
 ```groovy
     //Groovy - build.gradle
     allprojects {
@@ -22,6 +23,7 @@ navigation_weight: 0
         }
     }
 ```
+
 ```kotlin
     // Kotlin Gradle script  - build.gradle.kts
     allprojects {


### PR DESCRIPTION
## Description

Fixed the markdown style applied to the `nexmo-developer` : 
![image](https://user-images.githubusercontent.com/18151158/86369438-58c9bb80-bc76-11ea-81d9-3d8e66ba2380.png)

