### PR TITLE
phone to app objc tutorial

### DIFF
--- a/_tutorials/en/client-sdk/phone-to-app/call/objective_c.md
+++ b/_tutorials/en/client-sdk/phone-to-app/call/objective_c.md
@@ -1,0 +1,52 @@
+---
+title: Receive a call
+description: In this step you will receive the call.
+---
+
+# Receive a call
+
+At the top of the `ViewController` class, just below the `client` declaration, add a `NXMCall` property to hold a reference to any call in progress.
+
+```objective_c
+ @interface ViewController () <NXMClientDelegate>
+ ...
+ @property NXMCall * call;
+ @end
+ ```
+
+When the application receives a call we want to give the option to accept or reject the call. To do this add the `displayIncomingCallAlert` function to the `ViewController` class.
+
+```objective_c
+- (void)displayIncomingCallAlert:(NXMCall *)call {
+    NSString *from = call.otherCallMembers.firstObject.channel.from.data;
+    
+    UIAlertController *alert = [UIAlertController alertControllerWithTitle:@"Incoming call from" message:from preferredStyle:UIAlertControllerStyleAlert];
+    [alert addAction:[UIAlertAction actionWithTitle:@"Answer" style:UIAlertActionStyleDefault handler:^(UIAlertAction * _Nonnull action) {
+        self.call = call;
+        [call answer:nil];
+    }]];
+    [alert addAction:[UIAlertAction actionWithTitle:@"Reject" style:UIAlertActionStyleCancel handler:^(UIAlertAction * _Nonnull action) {
+        [call reject:nil];
+    }]];
+    
+    [self presentViewController:alert animated:YES completion:nil];
+}
+```
+The `displayIncomingCallAlert` function takes a `NXMCall` as a parameter, with this we can access the members, which are the type `NXMCallMember`, of the call to retrieve the phone number of the incoming call. Note in the `UIAlertAction` for answering the call we assign the call to the property from earlier.
+
+To use `displayIncomingCallAlert` you need to use the `NXMClientDelegate` which has a function that will be called when the client receives an incoming `NXMCall`.
+
+```objective_c
+- (void)client:(NXMClient *)client didReceiveCall:(NXMCall *)call {
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [self displayIncomingCallAlert:call];
+    });
+}
+```
+
+## Build and Run
+
+Press `Cmd + R` to build and run again, when you call the number linked with your application from earlier you will be presented with an alert. You can pick up and the call will be connected!
+
+![Incoming call alert](/meta/client-sdk/ios-phone-to-app/alert.png)
+

--- a/_tutorials/en/client-sdk/phone-to-app/call/swift.md
+++ b/_tutorials/en/client-sdk/phone-to-app/call/swift.md
@@ -5,7 +5,7 @@ description: In this step you will receive the call.
 
 # Receive a call
 
-At the top of the `ViewController` class, just below the `client` declaration, add a `NXMCall` property to hold a reference to any call in progress:
+At the top of the `ViewController` class, just below the `client` declaration, add a `NXMCall` property to hold a reference to any call in progress.
 
 ```swift
 class ViewController: UIViewController {
@@ -16,7 +16,7 @@ class ViewController: UIViewController {
 }
 ```
 
-When the application receives a call we want to give the option to accept or reject the call. To do this add the `displayIncomingCallAlert` function to the `ViewController` class:
+When the application receives a call we want to give the option to accept or reject the call. To do this add the `displayIncomingCallAlert` function to the `ViewController` class.
 
 ```swift
 class ViewController: UIViewController {
@@ -43,7 +43,7 @@ class ViewController: UIViewController {
 ```
 The `displayIncomingCallAlert` function takes a `NXMCall` as a parameter, with this we can access the members, which are the type `NXMCallMember`, of the call to retrieve the phone number of the incoming call. Note in the `UIAlertAction` for answering the call we assign the call to the property from earlier.
 
-To use `displayIncomingCallAlert` you need to use the `NXMClientDelegate` which has a function that will be called when the client receives an incoming `NXMCall`:
+To use `displayIncomingCallAlert` you need to use the `NXMClientDelegate` which has a function that will be called when the client receives an incoming `NXMCall`.
 
 ```swift
 extension ViewController: NXMClientDelegate {
@@ -58,7 +58,7 @@ extension ViewController: NXMClientDelegate {
 
 ## Build and Run
 
-`Cmd + R` to build and run again, when you call the number linked with your application from earlier you will be presented with an alert. You can pick up and the call will be connected!
+Press `Cmd + R` to build and run again, when you call the number linked with your application from earlier you will be presented with an alert. You can pick up and the call will be connected!
 
 ![Incoming call alert](/meta/client-sdk/ios-phone-to-app/alert.png)
 

--- a/_tutorials/en/client-sdk/phone-to-app/client/objective_c.md
+++ b/_tutorials/en/client-sdk/phone-to-app/client/objective_c.md
@@ -14,7 +14,7 @@ At the top of the file, import `NexmoClient`.
 #import <NexmoClient/NexmoClient.h>
 ```
 
-Add a `NXMClient` instance and conformance to the `NXMCallDelegate` to the interface .
+Add a `NXMClient` instance and conformance to the `NXMClientDelegate` to the interface .
 
 ```objective_c
 @interface ViewController () <NXMClientDelegate>

--- a/_tutorials/en/client-sdk/phone-to-app/client/objective_c.md
+++ b/_tutorials/en/client-sdk/phone-to-app/client/objective_c.md
@@ -1,0 +1,74 @@
+---
+title: NXMClient
+description: In this step you will authenticate to the Vonage servers.
+---
+
+# `NXMClient`
+
+Before you can place a call, the Client SDK needs to authenticate to the Vonage servers. The following additions are required to `ViewController.m`.
+
+At the top of the file, import `NexmoClient`.
+
+```objective_c
+#import "ViewController.h"
+#import <NexmoClient/NexmoClient.h>
+```
+
+Add a `NXMClient` instance and conformance to the `NXMCallDelegate` to the interface .
+
+```objective_c
+@interface ViewController () <NXMClientDelegate>
+...
+@property NXMClient *client;
+@end
+```
+
+## Add the JWT
+
+At the end of `viewDidLoad`, set the client delegate and log in - please make sure to replace `ALICE_JWT` for the `JWT` you created during a previous step. Please remember, the expiry time for the token was set to 6 hours so you will need to generate a new one if it is too old.
+
+```objective_c
+- (void)viewDidLoad {
+    ...
+    
+    self.client = NXMClient.shared;
+    [self.client setDelegate:self];
+    [self.client loginWithAuthToken:@"ALICE_JWT"];
+}
+```
+
+## The Client Delegate
+
+For the delegate to work, you need to have `ViewController` conform to `NXMClientDelegate`. Add these two delegate functions to the class.
+
+```objective_c
+- (void)client:(nonnull NXMClient *)client didChangeConnectionStatus:(NXMConnectionStatus)status reason:(NXMConnectionStatusReason)reason {
+    dispatch_async(dispatch_get_main_queue(), ^{
+        switch (status) {
+            case NXMConnectionStatusConnected:
+                self.connectionStatusLabel.text = @"Connected";
+                break;
+            case NXMConnectionStatusConnecting:
+                self.connectionStatusLabel.text = @"Connecting";
+                break;
+            case NXMConnectionStatusDisconnected:
+                self.connectionStatusLabel.text = @"Disconnected";
+                break;
+        }
+    });
+}
+
+- (void)client:(nonnull NXMClient *)client didReceiveError:(nonnull NSError *)error {
+    dispatch_async(dispatch_get_main_queue(), ^{
+        self.connectionStatusLabel.text = error.localizedDescription;
+    });
+}
+```
+
+An error is shown if encountered and the `connectionStatusLabel` is updated with the relevant connection status. 
+
+## Build and Run
+
+Press `Cmd + R` to build and run again:
+
+![Interface connected](/meta/client-sdk/ios-phone-to-app/interface-connected.png)

--- a/_tutorials/en/client-sdk/phone-to-app/client/swift.md
+++ b/_tutorials/en/client-sdk/phone-to-app/client/swift.md
@@ -5,18 +5,16 @@ description: In this step you will authenticate to the Vonage servers.
 
 # `NXMClient`
 
-Before you can place a call, the Client SDK needs to authenticate to the Vonage servers. 
+Before you can place a call, the Client SDK needs to authenticate to the Vonage servers. The following additions are required to `ViewController.swift`.
 
-The following additions are required to `ViewController.swift`:
-
-At the top of the file, import `NexmoClient`:
+At the top of the file, import `NexmoClient`.
 
 ```swift
 import UIKit
 import NexmoClient
 ```
 
-Add a `NXMClient` instance, below the `connectionStatusLabel`:
+Add a `NXMClient` instance, below the `connectionStatusLabel`.
 
 ```swift
 class ViewController: UIViewController {
@@ -41,7 +39,7 @@ override func viewDidLoad() {
 
 ## The Client Delegate
 
-For the delegate to work, you need to have `ViewController` conform to `NXMClientDelegate`. At the end of the file, add:
+For the delegate to work, you need to have `ViewController` conform to `NXMClientDelegate`. Add the extension the end of the file.
 
 ```swift
 extension ViewController: NXMClientDelegate {
@@ -70,6 +68,6 @@ An error is shown if encountered and the `connectionStatusLabel` is updated with
 
 ## Build and Run
 
-`Cmd + R` to build and run again:
+Press `Cmd + R` to build and run again:
 
 ![Interface connected](/meta/client-sdk/ios-phone-to-app/interface-connected.png)

--- a/_tutorials/en/client-sdk/phone-to-app/interface/objective_c.md
+++ b/_tutorials/en/client-sdk/phone-to-app/interface/objective_c.md
@@ -1,0 +1,40 @@
+---
+title: Building the interface
+description: In this step you will build the only screen of the app.
+---
+
+# Building the interface
+
+To be able view the connection status of the app you will need to add a `UILabel` element to the screen. Open `ViewController.swift` and add it programmatically.
+
+```objective_c
+@interface ViewController ()
+@property UILabel *connectionStatusLabel;
+@end
+
+@implementation ViewController
+
+- (void)viewDidLoad {
+    [super viewDidLoad];
+    
+    self.connectionStatusLabel = [[UILabel alloc] init];
+    self.connectionStatusLabel.text = @"Unknown";
+    self.connectionStatusLabel.textAlignment = NSTextAlignmentCenter;
+    self.connectionStatusLabel.translatesAutoresizingMaskIntoConstraints = NO;
+    [self.view addSubview:self.connectionStatusLabel];
+    
+    [NSLayoutConstraint activateConstraints:@[
+        [self.connectionStatusLabel.topAnchor constraintEqualToAnchor:self.view.safeAreaLayoutGuide.topAnchor constant:20],
+        [self.connectionStatusLabel.leadingAnchor constraintEqualToAnchor:self.view.leadingAnchor constant:20],
+        [self.connectionStatusLabel.trailingAnchor constraintEqualToAnchor:self.view.trailingAnchor constant:-20]
+    ]];
+}
+
+@end
+```
+
+## Build and Run
+
+Run the project again (`Cmd + R`) to launch it in the simulator. 
+
+![Interface](/meta/client-sdk/ios-phone-to-app/interface.png)

--- a/_tutorials/en/client-sdk/phone-to-app/interface/swift.md
+++ b/_tutorials/en/client-sdk/phone-to-app/interface/swift.md
@@ -5,9 +5,7 @@ description: In this step you will build the only screen of the app.
 
 # Building the interface
 
-To be able view the connection status of the app you will need to add a `UILabel` element to the screen.
-
-Open `ViewController.swift` and add it programmatically:
+To be able view the connection status of the app you will need to add a `UILabel` element to the screen. Open `ViewController.swift` and add it programmatically.
 
 ```swift
 class ViewController: UIViewController {

--- a/_tutorials/en/client-sdk/phone-to-app/permissions/objective_c.md
+++ b/_tutorials/en/client-sdk/phone-to-app/permissions/objective_c.md
@@ -23,22 +23,22 @@ Your `Info.plist` should look like this:
 
 ## Request permission on application start
 
-Open `AppDelegate.swift` and import the `AVFoundation` library right after where `UIKit` is included:
+Open `AppDelegate.h` and import the `AVFoundation` library right after where `UIKit` is included:
 
-```swift
-import UIKit
-import AVFoundation
+```objective_c
+#import <UIKit/UIKit.h>
+#import <AVFoundation/AVFoundation.h>
 ```
 
-Next, call `requestRecordPermission:` inside `application:didFinishLaunchingWithOptions:`:
+Next, call `requestRecordPermission:` inside `application:didFinishLaunchingWithOptions:` within `AppDelegate.m`:
 
-``` swift
-func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+```objective_c
+- (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
     // Override point for customization after application launch.
-    AVAudioSession.sharedInstance().requestRecordPermission { (granted:Bool) in
-        NSLog("Allow microphone use. Response: %d", granted)
-    }
-    return true
+    [AVAudioSession.sharedInstance requestRecordPermission:^(BOOL granted) {
+        NSLog(@"Allow microphone use. Response: %d", granted);
+    }];
+    return YES;
 }
 ```
 

--- a/_tutorials/en/client-sdk/phone-to-app/permissions/swift.md
+++ b/_tutorials/en/client-sdk/phone-to-app/permissions/swift.md
@@ -1,0 +1,51 @@
+---
+title: Project permissions
+description: In this step you will add the necessary permissions to the project properties.
+---
+
+# Project permissions
+
+As you'll be using the microphone when making a call, you need to request the permission to use it.
+
+## `Info.plist`
+
+Every Xcode project contains an `Info.plist` file containing all the metadata required in each app or bundle  - you will find the file inside the `PhoneToApp` group.
+
+A new entry in the `Info.plist` file is required:
+
+1. Hover your mouse over the last entry in the list and click the little `+` button that appears.
+
+2. From the dropdown list, pick `Privacy - Microphone Usage Description` and add `Microphone access required in order to make and receive audio calls.` for its value.
+
+Your `Info.plist` should look like this:
+
+![Info.plist](/meta/client-sdk/ios-phone-to-app/info-plist.png)
+
+## Request permission on application start
+
+Open `AppDelegate.swift` and import the `AVFoundation` library right after where `UIKit` is included.
+
+```swift
+import UIKit
+import AVFoundation
+```
+
+Next, call `requestRecordPermission:` inside `application:didFinishLaunchingWithOptions:`:
+
+``` swift
+func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+    // Override point for customization after application launch.
+    AVAudioSession.sharedInstance().requestRecordPermission { (granted:Bool) in
+        NSLog("Allow microphone use. Response: %d", granted)
+    }
+    return true
+}
+```
+
+## Build and Run
+
+You can now build and run the project, by either selecting `Product` > `Run` from the top menu, or pressing `Cmd + R`, and launch it in the simulator. 
+
+Notice the prompt asking for permission to use the microphone:
+
+![Simulator microphone permission ask](/meta/client-sdk/ios-phone-to-app/permissions.png)

--- a/_tutorials/en/client-sdk/phone-to-app/project/objective_c.md
+++ b/_tutorials/en/client-sdk/phone-to-app/project/objective_c.md
@@ -1,0 +1,103 @@
+---
+title: Xcode Project and Workspace
+description: In this step you create an Xcode project and add the iOS Client SDK library.
+---
+
+# Xcode Project & Workspace
+
+You will be using the iOS Client SDK library inside an Xcode project you'll create..
+
+## Create an Xcode Project
+
+* Open Xcode and, from the menu, select `File` > `New` > `Project...`.
+
+* Select a `Single View App` for the Application type and click `Next`.
+
+* For the `Product Name` type in `PhoneToApp`, select the relevant `Team` and `Organisation Identifier`.
+
+* User `Objective-C` for `Language` and `Storyboard` for `User Interface`. Click `Next`.
+
+* Select the `Desktop` as the place where your project folder will reside. You can select a different location but please make sure to remember it as you'll need to navigate to it soon from the `Terminal`.
+
+* You now have a brand new Xcode Project.
+
+
+**Before continuing, please close the new project you've just created.**
+
+You will add the iOS Client SDK library to your project via [CocoaPods](https://cocoapods.org/).
+
+## Install CocoaPods
+
+* Open the `Terminal` app and navigate to the project folder by typing.
+
+``` shell
+cd ~/Desktop/PhoneToApp
+```
+
+* Install CocoaPods in your system, if you don't have it already.
+
+``` shell
+sudo gem install cocoapods
+```
+
+Note: CocoaPods is built with Ruby, available by default on macOS.
+
+* Create a Podfile for your project.
+
+``` shell
+pod init
+```
+
+## Add the iOS Client SDK
+
+* Add the Nexmo iOS Client SDK to the Podfile. To do this, let's open it in `Xcode`.
+
+``` shell
+open -a Xcode Podfile
+```
+
+* Update the Podfile as shown below.
+
+```
+# Uncomment the next line to define a global platform for your project
+# platform :ios, '9.0'
+
+target 'PhoneToApp' do
+  # Comment the next line if you don't want to use dynamic frameworks
+  use_frameworks!
+
+  # Pods for PhoneToApp
+  pod 'NexmoClient'
+  
+end
+```
+
+* Install the library.
+
+``` shell
+pod install
+```
+
+The latest version of the library will be added to your project:
+
+```
+Analyzing dependencies
+Downloading dependencies
+Installing NexmoClient (2.1.0)
+Generating Pods project
+Integrating client project
+
+[!] Please close any current Xcode sessions and use `PhoneToApp.xcworkspace` for this project from now on.
+Pod installation complete! There is 1 dependency from the Podfile and 1 total pod installed.
+
+[!] Automatically assigning platform `iOS` with version `13.5` on target `PhoneToApp` because no platform was specified. Please specify a platform for this target in your Podfile. See `https://guides.cocoapods.org/syntax/podfile.html#platform`.
+```
+
+## Open the Workspace
+
+As described in the output above, please use `PhoneToApp.xcworkspace` rather than the initial project from now on. To open it, type the following in the terminal.
+
+``` shell
+open PhoneToApp.xcworkspace
+```
+

--- a/_tutorials/en/client-sdk/phone-to-app/project/swift.md
+++ b/_tutorials/en/client-sdk/phone-to-app/project/swift.md
@@ -5,8 +5,7 @@ description: In this step you create an Xcode project and add the iOS Client SDK
 
 # Xcode Project & Workspace
 
-You will be using the iOS Client SDK library inside an Xcode project you'll create next:
-
+You will be using the iOS Client SDK library inside an Xcode project you'll create..
 
 ## Create an Xcode Project
 
@@ -29,13 +28,13 @@ You will add the iOS Client SDK library to your project via [CocoaPods](https://
 
 ## Install CocoaPods
 
-* Open the `Terminal` app and navigate to the project folder by typing:
+* Open the `Terminal` app and navigate to the project folder by typing.
 
 ``` shell
 cd ~/Desktop/PhoneToApp
 ```
 
-* Install CocoaPods in your system, if you don't have it already:
+* Install CocoaPods in your system, if you don't have it already.
 
 ``` shell
 sudo gem install cocoapods
@@ -43,7 +42,7 @@ sudo gem install cocoapods
 
 Note: CocoaPods is built with Ruby, available by default on macOS.
 
-* Create a Podfile for your project:
+* Create a Podfile for your project.
 
 ``` shell
 pod init
@@ -51,13 +50,13 @@ pod init
 
 ## Add the iOS Client SDK
 
-* Add the Nexmo iOS Client SDK to the Podfile. To do this, let's open it in `Xcode`:
+* Add the Nexmo iOS Client SDK to the Podfile. To do this, let's open it in `Xcode`.
 
 ``` shell
 open -a Xcode Podfile
 ```
 
-* Update the Podfile as shown below:
+* Update the Podfile as shown below.
 
 ```
 # Uncomment the next line to define a global platform for your project
@@ -73,7 +72,7 @@ target 'PhoneToApp' do
 end
 ```
 
-* Install the library:
+* Install the library.
 
 ``` shell
 pod install
@@ -96,7 +95,7 @@ Pod installation complete! There is 1 dependency from the Podfile and 1 total po
 
 ## Open the Workspace
 
-As described in the output above, please use `PhoneToApp.xcworkspace` rather than the initial project from now on. To open it, type the following in the terminal:
+As described in the output above, please use `PhoneToApp.xcworkspace` rather than the initial project from now on. To open it, type the following in the terminal.
 
 ``` shell
 open PhoneToApp.xcworkspace

--- a/config/tutorials/en/in-app-messaging/objective_c.yml
+++ b/config/tutorials/en/in-app-messaging/objective_c.yml
@@ -10,11 +10,11 @@ introduction:
     # Introduction
     In this task, you will learn how to create and configure a Client SDK Application and then code an application that enables two users to send messages to each other.
 
-    First, you will create a Conversation and two Users. Then, you will authenticate these Users and add them to the Conversation as Members.
-
-    Finally, you will implement chat functionality in an application, including the ability to view and send messages.
+    First, you will create a Conversation and two Users. Then, you will authenticate these Users and add them to the Conversation as Members. Finally, you will implement chat functionality in an application, including the ability to view and send messages.
 
     If you would like to follow along without building the app yourself, the completed project for this tutorial is available on [GitHub](https://github.com/nexmo-community/ClientSDK-app-to-app-chat-objective-c).
+
+    *This tutorial uses NexmoClient version 2.2.1*
 
 prerequisites:
   - create-nexmo-account

--- a/config/tutorials/en/phone-to-app/objective_c.yml
+++ b/config/tutorials/en/phone-to-app/objective_c.yml
@@ -12,7 +12,7 @@ introduction:
     inbound <abbr title="Public Switched Telephone Network">PSTN</abbr> call.
 
     ### Completed project
-    If you would like to follow along without building the app yourself, the completed project for this tutorial is available on [Github](https://github.com/nexmo-community/client-sdk-swift-voice-phone-to-app) for you to download.
+    If you would like to follow along without building the app yourself, the completed project for this tutorial is available on [Github](https://github.com/nexmo-community/client-sdk-objective-c-voice-phone-to-app) for you to download.
 
 prerequisites:
 - create-nexmo-account
@@ -42,7 +42,7 @@ conclusion:
 
     # What's next?
 
-    For completeness, the project you've built as part of this tutorial is also available on [Github](https://github.com/nexmo-community/client-sdk-swift-voice-phone-to-app).
+    For completeness, the project you've built as part of this tutorial is also available on [Github](https://github.com/nexmo-community/client-sdk-objective-c-voice-phone-to-app).
 
     And... you can do a lot more with the Client SDK,  see [Client SDK documentation](/client-sdk/overview).
 


### PR DESCRIPTION
## Description

I also had to update the paths on the swift tutorial.

Old Swift: https://developer.nexmo.com/client-sdk/tutorials/phone-to-app/introduction/swift
New Swift: https://nexmo-developer-pr-3125.herokuapp.com/client-sdk/tutorials/phone-to-app/introduction/swift
New Objc: https://nexmo-developer-pr-3125.herokuapp.com/client-sdk/tutorials/phone-to-app/introduction/objective_c