### PR TITLE
ASR GA API Improvements

### DIFF
--- a/_documentation/en/voice/voice-api/guides/asr.md
+++ b/_documentation/en/voice/voice-api/guides/asr.md
@@ -58,8 +58,8 @@ Set `type` as `speech` for speech input only, or `[ "dtmf", "speech" ]` to accep
 
 The expected language of user speech should be specified as the `language` parameter (`en-US` by default).
 
-| #### Supported languages
-|
+#### Supported languages
+
 | Language | Code
 | ---- | ----
 | Afrikaans (South Africa) | `af-ZA`

--- a/_documentation/en/voice/voice-api/guides/asr.md
+++ b/_documentation/en/voice/voice-api/guides/asr.md
@@ -187,7 +187,7 @@ Some hints might be provided using the `context` array parameter to improve reco
 
 If the user is calling not for the first time, they may already know the question to be asked, so the user may start speaking even before the audio message finishes. In order to support that, `bargeIn` parameter of the TTS (or `stream` - whatever action is used for the message) should be activated.
 
-> It's recommended to have the very first TTS/audio message, for example, some short initial greeting, with inactivated "barge in" option because of better user experience (so that the user doesn't unintentionally interrupt the message even not starting to hear it) and increasing speech recognition accuracy (since at the very beginning of the call there is a higher probability of background noise affecting the recognition).
+> It is recommended to have the initial TTS/audio message be a short initial greeting without activating the `bargeIn` option to improve the user experience. If `bargeIn` is turned on for the first initial greeting, then the user may inadvertently interrupt it without hearing the prompt at all, since background noise may be interpreted by the application as an active interaction in those first moments.
 
 ### Event Payload Example
 

--- a/_documentation/en/voice/voice-api/guides/asr.md
+++ b/_documentation/en/voice/voice-api/guides/asr.md
@@ -22,6 +22,10 @@ Typically, ASR is used in conjunction with an audio message playing to the user.
 [
   {
     "action": "talk",
+    "text": "Hello!"
+  },
+  {
+    "action": "talk",
     "text": "Please tell us, how can we help you today?",
     "bargeIn": true
   },
@@ -31,10 +35,8 @@ Typically, ASR is used in conjunction with an audio message playing to the user.
     ],
     "eventMethod": "POST",
     "action": "input",
+    "type": [ "speech" ]
     "speech": {
-      "uuid": [
-        "aaaaaaaa-bbbb-cccc-dddd-0123456789ab"
-      ],
       "language": "en-gb",
       "context": [
         "support",
@@ -49,9 +51,8 @@ Typically, ASR is used in conjunction with an audio message playing to the user.
 
 The [NCCO Reference Guide](/voice/voice-api/ncco-reference#speech-recognition-settings) contains information on all the possible parameters that can be used in conjunction with the ASR `input` NCCO action.
 
-### Call ID
-
-ASR action (`input` with `speech`) cannot be executed for the whole conversation; it’s performed against the call (leg), so the call identifier should be explicitly specified in the NCCO as the `speech.uuid` parameter.
+### Input Type
+Set `type` as `speech` for speech input only, or `[ "dtmf", "speech" ]` to accept both speech or [DTMF](/voice/voice-api/guides/dtmf).
 
 ### Language
 
@@ -185,6 +186,8 @@ Some hints might be provided using the `context` array parameter to improve reco
 ### Barge In
 
 If the user is calling not for the first time, they may already know the question to be asked, so the user may start speaking even before the audio message finishes. In order to support that, `bargeIn` parameter of the TTS (or `stream` - whatever action is used for the message) should be activated.
+
+> It's recommended to have the very first TTS/audio message, for example, some short initial greeting, with inactivated "barge in" option because of better user experience (so that the user doesn't unintentionally interrupt the message even not starting to hear it) and increasing speech recognition accuracy (since at the very beginning of the call there is a higher probability of background noise affecting the recognition).
 
 ### Event Payload Example
 

--- a/_documentation/en/voice/voice-api/guides/asr.md
+++ b/_documentation/en/voice/voice-api/guides/asr.md
@@ -35,7 +35,7 @@ Typically, ASR is used in conjunction with an audio message playing to the user.
     ],
     "eventMethod": "POST",
     "action": "input",
-    "type": [ "speech" ]
+    "type": [ "speech" ],
     "speech": {
       "language": "en-gb",
       "context": [

--- a/_documentation/en/voice/voice-api/guides/dtmf.md
+++ b/_documentation/en/voice/voice-api/guides/dtmf.md
@@ -30,6 +30,7 @@ You can collect input from your caller by using the `input` action within your N
       "https://api.example.com/callbacks/events"
     ],
     "action": "input",
+    "type": [ "dtmf" ],
     "dtmf": {
       "maxDigits": 1,
       "submitOnHash": true,

--- a/_documentation/en/voice/voice-api/ncco-reference.md
+++ b/_documentation/en/voice/voice-api/ncco-reference.md
@@ -250,11 +250,12 @@ The following NCCO example shows how to configure an IVR endpoint:
     "eventUrl": [
       "https://example.com/ivr"
     ],
+    "type": [ "dtmf", "speech" ],
     "dtmf": {
       "maxDigits": 1
     },
     "speech": {
-      "uuid": ["aaaaaaaa-bbbb-cccc-dddd-0123456789ab"]
+      "context": [ "sales", "support" ]
     }
   }
 ]
@@ -274,12 +275,13 @@ The following NCCO example shows how to use `bargeIn` to allow a user to interru
     "eventUrl": [
       "https://example.com/ivr"
     ],
+    "type": [ "dtmf", "speech" ],	
     "dtmf": {
       "maxDigits": 1
     },
     "speech": {
-      "uuid": ["aaaaaaaa-bbbb-cccc-dddd-0123456789ab"]
-    }
+      "context": [ "sales", "support" ]
+    }	
   }
 ]
 ```
@@ -288,8 +290,9 @@ The following options can be used to control an `input` action:
 
 Option | Description | Required
 -- | -- | --
-`dtmf` | [DTMF settings](#dtmf-input-settings). Required if `speech` is not provided. Should be specified to enable DTMF input. If all the DTMF input settings will have default values, it should be specified as empty object: `dtmf: { }`. | No
-`speech` | [Speech recognition settings](#speech-recognition-settings). Required if `dtmf` is not provided. Should be specified to enable speech input. | No
+`type` | Acceptable input type, can be set as `[ "dtmf" ]` for DTMF input only, `[ "speech" ]` for ASR only, or `[ "dtmf", "speech" ]` for both. | Yes
+`dtmf` | [DTMF settings](#dtmf-input-settings). | No
+`speech` | [Speech recognition settings](#speech-recognition-settings). | No
 `eventUrl` | Nexmo sends the digits pressed by the callee to this URL 1) after `timeOut` pause in activity or when *#* is pressed for DTMF or 2) after user stops speaking or `30` seconds of speech for speech input.  | No
 `eventMethod` | The HTTP method used to send event information to `event_url` The default value is `POST`.| No
 
@@ -305,7 +308,7 @@ Option | Description | Required
 
 Option | Description | Required
 -- | -- | --
-`uuid` | The unique ID of the Call leg for the user to capture the speech of, defined as an array with a single element. | Yes
+`uuid` | The unique ID of the Call leg for the user to capture the speech of, defined as an array with a single element. The first joined leg of the call by default. | No
 `endOnSilence` | Controls how long the system will wait after user stops speaking to decide the input is completed. The default value is `2` (seconds). The range of possible values is between 1 second and 10 seconds. | No
 `language` | Expected language of the user's speech. Format: BCP-47. Default: `en-US`. [List of supported languages](/voice/voice-api/guides/asr#language). | No
 `context` | Array of hints (strings) to improve recognition quality if certain words are expected from the user. | No
@@ -313,13 +316,11 @@ Option | Description | Required
 `maxDuration` | Controls maximum speech duration (from the moment user starts speaking). The default value is 60 (seconds). The range of possible values is between 1 and 60 seconds. | No
 
 
-The following example shows the parameters sent to `eventUrl` for DTMF input:
+The following example shows the parameters sent back to `eventUrl` webhook for DTMF input:
 
 ```json
 {
-  "speech": {
-    "error": "Speech was not enabled"
-  },
+  "speech": { "results": [ ] },
   "dtmf": {
     "digits": "1234",
     "timed_out": true
@@ -367,36 +368,7 @@ The following example shows the parameters sent back to the `eventUrl` webhook f
 
 ### Input Return Parameters
 
-Input parameters which are returned to the `eventUrl` are:
-
-Name | Description
--- | --
-`uuid` | The unique ID of the Call leg for the user initiating the input.
-`conversation_uuid` | The unique ID for this conversation.
-`dtmf` | [DTMF capturing output](#dtmf-input-return-parameters)
-`speech` | [Speech recognition output](#speech-input-return-parameters)
-
-#### DTMF Input Return Parameters
-
-Name | Description
--- | --
-`timed_out` | Returns `true` if this input timed out based on the value of `timeOut`.
-`digits` | The numbers input by your callee, in order.
-
-#### Speech Input Return Parameters
-
-Name | Description
--- | --
-`timeout_reason` | Indicates if the input ended when user stopped speaking (`end_on_silence_timeout`), by max duration timeout (`max_duration`) or if the user didn't say anything (`start_timeout`)
-`results` | Array of [speech recognition results](#speech-recognition-results)
-
-##### Speech Recognition Results
-
-Name | Description
--- | --
-`text` | Transcript text representing the words that the user spoke.
-`confidence` | The confidence estimate between 0.0 and 1.0. A higher number indicates an estimated greater likelihood that the recognized words are correct.
-
+See [Webhook Reference](/voice/voice-api/webhook-reference#input) for input parameters which are returned to the `eventUrl`.
 
 ## Notify
 

--- a/_documentation/en/voice/voice-api/ncco-reference.md
+++ b/_documentation/en/voice/voice-api/ncco-reference.md
@@ -316,7 +316,7 @@ Option | Description | Required
 `maxDuration` | Controls maximum speech duration (from the moment user starts speaking). The default value is 60 (seconds). The range of possible values is between 1 and 60 seconds. | No
 
 
-The following example shows the parameters sent back to `eventUrl` webhook for DTMF input:
+The following example shows the parameters sent to the `eventUrl` webhook for DTMF input:
 
 ```json
 {

--- a/_documentation/en/voice/voice-api/webhook-reference.md
+++ b/_documentation/en/voice/voice-api/webhook-reference.md
@@ -326,7 +326,7 @@ Field | Example | Description
 -- | -- | --
 `timeout_reason` | `end_on_silence_timeout` | Indicates if the input ended when user stopped speaking (`end_on_silence_timeout`), by max duration timeout (`max_duration`) or if the user didn't say anything (`start_timeout`)
 `results` | _see below_ | Array of [recognized text objects](#transcript-text)
-`error` | `ERR1: Failed to analyze audio` | Error/status message: `Speech was not enabled` (status) - input action was configured to capture only DTMF input; `Speech overridden by DTMF` (status) - input action was configured to accept both speech/DTMF and user pressed keys; `ERRX: ...` (error) - user speech could not be recognized.
+`error` | `ERR1: Failed to analyze audio` | Error message.
 
 ##### Transcript text
 Field | Example | Description

--- a/_use_cases/en/asr-use-case-voice-bot.md
+++ b/_use_cases/en/asr-use-case-voice-bot.md
@@ -105,10 +105,7 @@ app.get('/webhooks/answer', (request, response) => {
       action: 'input',
       eventUrl: [
         `${request.protocol}://${request.get('host')}/webhooks/asr`],
-      speech: {
-        uuid: [request.query.uuid],
-        language: 'en-us'
-      }
+      type: [ "speech" ]
     },
     {
       action: 'talk',
@@ -119,8 +116,6 @@ app.get('/webhooks/answer', (request, response) => {
   response.json(ncco)
 })
 ```
-
-Speech recognition requires specifying the call leg identifier, in order to do that, use the `uuid` you get in the callback request: `request.query.uuid`, which is the identifier of the inbound PSTN leg you want to listen to.
 
 ## Write your event webhook
 


### PR DESCRIPTION
## Description

The following ASR improvements reflected:
* `uuid` is not a mandatory parameter now;
* `type` parameter supported for `input` action (which makes possible the next improvement);
* `dtmf` and `speech` parameters are not mandatory parameters now;
* `Speech was not enabled` and `Speech overridden by DTMF` "error" messages are not returned now for DTMF+ASR and DTMF-only cases.

