### PR TITLE
DEVX-3295 Remove Websocketa Beta label

### DIFF
--- a/_documentation/en/voice/voice-api/guides/websockets.md
+++ b/_documentation/en/voice/voice-api/guides/websockets.md
@@ -4,7 +4,7 @@ description: You can connect the audio of a call to a websocket to work with it 
 navigation_weight: 7
 ---
 
-# WebSockets [Beta]
+# WebSockets
 
 This guide introduces you to WebSockets and how and why you might want to use them in your Nexmo Voice API applications.
 

--- a/config/navigation.yml
+++ b/config/navigation.yml
@@ -87,7 +87,6 @@ navigation_overrides:
     voice-api:
       guides:
         websockets:
-          label: 'Beta'
         asr:
           label: 'Beta'
   verify:


### PR DESCRIPTION
## Description

Per the request documented in DEVX-3295 this PR removes the `Beta` label from the Websockets documentation.
