### PR TITLE
Adds tabs to include instructions for both npm and CDN options

### DIFF
--- a/_documentation/en/client-sdk/setup/add-sdk-to-your-app/javascript.md
+++ b/_documentation/en/client-sdk/setup/add-sdk-to-your-app/javascript.md
@@ -21,7 +21,7 @@ Open your terminal. If you have an existing app, navigate to its root. Otherwise
 npm init -y
 ```
 
-### Get the Client SDK into your project
+### Add the Client SDK to your project
 
 ```tabbed_content
 source: '_tutorials_tabbed_content/client-sdk/setup/add-sdk/javascript'

--- a/_documentation/en/client-sdk/setup/add-sdk-to-your-app/javascript.md
+++ b/_documentation/en/client-sdk/setup/add-sdk-to-your-app/javascript.md
@@ -21,29 +21,11 @@ Open your terminal. If you have an existing app, navigate to its root. Otherwise
 npm init -y
 ```
 
-### Install the Client SDK package
+### Get the Client SDK into your project
 
-Install the Client SDK using `npm`:
-
-```
-npm install nexmo-client -s
-```
-
-### Import the Client SDK into your code
-
-If your application is using ES6 module syntax, you can import the client module near the top of your application code:
-
-```
-import NexmoClient from 'nexmo-client';
-```
-
-If your application will run on a single page, you can load the module in your HTML using a script tag:
-
-```
-<script src="./node_modules/nexmo-client/dist/nexmoClient.js"></script>
-```
-
-Be sure to check that the path to `nexmoClient.js` is correct for your project structure.
+```tabbed_content
+source: '_tutorials_tabbed_content/client-sdk/setup/add-sdk/javascript'
+``` 
 
 ## Using the Client SDK in your app
 

--- a/_tutorials_tabbed_content/client-sdk/setup/add-sdk/javascript/cdn.md
+++ b/_tutorials_tabbed_content/client-sdk/setup/add-sdk/javascript/cdn.md
@@ -1,5 +1,5 @@
 ---
-title: via CDN
+title: Using CDN
 ---
 
 ### Load the Client SDK package
@@ -8,7 +8,7 @@ Load the Client SDK from a Content Delivery Network (CDN):
 
 Inside the `<head>` of your HTML file, add:
 
-```
+```html
 <!-- ******* Load nexmoClient from a CDN ****** -->
 <script type="module" src="https://unpkg.com/nexmo-client@latest/dist/nexmoClient.js?module"></script>
 ```

--- a/_tutorials_tabbed_content/client-sdk/setup/add-sdk/javascript/cdn.md
+++ b/_tutorials_tabbed_content/client-sdk/setup/add-sdk/javascript/cdn.md
@@ -1,0 +1,24 @@
+---
+title: via CDN
+---
+
+### Load the Client SDK package
+
+Load the Client SDK from a Content Delivery Network (CDN):
+
+Inside the `<head>` of your HTML file, add:
+
+```
+<!-- ******* Load nexmoClient from a CDN ****** -->
+<script type="module" src="https://unpkg.com/nexmo-client@latest/dist/nexmoClient.js?module"></script>
+```
+
+### Import the Client SDK into your code
+
+Near the top of your application code, add:
+
+```javascript
+//********* Get a reference to NexmoClient **********
+const NexmoClient = window.NexmoClient;
+```
+

--- a/_tutorials_tabbed_content/client-sdk/setup/add-sdk/javascript/cdn.md
+++ b/_tutorials_tabbed_content/client-sdk/setup/add-sdk/javascript/cdn.md
@@ -13,7 +13,7 @@ Inside the `<head>` of your HTML file, add:
 <script type="module" src="https://unpkg.com/nexmo-client@latest/dist/nexmoClient.js?module"></script>
 ```
 
-### Import the Client SDK into your code
+### Add the Client SDK into your code
 
 Near the top of your application code, add:
 

--- a/_tutorials_tabbed_content/client-sdk/setup/add-sdk/javascript/npm.md
+++ b/_tutorials_tabbed_content/client-sdk/setup/add-sdk/javascript/npm.md
@@ -1,0 +1,28 @@
+---
+title: via npm
+---
+
+### Install the Client SDK package
+
+Install the Client SDK using `npm`:
+
+```
+npm install nexmo-client -s
+```
+
+### Import the Client SDK into your code
+
+If your application is using ES6 module syntax, you can import the client module near the top of your application code:
+
+```
+import NexmoClient from 'nexmo-client';
+```
+
+If your application will run on a single page, you can load the module in your HTML using a script tag:
+
+```
+<script src="./node_modules/nexmo-client/dist/nexmoClient.js"></script>
+```
+
+Be sure to check that the path to `nexmoClient.js` is correct for your project structure.
+

--- a/_tutorials_tabbed_content/client-sdk/setup/add-sdk/javascript/npm.md
+++ b/_tutorials_tabbed_content/client-sdk/setup/add-sdk/javascript/npm.md
@@ -1,12 +1,12 @@
 ---
-title: via npm
+title: Using npm
 ---
 
 ### Install the Client SDK package
 
 Install the Client SDK using `npm`:
 
-```
+```shell
 npm install nexmo-client -s
 ```
 
@@ -14,13 +14,13 @@ npm install nexmo-client -s
 
 If your application is using ES6 module syntax, you can import the client module near the top of your application code:
 
-```
+```javascript
 import NexmoClient from 'nexmo-client';
 ```
 
 If your application will run on a single page, you can load the module in your HTML using a script tag:
 
-```
+```html
 <script src="./node_modules/nexmo-client/dist/nexmoClient.js"></script>
 ```
 


### PR DESCRIPTION
## Description

This pull request adds tabs to https://developer.nexmo.com/client-sdk/setup/add-sdk-to-your-app/javascript to include instructions for both options of getting the Client SDK into a project.

I have an example of using a CDN working here: https://glitch.com/edit/#!/royal-patch-dancer?path=public%2Fscript.js%3A6%3A39

I'm flexible on the text so I defer to your expertise. Hopefully, it makes sense.

Thanks.

## Deploy Notes

Notes regarding deployment the contained body of work. These should note any db migrations, etc.
