### PR TITLE
Add Node.js Message API snippets

### DIFF
--- a/_examples/messages/messenger/send-audio/node.yml
+++ b/_examples/messages/messenger/send-audio/node.yml
@@ -1,0 +1,7 @@
+---
+dependencies:
+    - nexmo@beta
+code:
+    source: .repos/nexmo/nexmo-node-code-snippets/messages/messenger/send-audio.js
+    from_line: 14
+    to_line: 46

--- a/_examples/messages/messenger/send-file/node.yml
+++ b/_examples/messages/messenger/send-file/node.yml
@@ -1,0 +1,7 @@
+---
+dependencies:
+    - nexmo@beta
+code:
+    source: .repos/nexmo/nexmo-node-code-snippets/messages/messenger/send-file.js
+    from_line: 14
+    to_line: 46

--- a/_examples/messages/messenger/send-image/node.yml
+++ b/_examples/messages/messenger/send-image/node.yml
@@ -1,0 +1,7 @@
+---
+dependencies:
+    - nexmo@beta
+code:
+    source: .repos/nexmo/nexmo-node-code-snippets/messages/messenger/send-image.js
+    from_line: 14
+    to_line: 46

--- a/_examples/messages/messenger/send-template/node.yml
+++ b/_examples/messages/messenger/send-template/node.yml
@@ -1,0 +1,7 @@
+---
+dependencies:
+    - nexmo@beta
+code:
+    source: .repos/nexmo/nexmo-node-code-snippets/messages/messenger/send-template.js
+    from_line: 16
+    to_line: 111

--- a/_examples/messages/messenger/send-text/node.yml
+++ b/_examples/messages/messenger/send-text/node.yml
@@ -3,5 +3,5 @@ dependencies:
     - nexmo@beta
 code:
     source: .repos/nexmo/nexmo-node-code-snippets/messages/messenger/send-text.js
-    from_line: 12
-    to_line: 39
+    from_line: 13
+    to_line: 44

--- a/_examples/messages/messenger/send-video/node.yml
+++ b/_examples/messages/messenger/send-video/node.yml
@@ -1,0 +1,7 @@
+---
+dependencies:
+    - nexmo@beta
+code:
+    source: .repos/nexmo/nexmo-node-code-snippets/messages/messenger/send-video.js
+    from_line: 14
+    to_line: 46

--- a/_examples/messages/viber/send-image/node.yml
+++ b/_examples/messages/viber/send-image/node.yml
@@ -1,0 +1,7 @@
+---
+dependencies:
+    - nexmo@beta
+code:
+    source: .repos/nexmo/nexmo-node-code-snippets/messages/viber/send-image.js
+    from_line: 14
+    to_line: 46

--- a/_examples/messages/whatsapp/send-audio/node.yml
+++ b/_examples/messages/whatsapp/send-audio/node.yml
@@ -1,0 +1,7 @@
+---
+dependencies:
+    - nexmo@beta
+code:
+    source: .repos/nexmo/nexmo-node-code-snippets/messages/whatsapp/send-audio.js
+    from_line: 14
+    to_line: 46

--- a/_examples/messages/whatsapp/send-button-link/node.yml
+++ b/_examples/messages/whatsapp/send-button-link/node.yml
@@ -1,0 +1,7 @@
+---
+dependencies:
+    - nexmo@beta
+code:
+    source: .repos/nexmo/nexmo-node-code-snippets/messages/whatsapp/send-link-button.js
+    from_line: 16
+    to_line: 101

--- a/_examples/messages/whatsapp/send-button-quick-reply/node.yml
+++ b/_examples/messages/whatsapp/send-button-quick-reply/node.yml
@@ -1,0 +1,7 @@
+---
+dependencies:
+    - nexmo@beta
+code:
+    source: .repos/nexmo/nexmo-node-code-snippets/messages/whatsapp/send-quick-reply-button.js
+    from_line: 15
+    to_line: 105

--- a/_examples/messages/whatsapp/send-contact/node.yml
+++ b/_examples/messages/whatsapp/send-contact/node.yml
@@ -1,0 +1,7 @@
+---
+dependencies:
+    - nexmo@beta
+code:
+    source: .repos/nexmo/nexmo-node-code-snippets/messages/whatsapp/send-contact.js
+    from_line: 13
+    to_line: 107

--- a/_examples/messages/whatsapp/send-file/node.yml
+++ b/_examples/messages/whatsapp/send-file/node.yml
@@ -1,0 +1,7 @@
+---
+dependencies:
+    - nexmo@beta
+code:
+    source: .repos/nexmo/nexmo-node-code-snippets/messages/whatsapp/send-file.js
+    from_line: 15
+    to_line: 49

--- a/_examples/messages/whatsapp/send-file/node.yml
+++ b/_examples/messages/whatsapp/send-file/node.yml
@@ -1,7 +1,7 @@
 ---
 dependencies:
-    - nexmo@beta
+  - nexmo@beta
 code:
-    source: .repos/nexmo/nexmo-node-code-snippets/messages/whatsapp/send-file.js
-    from_line: 15
-    to_line: 49
+  source: .repos/nexmo/nexmo-node-code-snippets/messages/whatsapp/send-file.js
+  from_line: 15
+  to_line: 48

--- a/_examples/messages/whatsapp/send-image/node.yml
+++ b/_examples/messages/whatsapp/send-image/node.yml
@@ -1,0 +1,7 @@
+---
+dependencies:
+    - nexmo@beta
+code:
+    source: .repos/nexmo/nexmo-node-code-snippets/messages/whatsapp/send-image.js
+    from_line: 14
+    to_line: 46

--- a/_examples/messages/whatsapp/send-location/node.yml
+++ b/_examples/messages/whatsapp/send-location/node.yml
@@ -1,0 +1,7 @@
+---
+dependencies:
+    - nexmo@beta
+code:
+    source: .repos/nexmo/nexmo-node-code-snippets/messages/whatsapp/send-location.js
+    from_line: 13
+    to_line: 51

--- a/_examples/messages/whatsapp/send-media-mtm/node.yml
+++ b/_examples/messages/whatsapp/send-media-mtm/node.yml
@@ -1,0 +1,7 @@
+---
+dependencies:
+    - nexmo@beta
+code:
+    source: .repos/nexmo/nexmo-node-code-snippets/messages/whatsapp/send-media-template.js
+    from_line: 15
+    to_line: 88

--- a/_examples/messages/whatsapp/send-mtm/node.yml
+++ b/_examples/messages/whatsapp/send-mtm/node.yml
@@ -1,0 +1,7 @@
+---
+dependencies:
+    - nexmo@beta
+code:
+    source: .repos/nexmo/nexmo-node-code-snippets/messages/whatsapp/send-template.js
+    from_line: 15
+    to_line: 62

--- a/_examples/messages/whatsapp/send-video/node.yml
+++ b/_examples/messages/whatsapp/send-video/node.yml
@@ -1,0 +1,7 @@
+---
+dependencies:
+    - nexmo@beta
+code:
+    source: .repos/nexmo/nexmo-node-code-snippets/messages/whatsapp/send-video.js
+    from_line: 14
+    to_line: 46


### PR DESCRIPTION
Adding new Node snippets for Messages API. The specs are [here](https://github.com/Nexmo/code-snippet-specs/tree/master/olympus/messages).

Ticket: [DEVX-1787](https://nexmoinc.atlassian.net/browse/DEVX-1787)

**Facebook**

- [x] Send an Image Message
- [x] Send a Video Message
- [x] Send an Audio Message
- [x] Send a Message Template
- [x] Send a File Message


**WhatsApp**

- [x] Send a Message Template (MTM)
- [x] Send a Media Message Template
- [x] Send an Image Message
- [x] Send a Contact
- [x] Send a Video Message
- [x] Send a Link Button
- [x] Send a Location
- [x] Send an Audio Message
- [x] Send a Quick Reply Button
- [x] Send a File Message


**Viber**

- [x] Send an Image Message