### PR TITLE
Fix reference to /verify/guides/workflows-and-events.

### DIFF
--- a/_documentation/en/verify/overview.md
+++ b/_documentation/en/verify/overview.md
@@ -29,7 +29,7 @@ Verification is a two-stage process that requires two API calls:
   
     > It is possible to supply your own PIN code in some circumstances, please contact your account manager.
     
-4. The Verify API then attempts to deliver this PIN to the user. The format (SMS or Text-to-speech (TTS)) and timing of these attempts are defined by your chosen [workflow](verify/guides/workflows-and-event).
+4. The Verify API then attempts to deliver this PIN to the user. The format (SMS or Text-to-speech (TTS)) and timing of these attempts are defined by your chosen [workflow](/verify/guides/workflows-and-events).
     If the user does not revisit your app or website to enter the PIN they have received, the verification request will ultimately time out. Otherwise, you need to verify the number that they entered using by performing a Verification check.
 
 ### Verification check


### PR DESCRIPTION
## Description

In https://nexmo-developer-pr-3070.herokuapp.com/verify/overview
The link highlighted in the picture was pointing to `https://developer.nexmo.com/verify/verify/guides/workflows-and-event` which returns `404`

<img width="1306" alt="Screenshot 2020-07-29 at 12 34 26" src="https://user-images.githubusercontent.com/715229/88790150-03f76300-d198-11ea-9ec9-28760ac0e6ca.png">

