### PR TITLE
Fixing broken code snippet

### DIFF
--- a/_examples/concepts/sample-code-snippet/csharp.yml
+++ b/_examples/concepts/sample-code-snippet/csharp.yml
@@ -4,13 +4,13 @@ language: dotnet
 dependencies:
     - Nexmo.Csharp.Client
 client:
-    source: .repos/nexmo/nexmo-dotnet-code-snippets/NexmoDotNetQuickStarts/Authentication/BasicAuth.cs
-    from_line: 13
-    to_line: 17
+    source: .repos/nexmo/nexmo-dotnet-code-snippets/DotNetCliCodeSnippets/Messaging/SendSms.cs
+    from_line: 18
+    to_line: 23
 code:
-    source: .repos/nexmo/nexmo-dotnet-code-snippets/NexmoDotNetQuickStarts/Controllers/SMSController.cs
-    from_line: 38
-    to_line: 51
+    source: .repos/nexmo/nexmo-dotnet-code-snippets/DotNetCliCodeSnippets/Messaging/SendSms.cs
+    from_line: 25
+    to_line: 30
 run_command: 'Run using your IDE'
 file_name: SMSController.cs
 unindent: true 


### PR DESCRIPTION
## Description

When the Code snippets moved over to 5.0 this one was left behind breaking [the sample code snippet page](https://developer.nexmo.com/contribute/code-snippets/sample-code-snippet) as those paths no longer exist in the dotnet code snippet repository.
