### PR TITLE
Update iOS SDK v2.2.2 release notes

### DIFF
--- a/_documentation/en/client-sdk/sdk-documentation/ios/release-notes.md
+++ b/_documentation/en/client-sdk/sdk-documentation/ios/release-notes.md
@@ -6,6 +6,12 @@ navigation_weight: 0
 
 # Release Notes
 
+## 2.2.2 - 2020-07-20
+
+### Fixed
+
+- Event syncing after socket disconnection.
+
 ## 2.2.1 - 2020-07-06
 
 ### Fixed


### PR DESCRIPTION
iOS SDK v2.2.2 notes added to `release-notes.md`.