### PR TITLE
Add platform-specific links to EventsPage refs

### DIFF
--- a/_documentation/en/client-sdk/in-app-messaging/guides/handling-pagination.md
+++ b/_documentation/en/client-sdk/in-app-messaging/guides/handling-pagination.md
@@ -19,7 +19,7 @@ Load first page of events:
 source: _tutorials_tabbed_content/client-sdk/guides/messaging/handling-pagnation/load-page-events
 ```
 
-After loading the first chunk of events you will get the reference to the current [Nexmo Events Page](/sdk/stitch/android/com/nexmo/client/NexmoEventsPage.html). This reference allows to retrieve following event pages:
+After loading the first chunk of events you will get the _reference_ to the current Nexmo Events Page ([JavaScript](/sdk/stitch/javascript/EventsPage.html), [iOS](/sdk/stitch/ios/Classes/NXMEventsPage.html), [Android](/sdk/stitch/android/com/nexmo/client/NexmoEventsPage.html)). This _reference_ allows you to retrieve following event pages:
 
 ```tabbed_content
 source: _tutorials_tabbed_content/client-sdk/guides/messaging/handling-pagnation/load-next-event-page
@@ -30,4 +30,3 @@ Preceding pages can also be retrieved using a similar technique:
 ```tabbed_content
 source: _tutorials_tabbed_content/client-sdk/guides/messaging/handling-pagnation/load-prev-event-page
 ```
-


### PR DESCRIPTION
## Description

Add platform-specific links to `EventsPage` in SDK documentation.

Note: the link for iOS won't currently work due to the iOS SDK reference needing to be updated.

## Review

* [Page to review](https://nexmo-developer-pr-3131.herokuapp.com/client-sdk/in-app-messaging/guides/handling-pagination)