### PR TITLE
Update iOS SDK v2.3.0 release notes

### DIFF
--- a/_documentation/en/client-sdk/sdk-documentation/ios/release-notes.md
+++ b/_documentation/en/client-sdk/sdk-documentation/ios/release-notes.md
@@ -6,6 +6,16 @@ navigation_weight: 0
 
 # Release Notes
 
+## 2.3.0 - 2020-08-17
+
+### Added
+
+- `[NXMClientConfig AMS]` static method.
+
+### Fixed
+
+- Custom events parsing.
+
 ## 2.2.2 - 2020-07-20
 
 ### Fixed


### PR DESCRIPTION
iOS SDK v2.3.0 notes added to `release-notes.md`.