### PR TITLE
Fixed bad version in PHP dependencies

### DIFF
--- a/_examples/messaging/sms/delivery-receipts/php.yml
+++ b/_examples/messaging/sms/delivery-receipts/php.yml
@@ -3,7 +3,7 @@ title: PHP
 language: php
 dependencies:
     - 'slim/slim:^3.8'
-    - 'nexmo/client:^2.2'
+    - 'nexmo/client'
 code:
     source: .repos/nexmo/nexmo-php-code-snippets/sms/receive-delivery-receipt-slim/index.php
     from_line: 9

--- a/_examples/messaging/sms/receiving-an-sms/php.yml
+++ b/_examples/messaging/sms/receiving-an-sms/php.yml
@@ -3,7 +3,7 @@ title: PHP
 language: php
 dependencies:
     - 'slim/slim:^3.8'
-    - 'nexmo/client:^2.2'
+    - 'nexmo/client'
 code:
     source: .repos/nexmo/nexmo-php-code-snippets/sms/receive-with-slim/index.php
     from_line: 9


### PR DESCRIPTION
## Description

During the PHP v2.2.0 release, two files got left referencing `nexmo/client:^2.2`, which was never released (it never needed to be). This changes those files back to just a generic `nexmo/client` reference like all the other files. 

## Deploy Notes

No special deploy notes, this is a typo fix
