### PR TITLE
Clarify report status values

### DIFF
--- a/_documentation/en/reports/code-snippets/before-you-begin.md
+++ b/_documentation/en/reports/code-snippets/before-you-begin.md
@@ -38,7 +38,7 @@ Variable | Description
 `DATE_START` | Date of time window from when you want to start gathering records in ISO-8601 format.
 `DATE_END` | Date of time window from when you want to stop gathering records in ISO-8601 format.
 `STATUS` | Status of message or call.
-`REPORT_STATUS` | Status of report generation.
+`REPORT_STATUS` | Status of report generation, can be any of `PENDING`, `PROCESSING`, `SUCCESS`, `ABORTED`, `FAILED`, `TRUNCATED`. For [report listing](/reports/code-snippets/list-reports), `status` is passed in as a comma-separated list of report status values.
 
 > In the following examples you can enter the product you want, but please note that some parameters are required for certain products, for example, `CONVERSATIONS` requires `type`.
 

--- a/_documentation/en/reports/code-snippets/list-reports.md
+++ b/_documentation/en/reports/code-snippets/list-reports.md
@@ -15,7 +15,7 @@ Variable | Required | Description
 `NEXMO_API_KEY` | Yes | Your API key which you can obtain from your [Dashboard](https://dashboard.nexmo.com/sign-in).
 `NEXMO_API_SECRET` | Yes | Your API secret which you can obtain from your [Dashboard](https://dashboard.nexmo.com/sign-in).
 `ACCOUNT_ID` | Yes | The API key for the target account. Reports generated, or records retrieved, are for this account.
-`REPORT_STATUS` | Yes | Can be one of `PENDING`, `PROCESSING`, `SUCCESS`, `ABORTED`, `FAILED`, `TRUNCATED`.
+`REPORT_STATUS` | Yes | A comma-separated list of report status values. Reports with any of the statuses specified are returned. The values in the comma-separated list specified for `status` can be any of `PENDING`, `PROCESSING`, `SUCCESS`, `ABORTED`, `FAILED`, `TRUNCATED`.
 
 If you don't specify a date range, you receive the reports generated over the previous seven days.
 


### PR DESCRIPTION
## Description

This PR clarifies that report status (the input) can be a comma-separated list of values. 

## Review

- [ ] [Page to review](https://nexmo-develo-tony-repor-gkczod.herokuapp.com/reports/code-snippets/before-you-begin)
- [ ] [Page to review](https://nexmo-develo-tony-repor-gkczod.herokuapp.com/reports/code-snippets/list-reports)
