### PR TITLE
remove uses of "we" in iOS tutorials

### DIFF
--- a/_tutorials/en/client-sdk/app-to-app/call-ui/objective_c.md
+++ b/_tutorials/en/client-sdk/app-to-app/call-ui/objective_c.md
@@ -138,7 +138,7 @@ Implement the initializer:
 @end
 ```
 
-This defines a custom initializer for the class which has a `User.type` as its parameter, which then gets stored in the local `user` property. Now that we have the user information you use the `callButton` to show who the user will be calling, in `viewDidLoad` add the following.
+This defines a custom initializer for the class which has a `User.type` as its parameter, which then gets stored in the local `user` property. Now that you have the user information you use the `callButton` to show who the user will be calling, in `viewDidLoad` add the following.
 
 ```objective_c
 self.navigationItem.leftBarButtonItem = [[UIBarButtonItem alloc] initWithTitle:@"Logout" style:UIBarButtonItemStyleDone target:self action:@selector(logout)];

--- a/_tutorials/en/client-sdk/app-to-app/make-call/objective_c.md
+++ b/_tutorials/en/client-sdk/app-to-app/make-call/objective_c.md
@@ -5,7 +5,7 @@ description: In this step you learn how to make an app-to-app call.
 
 # Make a call
 
-To make a call we will make use of the `callButton` in the `CallViewController` UI. First we need to add a target to the button in the `viewDidLoad` function.
+To make a call you will make use of the `callButton` in the `CallViewController` UI. First you need to add a target to the button in the `viewDidLoad` function.
 
 ```objective_c
 - (void)viewDidLoad {

--- a/_tutorials/en/client-sdk/app-to-app/make-call/swift.md
+++ b/_tutorials/en/client-sdk/app-to-app/make-call/swift.md
@@ -5,7 +5,7 @@ description: In this step you learn how to make an app-to-app call.
 
 # Make a call
 
-To make a call we will make use of the `callButton` in the `CallViewController` UI. First we need to add a target to the button.
+To make a call you will make use of the `callButton` in the `CallViewController` UI. First you need to add a target to the button.
 
 ```swift
 class CallViewController: UIViewController {

--- a/_tutorials/en/client-sdk/app-to-app/receive-call/objective_c.md
+++ b/_tutorials/en/client-sdk/app-to-app/receive-call/objective_c.md
@@ -92,4 +92,4 @@ Similar to `NXMClient`, `NXMCall` also has a delegate to handle changes to the c
 @end
 ```
 
-In the next step we will add the code needed to make a call.
+In the next step you will add the code needed to make a call.

--- a/_tutorials/en/client-sdk/app-to-app/receive-call/swift.md
+++ b/_tutorials/en/client-sdk/app-to-app/receive-call/swift.md
@@ -111,4 +111,4 @@ extension CallViewController: NXMCallDelegate {
 }
 ```
 
-In the next step we will add the code needed to make a call.
+In the next step you will add the code needed to make a call.

--- a/_tutorials/en/client-sdk/in-app-messaging/create-users/objective_c.md
+++ b/_tutorials/en/client-sdk/in-app-messaging/create-users/objective_c.md
@@ -20,4 +20,4 @@ This will return user IDs similar to the following:
 User created: USR-aaaaaaaa-bbbb-cccc-dddd-0123456789ab
 ```
 
-There is no need to remember this user ID because we will use user names (instead of user IDs) to add them to the conversation. 
+There is no need to remember this user ID because you will use user names (instead of user IDs) to add them to the conversation. 

--- a/_tutorials/en/client-sdk/in-app-messaging/create-users/swift.md
+++ b/_tutorials/en/client-sdk/in-app-messaging/create-users/swift.md
@@ -20,4 +20,4 @@ This will return user IDs similar to the following:
 User created: USR-aaaaaaaa-bbbb-cccc-dddd-0123456789ab
 ```
 
-There is no need to remember this user ID because we will use user names (instead of user IDs) to add them to the conversation. 
+There is no need to remember this user ID because you will use user names (instead of user IDs) to add them to the conversation. 

--- a/_tutorials/en/client-sdk/phone-to-app/call/objective_c.md
+++ b/_tutorials/en/client-sdk/phone-to-app/call/objective_c.md
@@ -14,7 +14,7 @@ At the top of the `ViewController` class, just below the `client` declaration, a
  @end
  ```
 
-When the application receives a call we want to give the option to accept or reject the call. To do this add the `displayIncomingCallAlert` function to the `ViewController` class.
+When the application receives a call you will want to give the option to accept or reject the call. To do this add the `displayIncomingCallAlert` function to the `ViewController` class.
 
 ```objective_c
 - (void)displayIncomingCallAlert:(NXMCall *)call {
@@ -32,7 +32,7 @@ When the application receives a call we want to give the option to accept or rej
     [self presentViewController:alert animated:YES completion:nil];
 }
 ```
-The `displayIncomingCallAlert` function takes a `NXMCall` as a parameter, with this we can access the members, which are the type `NXMCallMember`, of the call to retrieve the phone number of the incoming call. Note in the `UIAlertAction` for answering the call we assign the call to the property from earlier.
+The `displayIncomingCallAlert` function takes a `NXMCall` as a parameter, with this you can access the members, which are the type `NXMCallMember`, of the call to retrieve the phone number of the incoming call. Note in the `UIAlertAction` for answering the call you assign the call to the property from earlier.
 
 To use `displayIncomingCallAlert` you need to use the `NXMClientDelegate` which has a function that will be called when the client receives an incoming `NXMCall`.
 

--- a/_tutorials/en/client-sdk/phone-to-app/call/swift.md
+++ b/_tutorials/en/client-sdk/phone-to-app/call/swift.md
@@ -16,7 +16,7 @@ class ViewController: UIViewController {
 }
 ```
 
-When the application receives a call we want to give the option to accept or reject the call. To do this add the `displayIncomingCallAlert` function to the `ViewController` class.
+When the application receives a call you will want to give the option to accept or reject the call. To do this add the `displayIncomingCallAlert` function to the `ViewController` class.
 
 ```swift
 class ViewController: UIViewController {
@@ -41,7 +41,7 @@ class ViewController: UIViewController {
     }
 }
 ```
-The `displayIncomingCallAlert` function takes a `NXMCall` as a parameter, with this we can access the members, which are the type `NXMCallMember`, of the call to retrieve the phone number of the incoming call. Note in the `UIAlertAction` for answering the call we assign the call to the property from earlier.
+The `displayIncomingCallAlert` function takes a `NXMCall` as a parameter, with this you can access the members, which are the type `NXMCallMember`, of the call to retrieve the phone number of the incoming call. Note in the `UIAlertAction` for answering the call you assign the call to the property from earlier.
 
 To use `displayIncomingCallAlert` you need to use the `NXMClientDelegate` which has a function that will be called when the client receives an incoming `NXMCall`.
 


### PR DESCRIPTION
## Description

Removes the uses of "we" for consistency. 
