### PR TITLE
Fix `/hansel`.

### DIFF
--- a/custom/landing_pages/hansel.yml
+++ b/custom/landing_pages/hansel.yml
@@ -72,13 +72,7 @@ page:
             color: "blue-dark"
           url: "https://www.nexmo.com/blog/category/developer?ref=hansel-dr"
   - row:
-    - width: 2
-      column:
-      - type: tutorial
-        tutorial:
-          name: two-factor-authentication-dotnet-verify-api
-    - width: 2
-      column:
+    - column:
       - type: tutorial
         tutorial:
           name: number-insight-api-aspnet


### PR DESCRIPTION
## Description

It was returning a 500 because it tried to render a tutorial that no
longer exists.
