### PR TITLE
Update Android SDK v2.6.5 release notes

### DIFF
--- a/_documentation/en/client-sdk/sdk-documentation/android/release-notes.md
+++ b/_documentation/en/client-sdk/sdk-documentation/android/release-notes.md
@@ -6,6 +6,12 @@ navigation_weight: 0
 
 # Release Notes
 
+## Version 2.6.5 - Aug 24, 2020
+
+### Enhancements
+
+- Improved SDK logs implementation and socket connection stability.
+
 ## Version 2.6.4 - May 19, 2020
 
 ### New


### PR DESCRIPTION
Android SDK v2.6.5 notes added to `release-notes.md`.