### PR TITLE
Add Beta badge to Audit API

### DIFF
--- a/custom/landing_pages/api.yml
+++ b/custom/landing_pages/api.yml
@@ -146,3 +146,6 @@ page:
                   - title: 'Audit API'
                     path: 'api/audit'
                     description: 'Get an audit trail of changes to your account for security and compliance purposes.'
+                    badge:
+                      name: Beta
+                      color: green


### PR DESCRIPTION
## Description

Adds Beta badge to Audit API on API landing page.

## Review 

* [Page to review](https://nexmo-developer-pr-3010.herokuapp.com/api) - Audit should have green Beta badge. 