### PR TITLE
Rebrand constants to vonage

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -356,3 +356,5 @@ Keychain
 Valencian
 Yue
 2FA
+VonageApp1
+VonageApp2

--- a/_documentation/en/account/code-snippets/create-a-secret.md
+++ b/_documentation/en/account/code-snippets/create-a-secret.md
@@ -17,7 +17,7 @@ New API secrets must meet the following rules:
 
 Key | Description
  -- | --
-`NEXMO_API_KEY` | The API key of the account.
+`VONAGE_API_KEY` | The API key of the account.
 `NEW_SECRET` | The new API secret for the API key.
 
 ```code_snippets

--- a/_documentation/en/account/code-snippets/fetch-a-secret.md
+++ b/_documentation/en/account/code-snippets/fetch-a-secret.md
@@ -10,8 +10,8 @@ never be shown.
 
 Key | Description
  -- | --
-`NEXMO_API_KEY` | The API key of the account to fetch secrets for. Can be the same as authenticating account or it can be a subaccount.
-`NEXMO_SECRET_ID` | The ID of the secret to retrieve.
+`VONAGE_API_KEY` | The API key of the account to fetch secrets for. Can be the same as authenticating account or it can be a subaccount.
+`VONAGE_SECRET_ID` | The ID of the secret to retrieve.
 
 ```code_snippets
 source: _examples/account/secret-management/fetch-a-secret

--- a/_documentation/en/account/code-snippets/revoke-a-secret.md
+++ b/_documentation/en/account/code-snippets/revoke-a-secret.md
@@ -11,8 +11,8 @@ You must have at least one API secret at all times.
 
 Key | Description
  -- | --
-`NEXMO_API_KEY` | The API key of the account.
-`NEXMO_SECRET_ID` | The ID of the secret to delete.
+`VONAGE_API_KEY` | The API key of the account.
+`VONAGE_SECRET_ID` | The ID of the secret to delete.
 
 ```code_snippets
 source: _examples/account/secret-management/revoke-a-secret

--- a/_documentation/en/account/subaccounts/code-snippets/create-subaccount.md
+++ b/_documentation/en/account/subaccounts/code-snippets/create-subaccount.md
@@ -13,8 +13,8 @@ Ensure the following variables are set to your required values using any conveni
 
 Key | Description
 -- | --
-`NEXMO_API_KEY` | The API key of the parent account.
-`NEXMO_API_SECRET` | The API secret of the parent account.
+`VONAGE_API_KEY` | The API key of the parent account.
+`VONAGE_API_SECRET` | The API secret of the parent account.
 `NEW_SUBACCOUNT_NAME` | The name of the new subaccount.
 `NEW_SUBACCOUNT_SECRET` | The API secret of the new subaccount.
 

--- a/_documentation/en/account/subaccounts/code-snippets/get-balance-transfers.md
+++ b/_documentation/en/account/subaccounts/code-snippets/get-balance-transfers.md
@@ -13,8 +13,8 @@ Ensure the following variables are set to your required values using any conveni
 
 Key | Description
 -- | --
-`NEXMO_API_KEY` | The API key of the parent account.
-`NEXMO_API_SECRET` | The API secret of the parent account.
+`VONAGE_API_KEY` | The API key of the parent account.
+`VONAGE_API_SECRET` | The API secret of the parent account.
 `START_DATE` | The ISO format datetime from which to list transfers. Example: `2019-03-02T16:34:49Z`.
 
 ```code_snippets

--- a/_documentation/en/account/subaccounts/code-snippets/get-credit-transfers.md
+++ b/_documentation/en/account/subaccounts/code-snippets/get-credit-transfers.md
@@ -13,8 +13,8 @@ Ensure the following variables are set to your required values using any conveni
 
 Key | Description
 -- | --
-`NEXMO_API_KEY` | The API key of the parent account.
-`NEXMO_API_SECRET` | The API secret of the parent account.
+`VONAGE_API_KEY` | The API key of the parent account.
+`VONAGE_API_SECRET` | The API secret of the parent account.
 `START_DATE` | The ISO format datetime from which to list transfers. Example: `2019-03-02T16:34:49Z`.
 
 ```code_snippets

--- a/_documentation/en/account/subaccounts/code-snippets/get-subaccount.md
+++ b/_documentation/en/account/subaccounts/code-snippets/get-subaccount.md
@@ -13,8 +13,8 @@ Ensure the following variables are set to your required values using any conveni
 
 Key | Description
 -- | --
-`NEXMO_API_KEY` | The API key of the parent account.
-`NEXMO_API_SECRET` | The API secret of the parent account.
+`VONAGE_API_KEY` | The API key of the parent account.
+`VONAGE_API_SECRET` | The API secret of the parent account.
 `SUBACCOUNT_KEY` | The API key of the subaccount you want to retrieve the details of.
 
 ```code_snippets

--- a/_documentation/en/account/subaccounts/code-snippets/get-subaccounts.md
+++ b/_documentation/en/account/subaccounts/code-snippets/get-subaccounts.md
@@ -13,8 +13,8 @@ Ensure the following variables are set to your required values using any conveni
 
 Key | Description
 -- | --
-`NEXMO_API_KEY` | The API key of the parent account.
-`NEXMO_API_SECRET` | The API secret of the parent account.
+`VONAGE_API_KEY` | The API key of the parent account.
+`VONAGE_API_SECRET` | The API secret of the parent account.
 
 ```code_snippets
 source: '_examples/subaccounts/get-subaccounts'

--- a/_documentation/en/account/subaccounts/code-snippets/reactivate-subaccount.md
+++ b/_documentation/en/account/subaccounts/code-snippets/reactivate-subaccount.md
@@ -13,8 +13,8 @@ Ensure the following variables are set to your required values using any conveni
 
 Key | Description
 -- | --
-`NEXMO_API_KEY` | The API key of the parent account.
-`NEXMO_API_SECRET` | The API secret of the parent account.
+`VONAGE_API_KEY` | The API key of the parent account.
+`VONAGE_API_SECRET` | The API secret of the parent account.
 `SUBACCOUNT_KEY` | The API key of the subaccount to be reactivated.
 
 ```code_snippets

--- a/_documentation/en/account/subaccounts/code-snippets/suspend-subaccount.md
+++ b/_documentation/en/account/subaccounts/code-snippets/suspend-subaccount.md
@@ -13,8 +13,8 @@ Ensure the following variables are set to your required values using any conveni
 
 Key | Description
 -- | --
-`NEXMO_API_KEY` | The API key of the parent account.
-`NEXMO_API_SECRET` | The API secret of the parent account.
+`VONAGE_API_KEY` | The API key of the parent account.
+`VONAGE_API_SECRET` | The API secret of the parent account.
 `SUBACCOUNT_KEY` | The API key of the subaccount to be suspended.
 
 ```code_snippets

--- a/_documentation/en/account/subaccounts/code-snippets/transfer-balance.md
+++ b/_documentation/en/account/subaccounts/code-snippets/transfer-balance.md
@@ -13,8 +13,8 @@ Ensure the following variables are set to your required values using any conveni
 
 Key | Description
 -- | --
-`NEXMO_API_KEY` | The API key of the parent account.
-`NEXMO_API_SECRET` | The API secret of the parent account.
+`VONAGE_API_KEY` | The API key of the parent account.
+`VONAGE_API_SECRET` | The API secret of the parent account.
 `SUBACCOUNT_KEY` | The API key of the subaccount to receive the specified amount.
 `AMOUNT` | The amount of balance to be transferred to the specified subaccount.
 

--- a/_documentation/en/account/subaccounts/code-snippets/transfer-credit.md
+++ b/_documentation/en/account/subaccounts/code-snippets/transfer-credit.md
@@ -13,8 +13,8 @@ Ensure the following variables are set to your required values using any conveni
 
 Key | Description
 -- | --
-`NEXMO_API_KEY` | The API key of the parent account.
-`NEXMO_API_SECRET` | The API secret of the parent account.
+`VONAGE_API_KEY` | The API key of the parent account.
+`VONAGE_API_SECRET` | The API secret of the parent account.
 `SUBACCOUNT_KEY` | The API key of the subaccount to receive the credit.
 `AMOUNT` | The amount to be credited to the specified subaccount.
 

--- a/_documentation/en/application/code-snippets/create-application.md
+++ b/_documentation/en/application/code-snippets/create-application.md
@@ -14,8 +14,8 @@ You will need to ensure that the following replaceable values are set in the exa
 
 Key | Description
 -- | --
-`NEXMO_API_KEY` | Your Nexmo API key.
-`NEXMO_API_SECRET` | Your Nexmo API secret.
+`VONAGE_API_KEY` | Your Nexmo API key.
+`VONAGE_API_SECRET` | Your Nexmo API secret.
 `APPLICATION_NAME` | The name for your Nexmo Application.
 
 ```code_snippets

--- a/_documentation/en/application/code-snippets/create-application.md
+++ b/_documentation/en/application/code-snippets/create-application.md
@@ -16,7 +16,7 @@ Key | Description
 -- | --
 `VONAGE_API_KEY` | Your Vonage API key.
 `VONAGE_API_SECRET` | Your Vonage API secret.
-`APPLICATION_NAME` | The name for your Nexmo Application.
+`APPLICATION_NAME` | The name for your Vonage Application.
 
 ```code_snippets
 source: '_examples/application/create-application'

--- a/_documentation/en/application/code-snippets/create-application.md
+++ b/_documentation/en/application/code-snippets/create-application.md
@@ -14,8 +14,8 @@ You will need to ensure that the following replaceable values are set in the exa
 
 Key | Description
 -- | --
-`VONAGE_API_KEY` | Your Nexmo API key.
-`VONAGE_API_SECRET` | Your Nexmo API secret.
+`VONAGE_API_KEY` | Your Vonage API key.
+`VONAGE_API_SECRET` | Your Vonage API secret.
 `APPLICATION_NAME` | The name for your Nexmo Application.
 
 ```code_snippets

--- a/_documentation/en/application/code-snippets/delete-application.md
+++ b/_documentation/en/application/code-snippets/delete-application.md
@@ -14,9 +14,9 @@ You will need to ensure that the following replaceable values are set in the exa
 
 Key | Description
 -- | --
-`NEXMO_API_KEY` | Your Nexmo API key.
-`NEXMO_API_SECRET` | Your Nexmo API secret.
-`NEXMO_APPLICATION_ID` | The application ID for the Nexmo application you want to delete.
+`VONAGE_API_KEY` | Your Nexmo API key.
+`VONAGE_API_SECRET` | Your Nexmo API secret.
+`VONAGE_APPLICATION_ID` | The application ID for the Vonage application you want to delete.
 
 ```code_snippets
 source: '_examples/application/delete-application'

--- a/_documentation/en/application/code-snippets/delete-application.md
+++ b/_documentation/en/application/code-snippets/delete-application.md
@@ -14,8 +14,8 @@ You will need to ensure that the following replaceable values are set in the exa
 
 Key | Description
 -- | --
-`VONAGE_API_KEY` | Your Nexmo API key.
-`VONAGE_API_SECRET` | Your Nexmo API secret.
+`VONAGE_API_KEY` | Your Vonage API key.
+`VONAGE_API_SECRET` | Your Vonage API secret.
 `VONAGE_APPLICATION_ID` | The application ID for the Vonage application you want to delete.
 
 ```code_snippets

--- a/_documentation/en/application/code-snippets/get-application.md
+++ b/_documentation/en/application/code-snippets/get-application.md
@@ -14,8 +14,8 @@ You will need to ensure that the following replaceable values are set in the exa
 
 Key | Description
 -- | --
-`VONAGE_API_KEY` | Your Nexmo API key.
-`VONAGE_API_SECRET` | Your Nexmo API secret.
+`VONAGE_API_KEY` | Your Vonage API key.
+`VONAGE_API_SECRET` | Your Vonage API secret.
 `VONAGE_APPLICATION_ID` | The application ID for the Vonage application you want to get.
 
 ```code_snippets

--- a/_documentation/en/application/code-snippets/get-application.md
+++ b/_documentation/en/application/code-snippets/get-application.md
@@ -14,9 +14,9 @@ You will need to ensure that the following replaceable values are set in the exa
 
 Key | Description
 -- | --
-`NEXMO_API_KEY` | Your Nexmo API key.
-`NEXMO_API_SECRET` | Your Nexmo API secret.
-`NEXMO_APPLICATION_ID` | The application ID for the Nexmo application you want to get.
+`VONAGE_API_KEY` | Your Nexmo API key.
+`VONAGE_API_SECRET` | Your Nexmo API secret.
+`VONAGE_APPLICATION_ID` | The application ID for the Vonage application you want to get.
 
 ```code_snippets
 source: '_examples/application/get-application'

--- a/_documentation/en/application/code-snippets/list-applications.md
+++ b/_documentation/en/application/code-snippets/list-applications.md
@@ -14,8 +14,8 @@ You will need to ensure that the following replaceable values are set in the exa
 
 Key | Description
 -- | --
-`VONAGE_API_KEY` | Your Nexmo API key.
-`VONAGE_API_SECRET` | Your Nexmo API secret.
+`VONAGE_API_KEY` | Your Vonage API key.
+`VONAGE_API_SECRET` | Your Vonage API secret.
 
 ```code_snippets
 source: '_examples/application/list-applications'

--- a/_documentation/en/application/code-snippets/list-applications.md
+++ b/_documentation/en/application/code-snippets/list-applications.md
@@ -14,8 +14,8 @@ You will need to ensure that the following replaceable values are set in the exa
 
 Key | Description
 -- | --
-`NEXMO_API_KEY` | Your Nexmo API key.
-`NEXMO_API_SECRET` | Your Nexmo API secret.
+`VONAGE_API_KEY` | Your Nexmo API key.
+`VONAGE_API_SECRET` | Your Nexmo API secret.
 
 ```code_snippets
 source: '_examples/application/list-applications'

--- a/_documentation/en/application/code-snippets/update-application.md
+++ b/_documentation/en/application/code-snippets/update-application.md
@@ -14,10 +14,10 @@ You will need to ensure that the following replaceable values are set in the exa
 
 Key | Description
 -- | --
-`NEXMO_API_KEY` | Your Nexmo API key.
-`NEXMO_API_SECRET` | Your Nexmo API secret.
-`NEXMO_APPLICATION_ID` | The application ID for the Nexmo application you want to update.
-`NAME` | The new name for the Nexmo application you want to update.
+`VONAGE_API_KEY` | Your Nexmo API key.
+`VONAGE_API_SECRET` | Your Nexmo API secret.
+`VONAGE_APPLICATION_ID` | The application ID for the Vonage application you want to update.
+`NAME` | The new name for the Vonage application you want to update.
 
 ```code_snippets
 source: '_examples/application/update-application'

--- a/_documentation/en/application/code-snippets/update-application.md
+++ b/_documentation/en/application/code-snippets/update-application.md
@@ -14,8 +14,8 @@ You will need to ensure that the following replaceable values are set in the exa
 
 Key | Description
 -- | --
-`VONAGE_API_KEY` | Your Nexmo API key.
-`VONAGE_API_SECRET` | Your Nexmo API secret.
+`VONAGE_API_KEY` | Your Vonage API key.
+`VONAGE_API_SECRET` | Your Vonage API secret.
 `VONAGE_APPLICATION_ID` | The application ID for the Vonage application you want to update.
 `NAME` | The new name for the Vonage application you want to update.
 

--- a/_documentation/en/application/nexmo-cli.md
+++ b/_documentation/en/application/nexmo-cli.md
@@ -7,7 +7,7 @@ navigation_weight: 2
 
 # Managing applications with the Nexmo CLI
 
-The Nexmo CLI allows you to create and manage your Nexmo applications. To obtain help simply type `nexmo` once the CLI has been installed.
+The Nexmo CLI allows you to create and manage your Vonage applications. To obtain help simply type `nexmo` once the CLI has been installed.
 
 ## Installation
 
@@ -198,7 +198,7 @@ Then enter the following:
 openssl rsa -in private.key -pubout -outform PEM -out public.key.pub
 ```
 
-This generates `public.key.pub`. This is the public key you use in creating or updating your Nexmo application:
+This generates `public.key.pub`. This is the public key you use in creating or updating your Vonage application:
 
 ```shell
 nexmo app:update asdasdas-asdd-2344-2344-asdasd12345 "Application with Public Key" --capabilities=voice,rtc --voice-event-url=http://example.com/webhooks/event --voice-answer-url=http://example.com/webhooks/answer --rtc-event-url=http://example.com/webhooks/rtcevent --public-keyfile=public.key.pub

--- a/_documentation/en/audit/code-snippets/get-event-types.md
+++ b/_documentation/en/audit/code-snippets/get-event-types.md
@@ -13,8 +13,8 @@ You will need to ensure that the following replaceable values are set in the exa
 
 Key | Description
 -- | --
-`NEXMO_API_KEY` | Your Nexmo API key.
-`NEXMO_API_SECRET` | Your Nexmo API secret.
+`VONAGE_API_KEY` | Your Nexmo API key.
+`VONAGE_API_SECRET` | Your Nexmo API secret.
 
 > In the following example the _Create an application_ and _Initialize your dependencies_ procedures are optional.
 

--- a/_documentation/en/audit/code-snippets/get-event-types.md
+++ b/_documentation/en/audit/code-snippets/get-event-types.md
@@ -13,8 +13,8 @@ You will need to ensure that the following replaceable values are set in the exa
 
 Key | Description
 -- | --
-`VONAGE_API_KEY` | Your Nexmo API key.
-`VONAGE_API_SECRET` | Your Nexmo API secret.
+`VONAGE_API_KEY` | Your Vonage API key.
+`VONAGE_API_SECRET` | Your Vonage API secret.
 
 > In the following example the _Create an application_ and _Initialize your dependencies_ procedures are optional.
 

--- a/_documentation/en/audit/code-snippets/get-event.md
+++ b/_documentation/en/audit/code-snippets/get-event.md
@@ -13,8 +13,8 @@ You will need to ensure that the following replaceable values are set in the exa
 
 Key | Description
 -- | --
-`NEXMO_API_KEY` | Your Nexmo API key.
-`NEXMO_API_SECRET` | Your Nexmo API secret.
+`VONAGE_API_KEY` | Your Nexmo API key.
+`VONAGE_API_SECRET` | Your Nexmo API secret.
 `EVENT_UUID` | The UUID of the audit event you want to retrieve.
 
 > In the following example the _Create an application_ and _Initialize your dependencies_ procedures are optional.

--- a/_documentation/en/audit/code-snippets/get-event.md
+++ b/_documentation/en/audit/code-snippets/get-event.md
@@ -13,8 +13,8 @@ You will need to ensure that the following replaceable values are set in the exa
 
 Key | Description
 -- | --
-`VONAGE_API_KEY` | Your Nexmo API key.
-`VONAGE_API_SECRET` | Your Nexmo API secret.
+`VONAGE_API_KEY` | Your Vonage API key.
+`VONAGE_API_SECRET` | Your Vonage API secret.
 `EVENT_UUID` | The UUID of the audit event you want to retrieve.
 
 > In the following example the _Create an application_ and _Initialize your dependencies_ procedures are optional.

--- a/_documentation/en/audit/code-snippets/get-events-with-filtering.md
+++ b/_documentation/en/audit/code-snippets/get-events-with-filtering.md
@@ -26,8 +26,8 @@ You will need to ensure that the following replaceable values are set in the exa
 
 Key | Description
 -- | --
-`NEXMO_API_KEY` | Your Nexmo API key.
-`NEXMO_API_SECRET` | Your Nexmo API secret.
+`VONAGE_API_KEY` | Your Nexmo API key.
+`VONAGE_API_SECRET` | Your Nexmo API secret.
 `SEARCH_TEXT` | Some JSON compatible text to search for. For example, "number".
 `DATE_FROM` | Audit events starting from this ISO-8601 datetime value. For example, "2018-07-01".
 `DATE_TO` | Audit events up to this ISO-8601 datetime value. For example, "2018-08-01".

--- a/_documentation/en/audit/code-snippets/get-events-with-filtering.md
+++ b/_documentation/en/audit/code-snippets/get-events-with-filtering.md
@@ -26,8 +26,8 @@ You will need to ensure that the following replaceable values are set in the exa
 
 Key | Description
 -- | --
-`VONAGE_API_KEY` | Your Nexmo API key.
-`VONAGE_API_SECRET` | Your Nexmo API secret.
+`VONAGE_API_KEY` | Your Vonage API key.
+`VONAGE_API_SECRET` | Your Vonage API secret.
 `SEARCH_TEXT` | Some JSON compatible text to search for. For example, "number".
 `DATE_FROM` | Audit events starting from this ISO-8601 datetime value. For example, "2018-07-01".
 `DATE_TO` | Audit events up to this ISO-8601 datetime value. For example, "2018-08-01".

--- a/_documentation/en/audit/code-snippets/get-events.md
+++ b/_documentation/en/audit/code-snippets/get-events.md
@@ -13,8 +13,8 @@ You will need to ensure that the following replaceable values are set in the exa
 
 Key | Description
 -- | --
-`NEXMO_API_KEY` | Your Nexmo API key.
-`NEXMO_API_SECRET` | Your Nexmo API secret.
+`VONAGE_API_KEY` | Your Nexmo API key.
+`VONAGE_API_SECRET` | Your Nexmo API secret.
 
 > In the following example the _Create an application_ and _Initialize your dependencies_ procedures are optional.
 

--- a/_documentation/en/audit/code-snippets/get-events.md
+++ b/_documentation/en/audit/code-snippets/get-events.md
@@ -13,8 +13,8 @@ You will need to ensure that the following replaceable values are set in the exa
 
 Key | Description
 -- | --
-`VONAGE_API_KEY` | Your Nexmo API key.
-`VONAGE_API_SECRET` | Your Nexmo API secret.
+`VONAGE_API_KEY` | Your Vonage API key.
+`VONAGE_API_SECRET` | Your Vonage API secret.
 
 > In the following example the _Create an application_ and _Initialize your dependencies_ procedures are optional.
 

--- a/_documentation/en/audit/concepts/audit-events.md
+++ b/_documentation/en/audit/concepts/audit-events.md
@@ -29,8 +29,8 @@ The following table lists currently supported Audit Event types:
 | NUMBER_ASSIGN | Number assigned |
 | NUMBER_USER_CANCELED | Number was canceled by the user |
 | NUMBER_UPDATED | Number updated |
-| NUMBER_LINKED | Number linked to Nexmo application |
-| NUMBER_UNLINKED | Number unlinked from Nexmo application |
+| NUMBER_LINKED | Number linked to Vonage application |
+| NUMBER_UNLINKED | Number unlinked from Vonage application |
 | USER_API_KEYS_UPDATE | Sub-accounts for user updated |
 | USER_BILLING_UPDATE | User billing updated |
 | USER_CREATE | User created |
@@ -63,7 +63,7 @@ For example, for a `NUMBER_UPDATED` event type the event object would resemble t
         "created_at": "2018-05-16T16:34:22",
         "user_email": "yourname@example.com",
         "user_id": 1234567,
-        "account_id": "NEXMO_API_KEY",
+        "account_id": "VONAGE_API_KEY",
         "source": "CD",
         "source_ip": "1.2.3.4",
         "source_description": "Customer dashboard",
@@ -73,7 +73,7 @@ For example, for a `NUMBER_UPDATED` event type the event object would resemble t
           "msisdn": "447700900000",
           "http": "http://example.com:9000/webhooks/inbound-sms",
           "voice-type": "app",
-          "voice-value": "NEXMO_APP_ID"
+          "voice-value": "VONAGE_APP_ID"
         }
       }
 ```

--- a/_documentation/en/audit/overview.md
+++ b/_documentation/en/audit/overview.md
@@ -38,7 +38,7 @@ In this document you can learn about:
 
 ## Authentication
 
-Interactions with the Audit API are authenticated using Basic Authentication. Basic Authentication allows you to use your `NEXMO_API_KEY` and `NEXMO_API_SECRET` to validate your API requests. For more general information on authentication see [Authentication](/concepts/guides/authentication).
+Interactions with the Audit API are authenticated using Basic Authentication. Basic Authentication allows you to use your `VONAGE_API_KEY` and `VONAGE_API_SECRET` to validate your API requests. For more general information on authentication see [Authentication](/concepts/guides/authentication).
 
 ## Audit Events
 
@@ -88,8 +88,8 @@ You will need to ensure that the following replaceable values are set in the exa
 
 Key | Description
 -- | --
-`NEXMO_API_KEY` | Your Vonage API key.
-`NEXMO_API_SECRET` | Your Vonage API secret.
+`VONAGE_API_KEY` | Your Vonage API key.
+`VONAGE_API_SECRET` | Your Vonage API secret.
 
 > In the following example the _Create an application_ and _Initialize your dependencies_ procedures are optional.
 

--- a/_documentation/en/client-sdk/setup/create-your-application.md
+++ b/_documentation/en/client-sdk/setup/create-your-application.md
@@ -1,6 +1,6 @@
 ---
 title: Create your application
-description: This topic shows you how to create a Nexmo application, users and tokens.
+description: This topic shows you how to create a Vonage application, users and tokens.
 navigation_weight: 1
 ---
 
@@ -43,13 +43,13 @@ This adds this authentication information to the `.nexmorc` file in your home di
 
 ## Create a Nexmo Application
 
-You now need to create a Nexmo application. In this example you create an application capable of handling both in-app Voice and in-app Messaging use cases.
+You now need to create a Vonage application. In this example you create an application capable of handling both in-app Voice and in-app Messaging use cases.
 
 1) First create your project directory if you've not already done so.
 
 2) Change into the project directory you've just created.
 
-3) Use the following command to create a Nexmo application with Voice and WebRTC capabilities. Replace the webhook URLs with your own.
+3) Use the following command to create a Vonage application with Voice and WebRTC capabilities. Replace the webhook URLs with your own.
 
 ``` shell
 nexmo app:create "My Sample App" --capabilities=voice,rtc --voice-answer-url=https://example.com/webhooks/answer --voice-event-url=https://example.com/webhooks/event --rtc-event-url=https://example.com/webhooks/rtc --keyfile=private.key

--- a/_documentation/en/client-sdk/troubleshooting.md
+++ b/_documentation/en/client-sdk/troubleshooting.md
@@ -9,7 +9,7 @@ navigation_weight: 1
 
 ### Nexmo Application setup
 
-Since you can create multiple Nexmo applications, the commands you run refer to the application that was set up. For example, when you create a user, you must make sure to create it on the application you intended.
+Since you can create multiple Vonage applications, the commands you run refer to the application that was set up. For example, when you create a user, you must make sure to create it on the application you intended.
 
 * Check the app your CLI refers to by running:
 

--- a/_documentation/en/concepts/guides/authentication.md
+++ b/_documentation/en/concepts/guides/authentication.md
@@ -53,7 +53,7 @@ Your API key and secret should be included in the query parameters of requests y
 An example of authentication query parameters would be as follows:
 
 ```
-?api_key=NEXMO_API_KEY&api_secret=NEXMO_API_SECRET
+?api_key=VONAGE_API_KEY&api_secret=VONAGE_API_SECRET
 ```
 
 The request may also need other query parameters and these can be added in any order.

--- a/_documentation/en/concepts/guides/glossary.md
+++ b/_documentation/en/concepts/guides/glossary.md
@@ -411,7 +411,7 @@ The phone number or message shown on a handset when it receives an SMS API messa
 ## Server SDKs
 
 Nexmo provides Server SDKs for various programming languages. These SDKs abstract away much of the complexity involved with accessing our APIs directly, enabling you to develop
-Nexmo applications quickly and reduce time to market.
+Vonage applications quickly and reduce time to market.
 
 Further information can be found on the [Nexmo Tools page](https://developer.nexmo.com/tools).
 

--- a/_documentation/en/conversation/guides/application-setup.md
+++ b/_documentation/en/conversation/guides/application-setup.md
@@ -7,7 +7,7 @@ navigation_weight: 1
 
 In order to set up your Conversation API application, you typically need to carry out the following steps:
 
-1. Create a Nexmo application
+1. Create a Vonage application
 2. Rent and assign a Nexmo number
 3. Build a backend service
 4. Create a client-side application (possibly using the Client SDK)
@@ -24,9 +24,9 @@ This process is illustrated in the following diagram:
 
     a. Set an `answer_url` [webhook](/application/overview#webhooks) to define the behavior when a new call is taking place.
 
-    b. Set `event_url` [webhook](/voice/voice-api/webhook-reference#event-webhook) for your Nexmo application's voice capability to receive the voice events that are dispatched by Voice API. This step is optional but recommended.
+    b. Set `event_url` [webhook](/voice/voice-api/webhook-reference#event-webhook) for your Vonage application's voice capability to receive the voice events that are dispatched by Voice API. This step is optional but recommended.
 
-    c. Set `event_url` [webhook](/application/overview#webhook-types) for your Nexmo application's RTC capability to receive the RTC events that are dispatched by Conversation API. This step is optional but recommended.
+    c. Set `event_url` [webhook](/application/overview#webhook-types) for your Vonage application's RTC capability to receive the RTC events that are dispatched by Conversation API. This step is optional but recommended.
     
     d. Create [Users](/conversation/concepts/user) using the Conversation API.
 

--- a/_documentation/en/conversation/guides/application-setup.md
+++ b/_documentation/en/conversation/guides/application-setup.md
@@ -7,7 +7,7 @@ navigation_weight: 1
 
 In order to set up your Conversation API application, you typically need to carry out the following steps:
 
-1. Create a Vonage application
+1. Create a Nexmo application
 2. Rent and assign a Nexmo number
 3. Build a backend service
 4. Create a client-side application (possibly using the Client SDK)

--- a/_documentation/en/conversation/guides/event-flow.md
+++ b/_documentation/en/conversation/guides/event-flow.md
@@ -58,7 +58,7 @@ As a result of `answer_url` execution, a new [Conversation](/conversation/concep
 
 5. All the respective events are dispatched to your application. These events can be inbound to the backend or to the client app:
 
-    a. and b. **To your backend** via [`event_url` webhooks](/application/overview#webhooks), that you could assign to your Nexmo application. There are both Voice events and RTC events. Events to your Nexmo application's [voice `event_url` webhook](/voice/voice-api/webhook-reference#event-webhook) are dispatched by Voice API. Events to your Nexmo application's RTC capability `event_url` webhook are dispatched by Conversation API.
+    a. and b. **To your backend** via [`event_url` webhooks](/application/overview#webhooks), that you could assign to your Vonage application. There are both Voice events and RTC events. Events to your Vonage application's [voice `event_url` webhook](/voice/voice-api/webhook-reference#event-webhook) are dispatched by Voice API. Events to your Vonage application's RTC capability `event_url` webhook are dispatched by Conversation API.
 
     c. **To your client-side application**, which is [integrated with the Client SDK](/client-sdk/setup/add-sdk-to-your-app/android). These events can be received via callbacks that the Client SDKs trigger if a user is logged in to the SDK. They can also be received via push notifications, if they [have been enabled](/client-sdk/setup/set-up-push-notifications), and the app is in the background.
 

--- a/_documentation/en/conversation/guides/user-authentication.md
+++ b/_documentation/en/conversation/guides/user-authentication.md
@@ -41,7 +41,7 @@ These steps are described in more detail below.
 
 3. **The Conversation API generates a JWT.** If the user is valid your backend calls the Conversation API to generate a JWT for the user. To [generate a JWT](/conversation/guides/jwt-acl) you need:
 
-    a. Your Nexmo application's **private key**. For security reasons, this should be generated and always securely stored on your backend application and not on the client.
+    a. Your Vonage application's **private key**. For security reasons, this should be generated and always securely stored on your backend application and not on the client.
 
     b. **A username** that matches the username of the Nexmo User you’ve created with Conversation API.
     

--- a/_documentation/en/dispatch/code-snippets/before-you-begin.md
+++ b/_documentation/en/dispatch/code-snippets/before-you-begin.md
@@ -51,7 +51,7 @@ The main ones you will meet here are:
 * `/webhooks/inbound-message` - You will receive a callback here when Nexmo receives a message.
 * `/webhooks/message-status` - You will receive a callback here when Nexmo receives a message status update.
 
-If you are testing locally using [Ngrok](https://ngrok.com) you will set your webhook URLs in the Nexmo Application object using a format similar to the following examples:
+If you are testing locally using [Ngrok](https://ngrok.com) you will set your webhook URLs in the Vonage Application object using a format similar to the following examples:
 
 * `https://demo.ngrok.io/webhooks/inbound-message`
 * `https://demo.ngrok.io/webhooks/message-status`

--- a/_documentation/en/dispatch/code-snippets/before-you-begin.md
+++ b/_documentation/en/dispatch/code-snippets/before-you-begin.md
@@ -24,11 +24,11 @@ The following replaceable information depends on the library and specific call:
 
 Key | Description
 -- | --
-`NEXMO_API_KEY` | API key.
-`NEXMO_API_SECRET` | API secret.
-`NEXMO_APPLICATION_PRIVATE_KEY_PATH` |  Private key path.
-`NEXMO_APPLICATION_PRIVATE_KEY` | Private key.
-`NEXMO_APPLICATION_ID` | The Nexmo Application ID.
+`VONAGE_API_KEY` | API key.
+`VONAGE_API_SECRET` | API secret.
+`VONAGE_APPLICATION_PRIVATE_KEY_PATH` |  Private key path.
+`VONAGE_APPLICATION_PRIVATE_KEY` | Private key.
+`VONAGE_APPLICATION_ID` | The Vonage Application ID.
 
 ### Numbers
 
@@ -36,7 +36,7 @@ All phone numbers are in E.164 format.
 
 Key | Description
 -- | --
-`NEXMO_NUMBER` | Replace with your Nexmo Number. E.g. 447700900000
+`VONAGE_NUMBER` | Replace with your Vonage Number. E.g. 447700900000
 `FROM_NUMBER` | Replace with number you are sending from. E.g. 447700900002
 `TO_NUMBER` | Replace with the number you are sending to. E.g. 447700900001
 

--- a/_documentation/en/dispatch/code-snippets/send-a-facebook-message-with-failover.md
+++ b/_documentation/en/dispatch/code-snippets/send-a-facebook-message-with-failover.md
@@ -14,7 +14,7 @@ Ensure the following variables are set to your required values using any conveni
 
 Key | Description
 -- | --
-`NEXMO_APPLICATION_ID` | The ID of the application that you created.
+`VONAGE_APPLICATION_ID` | The ID of the application that you created.
 `FROM_NUMBER` | The phone number you are sending the message from.
 `TO_NUMBER` | The phone number you are sending the message to.
 `FB_SENDER_ID` | Your Page ID. The `FB_SENDER_ID` is the same as the `to.id` value you received in the inbound messenger event on your Inbound Message Webhook URL.

--- a/_documentation/en/dispatch/code-snippets/send-a-viber-message-with-failover.md
+++ b/_documentation/en/dispatch/code-snippets/send-a-viber-message-with-failover.md
@@ -12,7 +12,7 @@ Ensure the following variables are set to your required values using any conveni
 
 Key | Description
 -- | --
-`NEXMO_APPLICATION_ID` | The ID of the application that you created.
+`VONAGE_APPLICATION_ID` | The ID of the application that you created.
 `FROM_NUMBER` | The phone number you are sending the message from.
 `TO_NUMBER` | The phone number you are sending the message to.
 `VIBER_SERVICE_MESSAGE_ID` | Your Viber Service Message ID.

--- a/_documentation/en/dispatch/code-snippets/send-a-whatsapp-message-with-failover.md
+++ b/_documentation/en/dispatch/code-snippets/send-a-whatsapp-message-with-failover.md
@@ -16,7 +16,7 @@ Ensure the following variables are set to your required values using any conveni
 
 Key | Description
 -- | --
-`NEXMO_APPLICATION_ID` | The ID of the application that you created.
+`VONAGE_APPLICATION_ID` | The ID of the application that you created.
 `FROM_NUMBER` | The phone number you are sending the message from.
 `TO_NUMBER` | The phone number you are sending the message to.
 `WHATSAPP_NUMBER` | Your WhatsApp Number.

--- a/_documentation/en/dispatch/code-snippets/send-an-mms-with-failover.md
+++ b/_documentation/en/dispatch/code-snippets/send-an-mms-with-failover.md
@@ -16,7 +16,7 @@ Ensure the following variables are set to your required values using any conveni
 
 Key | Description
 -- | --
-`NEXMO_APPLICATION_ID` | The ID of the application that you created.
+`VONAGE_APPLICATION_ID` | The ID of the application that you created.
 `FROM_NUMBER` | The phone number you are sending the MMS from (US Short Code only).
 `TO_NUMBER` | The phone number you are sending the MMS to.
 

--- a/_documentation/en/dispatch/code-snippets/send-an-sms-with-failover.md
+++ b/_documentation/en/dispatch/code-snippets/send-an-sms-with-failover.md
@@ -14,7 +14,7 @@ Ensure the following variables are set to your required values using any conveni
 
 Key | Description
 -- | --
-`NEXMO_APPLICATION_ID` | The ID of the application that you created.
+`VONAGE_APPLICATION_ID` | The ID of the application that you created.
 `FROM_NUMBER` | The phone number you are sending the SMS from.
 `TO_NUMBER_1` | The phone number you are sending the SMS to.
 `TO_NUMBER_2` | The phone number of the second phone. In this example, the workflow will failover to this number if the first message is not read in 60 seconds.

--- a/_documentation/en/dispatch/overview.md
+++ b/_documentation/en/dispatch/overview.md
@@ -55,8 +55,8 @@ In this example you will need to replace the following variables with actual val
 
 Key | Description
 -- | --
-`NEXMO_API_KEY` | Vonage API key which can be obtained from your [Vonage API Dashboard](https://dashboard.nexmo.com).
-`NEXMO_API_SECRET` | Vonage API secret which can be obtained from your [Vonage API Dashboard](https://dashboard.nexmo.com).
+`VONAGE_API_KEY` | Vonage API key which can be obtained from your [Vonage API Dashboard](https://dashboard.nexmo.com).
+`VONAGE_API_SECRET` | Vonage API secret which can be obtained from your [Vonage API Dashboard](https://dashboard.nexmo.com).
 `FB_SENDER_ID` | Your Page ID. The `FB_SENDER_ID` is the same as the `to.id` value you received in the inbound messenger event on your Inbound Message Webhook URL.
 `FB_RECIPIENT_ID` | The PSID of the user you want to reply to. The `FB_RECIPIENT_ID` is the PSID of the Facebook User you are messaging. This value is the `from.id` value you received in the inbound messenger event on your Inbound Message Webhook URL.
 `FROM_NUMBER` | A phone number you own or some text to identify the sender.

--- a/_documentation/en/messages/code-snippets/before-you-begin.md
+++ b/_documentation/en/messages/code-snippets/before-you-begin.md
@@ -54,7 +54,7 @@ The main ones you will meet here are:
 * `/webhooks/inbound-message` - You will receive a callback here when Nexmo receives a message.
 * `/webhooks/message-status` - You will receive a callback here when Nexmo receives a message status update.
 
-If you are testing locally using [Ngrok](https://ngrok.com) you will set your webhook URLs in the Nexmo Application object using a format similar to the following examples:
+If you are testing locally using [Ngrok](https://ngrok.com) you will set your webhook URLs in the Vonage Application object using a format similar to the following examples:
 
 * `https://demo.ngrok.io/webhooks/inbound-message`
 * `https://demo.ngrok.io/webhooks/message-status`

--- a/_documentation/en/messages/code-snippets/before-you-begin.md
+++ b/_documentation/en/messages/code-snippets/before-you-begin.md
@@ -27,11 +27,11 @@ The following replaceable information depends on the library and specific call:
 
 Key | Description
 -- | --
-`NEXMO_API_KEY` | API key.
-`NEXMO_API_SECRET` | API secret.
-`NEXMO_APPLICATION_PRIVATE_KEY_PATH` |  Private key path.
-`NEXMO_APPLICATION_PRIVATE_KEY` | Private key.
-`NEXMO_APPLICATION_ID` | The Nexmo Application ID.
+`VONAGE_API_KEY` | API key.
+`VONAGE_API_SECRET` | API secret.
+`VONAGE_APPLICATION_PRIVATE_KEY_PATH` |  Private key path.
+`VONAGE_APPLICATION_PRIVATE_KEY` | Private key.
+`VONAGE_APPLICATION_ID` | The Vonage Application ID.
 
 ### Numbers
 
@@ -39,7 +39,7 @@ All phone numbers are in E.164 format.
 
 Key | Description
 -- | --
-`NEXMO_NUMBER` | Replace with your Nexmo Number. E.g. 447700900000
+`VONAGE_NUMBER` | Replace with your Vonage Number. E.g. 447700900000
 `FROM_NUMBER` | Replace with number you are sending from. E.g. 447700900002
 `TO_NUMBER` | Replace with the number you are sending to. E.g. 447700900001
 

--- a/_documentation/en/messages/code-snippets/create-an-application.md
+++ b/_documentation/en/messages/code-snippets/create-an-application.md
@@ -1,7 +1,7 @@
 ---
-title: Create a Nexmo Application
+title: Create a Vonage Application
 navigation_weight: 2
-description: You can create a Nexmo Messages and Dispatch application either in the Dashboard or using the Nexmo CLI.
+description: You can create a Vonage Messages and Dispatch application either in the Dashboard or using the Nexmo CLI.
 ---
 
 # Create a Messages API Application

--- a/_documentation/en/messages/code-snippets/sms/send-sms.md
+++ b/_documentation/en/messages/code-snippets/sms/send-sms.md
@@ -26,7 +26,7 @@ Ensure the following variables are set to your required values using any conveni
 
 Key | Description
 -- | --
-`NEXMO_APPLICATION_ID` | The ID of the application that you created.
+`VONAGE_APPLICATION_ID` | The ID of the application that you created.
 `FROM_NUMBER` | The phone number you are sending the message from.
 `TO_NUMBER` | The phone number you are sending the message to.
 

--- a/_documentation/en/messages/code-snippets/viber/send-image.md
+++ b/_documentation/en/messages/code-snippets/viber/send-image.md
@@ -20,7 +20,7 @@ Key | Description
 -- | --
 `BASE_URL` | For production use the base URL is `https://api.nexmo.com/`. For sandbox testing the base URL is `https://messages-sandbox.nexmo.com/`.
 `MESSAGES_API_URL` | For production use the Messages API endpoint is `https://api.nexmo.com/v0.1/messages`. For sandbox testing the Messages API endpoint is `https://messages-sandbox.nexmo.com/v0.1/messages`.
-`NEXMO_APPLICATION_ID` | The ID of the application that you created.
+`VONAGE_APPLICATION_ID` | The ID of the application that you created.
 `VIBER_SERVICE_MESSAGE_ID` | Your Viber Service Message ID. For sandbox testing this is `16273`.
 `TO_NUMBER` | The phone number you are sending the message to.
 `IMAGE_URL` | The URL of the image you want to send.

--- a/_documentation/en/messages/code-snippets/viber/send-text.md
+++ b/_documentation/en/messages/code-snippets/viber/send-text.md
@@ -20,7 +20,7 @@ Key | Description
 -- | --
 `BASE_URL` | For production use the base URL is `https://api.nexmo.com/`. For sandbox testing the base URL is `https://messages-sandbox.nexmo.com/`.
 `MESSAGES_API_URL` | For production use the Messages API endpoint is `https://api.nexmo.com/v0.1/messages`. For sandbox testing the Messages API endpoint is `https://messages-sandbox.nexmo.com/v0.1/messages`.
-`NEXMO_APPLICATION_ID` | The ID of the application that you created.
+`VONAGE_APPLICATION_ID` | The ID of the application that you created.
 `VIBER_SERVICE_MESSAGE_ID` | Your Viber Service Message ID. For sandbox testing this is `16273`.
 `TO_NUMBER` | The phone number you are sending the message to.
 

--- a/_documentation/en/messages/overview.md
+++ b/_documentation/en/messages/overview.md
@@ -85,8 +85,8 @@ In this example you will need to replace the following variables with actual val
 
 Key | Description
 -- | --
-`NEXMO_API_KEY` | Vonage API key which can be obtained from your [Vonage API Dashboard](https://dashboard.nexmo.com).
-`NEXMO_API_SECRET` | Vonage API secret which can be obtained from your [Vonage API Dashboard](https://dashboard.nexmo.com).
+`VONAGE_API_KEY` | Vonage API key which can be obtained from your [Vonage API Dashboard](https://dashboard.nexmo.com).
+`VONAGE_API_SECRET` | Vonage API secret which can be obtained from your [Vonage API Dashboard](https://dashboard.nexmo.com).
 `FROM_NUMBER` | A phone number you own or some text to identify the sender.
 `TO_NUMBER` | The number of the phone to which the message will be sent.
 

--- a/_documentation/en/messaging/sms/code-snippets/delivery-receipts.md
+++ b/_documentation/en/messaging/sms/code-snippets/delivery-receipts.md
@@ -13,7 +13,7 @@ You can verify that a message you sent using Nexmo's SMS API reached your custom
 To access the delivery receipt, you need to:
 
 * [Create a webhook endpoint](/messaging/sms/code-snippets/before-you-begin#webhooks) using one of the code examples shown below
-* [Configure the webhook endpoint in your Nexmo Dashboard](#configure-the-webhook-endpoint-in-your-nexmo-dashboard)
+* [Configure the webhook endpoint in your Vonage Dashboard](#configure-the-webhook-endpoint-in-your-nexmo-dashboard)
 
 > **NOTE:** After you send a message there may be a delay before you receive the delivery receipt.
 
@@ -21,11 +21,11 @@ To access the delivery receipt, you need to:
 source: '_examples/messaging/sms/delivery-receipts'
 ```
 
-## Configure the webhook endpoint in your Nexmo Dashboard
+## Configure the webhook endpoint in your Vonage Dashboard
 
 So that Nexmo knows how to access your webhook, you must configure it in your Nexmo account.
 
-In the code snippets, the webhook is located at `/webhooks/delivery-receipt`. If you are using Ngrok, the webhook you need to configure in your [Nexmo Dashboard API Settings page](https://dashboard.nexmo.com/settings) is of the form `https://demo.ngrok.io/webhooks/delivery-receipt`. Replace `demo` with the subdomain provided by Ngrok and enter your endpoint in the field labeled **Webhook URL for Delivery Receipts**:
+In the code snippets, the webhook is located at `/webhooks/delivery-receipt`. If you are using Ngrok, the webhook you need to configure in your [Vonage Dashboard API Settings page](https://dashboard.nexmo.com/settings) is of the form `https://demo.ngrok.io/webhooks/delivery-receipt`. Replace `demo` with the subdomain provided by Ngrok and enter your endpoint in the field labeled **Webhook URL for Delivery Receipts**:
 
 ```screenshot
 script: app/screenshots/webhook-url-for-delivery-receipt.js

--- a/_documentation/en/messaging/sms/code-snippets/receiving-an-sms.md
+++ b/_documentation/en/messaging/sms/code-snippets/receiving-an-sms.md
@@ -9,18 +9,18 @@ To receive an SMS, you need to:
 
 * [Rent a virtual number](/numbers/guides/number-management#rent-a-virtual-number) to receive messages
 * [Create a webhook endpoint](/messaging/sms/code-snippets/before-you-begin#webhooks) using one of the code examples shown below
-* [Configure the webhook in your Nexmo Dashboard](#configure-the-webhook-endpoint-in-your-nexmo-dashboard)
+* [Configure the webhook in your Vonage Dashboard](#configure-the-webhook-endpoint-in-your-nexmo-dashboard)
 
 
 ```code_snippets
 source: '_examples/messaging/sms/receiving-an-sms'
 ```
 
-## Configure the webhook endpoint in your Nexmo Dashboard
+## Configure the webhook endpoint in your Vonage Dashboard
 
 So that Nexmo knows how to access your webhook, you must configure it in your Nexmo account.
 
-In the code snippets, the webhook is located at `/webhooks/inbound-sms`. If you are using Ngrok, the webhook you need to configure in your [Nexmo Dashboard API Settings page](https://dashboard.nexmo.com/settings) is of the form `https://demo.ngrok.io/webhooks/inbound-sms`. Replace `demo` with the subdomain provided by Ngrok and enter your endpoint in the field labeled **Webhook URL for Inbound Message**:
+In the code snippets, the webhook is located at `/webhooks/inbound-sms`. If you are using Ngrok, the webhook you need to configure in your [Vonage Dashboard API Settings page](https://dashboard.nexmo.com/settings) is of the form `https://demo.ngrok.io/webhooks/inbound-sms`. Replace `demo` with the subdomain provided by Ngrok and enter your endpoint in the field labeled **Webhook URL for Inbound Message**:
 
 ```screenshot
 script: app/screenshots/webhook-url-for-inbound-message.js

--- a/_documentation/en/messaging/sms/code-snippets/send-an-sms-with-unicode.md
+++ b/_documentation/en/messaging/sms/code-snippets/send-an-sms-with-unicode.md
@@ -12,8 +12,8 @@ To send an SMS that contains Unicode characters, replace the following variables
 
 Key | Description
 -- | --
-`VONAGE_API_KEY` | You can find this in your Nexmo Dashboard.
-`VONAGE_API_SECRET` | You can find this in your Nexmo Dashboard.
+`VONAGE_API_KEY` | You can find this in your Vonage Dashboard.
+`VONAGE_API_SECRET` | You can find this in your Vonage Dashboard.
 `VONAGE_BRAND_NAME` | The alphanumeric string that represents the name or number of the organization sending the message.
 `TO_NUMBER` | The number you are sending the SMS to, for example `447700900000`.
 

--- a/_documentation/en/messaging/sms/code-snippets/send-an-sms-with-unicode.md
+++ b/_documentation/en/messaging/sms/code-snippets/send-an-sms-with-unicode.md
@@ -12,9 +12,9 @@ To send an SMS that contains Unicode characters, replace the following variables
 
 Key | Description
 -- | --
-`NEXMO_API_KEY` | You can find this in your Nexmo Dashboard.
-`NEXMO_API_SECRET` | You can find this in your Nexmo Dashboard.
-`NEXMO_BRAND_NAME` | The alphanumeric string that represents the name or number of the organization sending the message.
+`VONAGE_API_KEY` | You can find this in your Nexmo Dashboard.
+`VONAGE_API_SECRET` | You can find this in your Nexmo Dashboard.
+`VONAGE_BRAND_NAME` | The alphanumeric string that represents the name or number of the organization sending the message.
 `TO_NUMBER` | The number you are sending the SMS to, for example `447700900000`.
 
 ```code_snippets

--- a/_documentation/en/messaging/sms/code-snippets/send-an-sms.md
+++ b/_documentation/en/messaging/sms/code-snippets/send-an-sms.md
@@ -10,9 +10,9 @@ To send an SMS, replace the following variables in the example below:
 
 Key | Description
 -- | --
-`NEXMO_API_KEY` | You can find this in your account overview
-`NEXMO_API_SECRET` | You can find this in your account overview
-`NEXMO_BRAND_NAME` | The alphanumeric string that represents the name or number of the organization sending the message.
+`VONAGE_API_KEY` | You can find this in your account overview
+`VONAGE_API_SECRET` | You can find this in your account overview
+`VONAGE_BRAND_NAME` | The alphanumeric string that represents the name or number of the organization sending the message.
 `TO_NUMBER` | The number you are sending the SMS to in E.164  format. For example `447700900000`.
 
 

--- a/_documentation/en/messaging/sms/overview.md
+++ b/_documentation/en/messaging/sms/overview.md
@@ -39,8 +39,8 @@ Replace the following placeholder values in the sample code:
 
 Key | Description
 -- | --
-`NEXMO_API_KEY` | Your Nexmo API key.
-`NEXMO_API_SECRET` | Your Nexmo API secret.
+`VONAGE_API_KEY` | Your Nexmo API key.
+`VONAGE_API_SECRET` | Your Nexmo API secret.
 
 ```code_snippets
 source: '_examples/messaging/sms/send-an-sms'

--- a/_documentation/en/messaging/sms/overview.md
+++ b/_documentation/en/messaging/sms/overview.md
@@ -39,8 +39,8 @@ Replace the following placeholder values in the sample code:
 
 Key | Description
 -- | --
-`VONAGE_API_KEY` | Your Nexmo API key.
-`VONAGE_API_SECRET` | Your Nexmo API secret.
+`VONAGE_API_KEY` | Your Vonage API key.
+`VONAGE_API_SECRET` | Your Vonage API secret.
 
 ```code_snippets
 source: '_examples/messaging/sms/send-an-sms'

--- a/_documentation/en/number-insight/code-snippets/before-you-begin.md
+++ b/_documentation/en/number-insight/code-snippets/before-you-begin.md
@@ -32,8 +32,8 @@ Replace the following values in the code snippets with your own details:
 
 Key |	Description
 -- | --
-`NEXMO_API_KEY` | API key.
-`NEXMO_API_SECRET` | API secret.
+`VONAGE_API_KEY` | API key.
+`VONAGE_API_SECRET` | API secret.
 `INSIGHT_NUMBER` | The number you want to retrieve insight information for.
 
 ## Webhooks

--- a/_documentation/en/number-insight/guides/cnam.md
+++ b/_documentation/en/number-insight/guides/cnam.md
@@ -21,7 +21,7 @@ Passing `cnam=true` as an extra parameter in a call to the Advanced API looks up
 The following example shows how you would request CNAM data using `curl`:
 
 ```bash
-$ curl "https://api.nexmo.com/ni/advanced/json?api_key=NEXMO_API_KEY&api_secret=NEXMO_API_SECRET&number=14155550100&cnam=true"
+$ curl "https://api.nexmo.com/ni/advanced/json?api_key=VONAGE_API_KEY&api_secret=VONAGE_API_SECRET&number=14155550100&cnam=true"
 ```
 
 ## Understanding the response

--- a/_documentation/en/number-insight/guides/number-insight-via-cli.md
+++ b/_documentation/en/number-insight/guides/number-insight-via-cli.md
@@ -27,11 +27,11 @@ $ npm install -g nexmo-cli
 
 > *Note*: If you do not have sufficient system privileges you might need to prefix the above command with `sudo`.
 
-Then, provide the Nexmo CLI with your `NEXMO_API_KEY` and `NEXMO_API_SECRET` which you can 
+Then, provide the Nexmo CLI with your `VONAGE_API_KEY` and `VONAGE_API_SECRET` which you can 
 find on the [dashboard getting started page](https://dashboard.nexmo.com/getting-started-guide):
 
 ```bash
-$ nexmo setup NEXMO_API_KEY NEXMO_API_SECRET
+$ nexmo setup VONAGE_API_KEY VONAGE_API_SECRET
 ```
 
 You only need to do this the first time you use the Nexmo CLI.

--- a/_documentation/en/number-insight/overview.md
+++ b/_documentation/en/number-insight/overview.md
@@ -69,10 +69,10 @@ $ npm install -g nexmo-cli
 
 > Note: Depending on your user permissions, you might need to prefix the above command with `sudo`.
 
-Use your `NEXMO_API_KEY` and `NEXMO_API_SECRET` from the [dashboard getting started page](https://dashboard.nexmo.com/getting-started-guide) to set up the Nexmo CLI with your credentials:
+Use your `VONAGE_API_KEY` and `VONAGE_API_SECRET` from the [dashboard getting started page](https://dashboard.nexmo.com/getting-started-guide) to set up the Nexmo CLI with your credentials:
 
 ```
-$ nexmo setup NEXMO_API_KEY NEXMO_API_SECRET
+$ nexmo setup VONAGE_API_KEY VONAGE_API_SECRET
 ```
 
 ### Execute a Number Insight API Basic lookup

--- a/_documentation/en/numbers/code-snippets/buy.md
+++ b/_documentation/en/numbers/code-snippets/buy.md
@@ -19,10 +19,10 @@ Replace the following variables in the sample code with your own values:
 
 Name | Description
 --|--
-`NEXMO_API_KEY` | Your Nexmo [API key](https://developer.nexmo.com/concepts/guides/authentication#api-key-and-secret)
-`NEXMO_API_SECRET` | Your Nexmo [API secret](https://developer.nexmo.com/concepts/guides/authentication#api-key-and-secret)
+`VONAGE_API_KEY` | Your Vonage [API key](https://developer.nexmo.com/concepts/guides/authentication#api-key-and-secret)
+`VONAGE_API_SECRET` | Your Vonage [API secret](https://developer.nexmo.com/concepts/guides/authentication#api-key-and-secret)
 `COUNTRY_CODE` | The two digit country code for the number you want to buy. For example: `GB` for the United Kingdom.
-`NEXMO_NUMBER` | The Nexmo virtual number you want to cancel. Omit the leading zero but include the international dialing code. For example: `447700900000`.
+`VONAGE_NUMBER` | The Vonage virtual number you want to cancel. Omit the leading zero but include the international dialing code. For example: `447700900000`.
 
 ```code_snippets
 source: '_examples/numbers/buy'

--- a/_documentation/en/numbers/code-snippets/cancel.md
+++ b/_documentation/en/numbers/code-snippets/cancel.md
@@ -15,10 +15,10 @@ Replace the following variables in the sample code with your own values:
 
 Name | Description
 --|--
-`NEXMO_API_KEY` | Your Nexmo [API key](https://developer.nexmo.com/concepts/guides/authentication#api-key-and-secret)
-`NEXMO_API_SECRET` | Your Nexmo [API secret](https://developer.nexmo.com/concepts/guides/authentication#api-key-and-secret)
+`VONAGE_API_KEY` | Your Vonage [API key](https://developer.nexmo.com/concepts/guides/authentication#api-key-and-secret)
+`VONAGE_API_SECRET` | Your Vonage [API secret](https://developer.nexmo.com/concepts/guides/authentication#api-key-and-secret)
 `COUNTRY_CODE` | The two digit country code for the number you want to cancel. For example: `GB` for the United Kingdom.
-`NEXMO_NUMBER` | The Nexmo virtual number you want to cancel. Omit the leading zero but include the international dialing code. For example: `447700900000`.
+`VONAGE_NUMBER` | The Vonage virtual number you want to cancel. Omit the leading zero but include the international dialing code. For example: `447700900000`.
 
 ```code_snippets
 source: '_examples/numbers/cancel'

--- a/_documentation/en/numbers/code-snippets/list-owned.md
+++ b/_documentation/en/numbers/code-snippets/list-owned.md
@@ -13,8 +13,8 @@ Replace the following variables in the sample code with your own values:
 
 Name | Description
 --|--
-`NEXMO_API_KEY` | Your Nexmo [API key](https://developer.nexmo.com/concepts/guides/authentication#api-key-and-secret)
-`NEXMO_API_SECRET` | Your Nexmo [API secret](https://developer.nexmo.com/concepts/guides/authentication#api-key-and-secret)
+`VONAGE_API_KEY` | Your Vonage [API key](https://developer.nexmo.com/concepts/guides/authentication#api-key-and-secret)
+`VONAGE_API_SECRET` | Your Vonage [API secret](https://developer.nexmo.com/concepts/guides/authentication#api-key-and-secret)
 `NUMBER_SEARCH_CRITERIA` | The filter criteria. For example, numbers containing `234`.
 `NUMBER_SEARCH_PATTERN` | Where the `NUMBER_SEARCH_CRITERIA` should appear in the number: <ul><li>`0` - At the beginning of the number</li><li>`1`- Anywhere in the number</li><li>`2` - At the end of the number</ul>
 

--- a/_documentation/en/numbers/code-snippets/search-available.md
+++ b/_documentation/en/numbers/code-snippets/search-available.md
@@ -13,11 +13,11 @@ Replace the following variables in the sample code with your own values:
 
 Name | Description
 --|--
-`NEXMO_API_KEY` | Your Nexmo [API key](https://developer.nexmo.com/concepts/guides/authentication#api-key-and-secret)
-`NEXMO_API_SECRET` | Your Nexmo [API secret](https://developer.nexmo.com/concepts/guides/authentication#api-key-and-secret)
+`VONAGE_API_KEY` | Your Vonage [API key](https://developer.nexmo.com/concepts/guides/authentication#api-key-and-secret)
+`VONAGE_API_SECRET` | Your Vonage [API secret](https://developer.nexmo.com/concepts/guides/authentication#api-key-and-secret)
 `COUNTRY_CODE` | The two digit country code for the numbers you want to search. For example: `GB` for the United Kingdom.
-`NEXMO_NUMBER_TYPE` | The type of number: `landline`, `mobile-lvn` or `landline-toll-free`
-`NEXMO_NUMBER_FEATURES` | The capabilities of the number: `SMS`, `VOICE` or `SMS,VOICE` for both
+`VONAGE_NUMBER_TYPE` | The type of number: `landline`, `mobile-lvn` or `landline-toll-free`
+`VONAGE_NUMBER_FEATURES` | The capabilities of the number: `SMS`, `VOICE` or `SMS,VOICE` for both
 `NUMBER_SEARCH_CRITERIA` | The filter criteria. For example, numbers containing `234`.
 `NUMBER_SEARCH_PATTERN` | Where the `NUMBER_SEARCH_CRITERIA` should appear in the number: <ul><li>`0` - At the beginning of the number</li><li>`1`- Anywhere in the number</li><li>`2` - At the end of the number</ul>
 

--- a/_documentation/en/numbers/code-snippets/update.md
+++ b/_documentation/en/numbers/code-snippets/update.md
@@ -13,12 +13,12 @@ Replace the following variables in the sample code with your own values:
 
 Name | Description
 --|--
-`NEXMO_API_KEY` | Your Nexmo [API key](https://developer.nexmo.com/concepts/guides/authentication#api-key-and-secret)
-`NEXMO_API_SECRET` | Your Nexmo [API secret](https://developer.nexmo.com/concepts/guides/authentication#api-key-and-secret)
+`VONAGE_API_KEY` | Your Vonage [API key](https://developer.nexmo.com/concepts/guides/authentication#api-key-and-secret)
+`VONAGE_API_SECRET` | Your Vonage [API secret](https://developer.nexmo.com/concepts/guides/authentication#api-key-and-secret)
 `COUNTRY_CODE` | The two digit country code for the number you want to update. For example: `GB` for the United Kingdom.
-`NEXMO_NUMBER` | The Nexmo virtual number you want to update. Omit the leading zero but include the international dialing code. For example: `447700900000`.
+`VONAGE_NUMBER` | The Vonage virtual number you want to update. Omit the leading zero but include the international dialing code. For example: `447700900000`.
 `SMS_CALLBACK_URL` | An URL-encoded URI to the webhook endpoint that handles inbound messages. Your webhook endpoint must be active before you make this request. Nexmo makes a GET request to the endpoint and checks that it returns a 200 OK response. Set this parameter's value to an empty string to remove the webhook.
-`NEXMO_APPLICATION_ID` | The ID of the application that handles inbound traffic to this number.
+`VONAGE_APPLICATION_ID` | The ID of the application that handles inbound traffic to this number.
 `VOICE_CALLBACK_TYPE` | The Voice API webhook type: `sip`, `tel` or `app`
 `VOICE_CALLBACK_VALUE` | A SIP URI, telephone number or Application ID, depending on `VOICE_CALLBACK_TYPE`
 `VOICE_STATUS_URL` | A webhook URL for Nexmo to post Voice API status updates to

--- a/_documentation/en/redact/code-snippets/redact-using-id.md
+++ b/_documentation/en/redact/code-snippets/redact-using-id.md
@@ -13,8 +13,8 @@ Replace the following variables in the example code:
 
 Key |	Description
 -- | --
-`NEXMO_REDACT_ID` | The ID of the data record that you'd like to redact
-`NEXMO_REDACT_TYPE` | The product that the ID belongs to e.g. `sms`
+`VONAGE_REDACT_ID` | The ID of the data record that you'd like to redact
+`VONAGE_REDACT_TYPE` | The product that the ID belongs to e.g. `sms`
 
 ```code_snippets
 source: '_examples/redact/redact-a-transaction'

--- a/_documentation/en/reports/code-snippets/before-you-begin.md
+++ b/_documentation/en/reports/code-snippets/before-you-begin.md
@@ -30,9 +30,9 @@ When you use the code snippets you copy in your replacements for variables such 
 
 Variable | Description
 ----|----
-`NEXMO_API_KEY` | Your API key which you can obtain from your [Dashboard](https://dashboard.nexmo.com/sign-in).
-`NEXMO_API_SECRET` | Your API secret which you can obtain from your [Dashboard](https://dashboard.nexmo.com/sign-in).
-`ACCOUNT_ID` | The account ID (same as `NEXMO_API_KEY`) for the account you want to generate reports, or retrieve records for.
+`VONAGE_API_KEY` | Your API key which you can obtain from your [Dashboard](https://dashboard.nexmo.com/sign-in).
+`VONAGE_API_SECRET` | Your API secret which you can obtain from your [Dashboard](https://dashboard.nexmo.com/sign-in).
+`ACCOUNT_ID` | The account ID (same as `VONAGE_API_KEY`) for the account you want to generate reports, or retrieve records for.
 `REPORT_PRODUCT` | Specifies the product for which reports and records are obtained. Can be one of `SMS`, `VOICE-CALL`, `VERIFY-API`, `NUMBER-INSIGHT`, `MESSAGES` or `CONVERSATIONS`.
 `REQUEST_ID` | When you request creation of report asynchronously, a `request_id` for the report generation is returned.
 `DATE_START` | Date of time window from when you want to start gathering records in ISO-8601 format.
@@ -59,14 +59,14 @@ The dates can use either of the following formats: `yyyy-mm-ddThh:mm:ss[.sss]±h
 This example shows fetching a list of records using a date range:
 
 ```sh
-curl -u "$NEXMO_API_KEY:$NEXMO_API_SECRET" \
+curl -u "$VONAGE_API_KEY:$VONAGE_API_SECRET" \
      "https://api.nexmo.com/v2/reports/records?account_id=abcd1234&product=MESSAGES&direction=outbound&date_start=2020-06-04T00:01:00Z&date_end=2020-06-04T00:02:00Z"
 ```
 
 For dates containing a `+` in a `GET` query, where dates are passed as query parameters, you need to URL encode the dates, for example:
 
 ```sh
-curl -G --data-urlencode date_start="2020-06-04T08:00:00+0000" --data-urlencode date_end="2020-06-04T14:00:00+0000" -u "$NEXMO_API_KEY:$NEXMO_API_SECRET" \
+curl -G --data-urlencode date_start="2020-06-04T08:00:00+0000" --data-urlencode date_end="2020-06-04T14:00:00+0000" -u "$VONAGE_API_KEY:$VONAGE_API_SECRET" \
      "https://api.nexmo.com/v2/reports/records?account_id=abcd1234&product=SMS&direction=outbound"
 ```
 

--- a/_documentation/en/reports/code-snippets/cancel-report.md
+++ b/_documentation/en/reports/code-snippets/cancel-report.md
@@ -12,8 +12,8 @@ This code snippet shows you how to cancel the creation of a report.
 
 Variable | Required | Description
 ----|----|----
-`NEXMO_API_KEY` | Yes | Your API key which you can obtain from your [Dashboard](https://dashboard.nexmo.com/sign-in).
-`NEXMO_API_SECRET` | Yes | Your API secret which you can obtain from your [Dashboard](https://dashboard.nexmo.com/sign-in).
+`VONAGE_API_KEY` | Yes | Your API key which you can obtain from your [Dashboard](https://dashboard.nexmo.com/sign-in).
+`VONAGE_API_SECRET` | Yes | Your API secret which you can obtain from your [Dashboard](https://dashboard.nexmo.com/sign-in).
 `REQUEST_ID` | Yes | The request ID of the report to cancel creation of.
 
 ```code_snippets

--- a/_documentation/en/reports/code-snippets/create-async-report.md
+++ b/_documentation/en/reports/code-snippets/create-async-report.md
@@ -16,8 +16,8 @@ Date range is limited to 13 months for this call.
 
 Variable | Required | Description
 ----|----|----
-`NEXMO_API_KEY` | Yes | Your API key which you can obtain from your [Dashboard](https://dashboard.nexmo.com/sign-in).
-`NEXMO_API_SECRET` | Yes | Your API secret which you can obtain from your [Dashboard](https://dashboard.nexmo.com/sign-in).
+`VONAGE_API_KEY` | Yes | Your API key which you can obtain from your [Dashboard](https://dashboard.nexmo.com/sign-in).
+`VONAGE_API_SECRET` | Yes | Your API secret which you can obtain from your [Dashboard](https://dashboard.nexmo.com/sign-in).
 `ACCOUNT_ID` | Yes | The API key for the target account. Reports generated, or records retrieved, are for this account.
 `REPORT_DIRECTION` | Yes | Either `inbound` or `outbound`
 `REPORT_PRODUCT` | Yes | Specifies the product for which reports and records are obtained. Can be one of `SMS`, `VOICE-CALL`, `VERIFY-API`, `NUMBER-INSIGHT`, `MESSAGES` or `CONVERSATIONS`.

--- a/_documentation/en/reports/code-snippets/get-report-status.md
+++ b/_documentation/en/reports/code-snippets/get-report-status.md
@@ -12,8 +12,8 @@ This code snippet shows you how to obtain the status of a report. It is often us
 
 Variable | Required | Description
 ----|----|----
-`NEXMO_API_KEY` | Yes | Your API key which you can obtain from your [Dashboard](https://dashboard.nexmo.com/sign-in).
-`NEXMO_API_SECRET` | Yes | Your API secret which you can obtain from your [Dashboard](https://dashboard.nexmo.com/sign-in).
+`VONAGE_API_KEY` | Yes | Your API key which you can obtain from your [Dashboard](https://dashboard.nexmo.com/sign-in).
+`VONAGE_API_SECRET` | Yes | Your API secret which you can obtain from your [Dashboard](https://dashboard.nexmo.com/sign-in).
 `REQUEST_ID` | Yes | The request ID of the report to check the status of.
 
 ```code_snippets

--- a/_documentation/en/reports/code-snippets/get-report.md
+++ b/_documentation/en/reports/code-snippets/get-report.md
@@ -12,8 +12,8 @@ This code snippet shows you how to retrieve a report file. The report file is a 
 
 Variable | Required | Description
 ----|----|----
-`NEXMO_API_KEY` | Yes | Your API key which you can obtain from your [Dashboard](https://dashboard.nexmo.com/sign-in).
-`NEXMO_API_SECRET` | Yes | Your API secret which you can obtain from your [Dashboard](https://dashboard.nexmo.com/sign-in).
+`VONAGE_API_KEY` | Yes | Your API key which you can obtain from your [Dashboard](https://dashboard.nexmo.com/sign-in).
+`VONAGE_API_SECRET` | Yes | Your API secret which you can obtain from your [Dashboard](https://dashboard.nexmo.com/sign-in).
 `FILE_ID` | Yes | The file ID of the report to retrieve.
 
 ```code_snippets

--- a/_documentation/en/reports/code-snippets/list-reports.md
+++ b/_documentation/en/reports/code-snippets/list-reports.md
@@ -12,8 +12,8 @@ This code snippet shows you how to list all asynchronous report requests with th
 
 Variable | Required | Description
 ----|----|----
-`NEXMO_API_KEY` | Yes | Your API key which you can obtain from your [Dashboard](https://dashboard.nexmo.com/sign-in).
-`NEXMO_API_SECRET` | Yes | Your API secret which you can obtain from your [Dashboard](https://dashboard.nexmo.com/sign-in).
+`VONAGE_API_KEY` | Yes | Your API key which you can obtain from your [Dashboard](https://dashboard.nexmo.com/sign-in).
+`VONAGE_API_SECRET` | Yes | Your API secret which you can obtain from your [Dashboard](https://dashboard.nexmo.com/sign-in).
 `ACCOUNT_ID` | Yes | The API key for the target account. Reports generated, or records retrieved, are for this account.
 `REPORT_STATUS` | Yes | A comma-separated list of report status values. Reports with any of the statuses specified are returned. The values in the comma-separated list specified for `status` can be any of `PENDING`, `PROCESSING`, `SUCCESS`, `ABORTED`, `FAILED`, `TRUNCATED`.
 

--- a/_documentation/en/reports/code-snippets/load-records-sync-dates.md
+++ b/_documentation/en/reports/code-snippets/load-records-sync-dates.md
@@ -14,8 +14,8 @@ This code snippet shows you how to retrieve a set of records using a date range.
 
 Variable | Required | Description
 ----|----|----
-`NEXMO_API_KEY` | Yes | Your API key which you can obtain from your [Dashboard](https://dashboard.nexmo.com/sign-in).
-`NEXMO_API_SECRET` | Yes | Your API secret which you can obtain from your [Dashboard](https://dashboard.nexmo.com/sign-in).
+`VONAGE_API_KEY` | Yes | Your API key which you can obtain from your [Dashboard](https://dashboard.nexmo.com/sign-in).
+`VONAGE_API_SECRET` | Yes | Your API secret which you can obtain from your [Dashboard](https://dashboard.nexmo.com/sign-in).
 `ACCOUNT_ID` | Yes | The API key for the target account. Reports generated, or records retrieved, are for this account.
 `REPORT_DIRECTION` | Yes | Either `inbound` or `outbound`
 `REPORT_PRODUCT` | Yes | Specifies the product for which reports and records are obtained. Can be one of `SMS`, `VOICE-CALL`, `VERIFY-API`, `NUMBER-INSIGHT`, `MESSAGES` or `CONVERSATIONS`.

--- a/_documentation/en/reports/code-snippets/load-records-sync-id.md
+++ b/_documentation/en/reports/code-snippets/load-records-sync-id.md
@@ -12,8 +12,8 @@ This code snippet shows you how to retrieve a specific record by specifying a **
 
 Variable | Required | Description
 ----|----|----
-`NEXMO_API_KEY` | Yes | Your API key which you can obtain from your [Dashboard](https://dashboard.nexmo.com/sign-in).
-`NEXMO_API_SECRET` | Yes | Your API secret which you can obtain from your [Dashboard](https://dashboard.nexmo.com/sign-in).
+`VONAGE_API_KEY` | Yes | Your API key which you can obtain from your [Dashboard](https://dashboard.nexmo.com/sign-in).
+`VONAGE_API_SECRET` | Yes | Your API secret which you can obtain from your [Dashboard](https://dashboard.nexmo.com/sign-in).
 `ACCOUNT_ID` | Yes | The API key for the target account. Reports generated, or records retrieved, are for this account.
 `REPORT_DIRECTION` | Yes | Either `inbound` or `outbound`
 `REPORT_PRODUCT` | Yes | Specifies the product for which reports and records are obtained. Can be one of `SMS`, `VOICE-CALL`, `VERIFY-API`, `NUMBER-INSIGHT`, `MESSAGES` or `CONVERSATIONS`.

--- a/_documentation/en/tools/ngrok.md
+++ b/_documentation/en/tools/ngrok.md
@@ -1,6 +1,6 @@
 ---
 title: Ngrok
-description: This topic shows you how to test your Nexmo application locally using Ngrok. 
+description: This topic shows you how to test your Vonage application locally using Ngrok.
 ---
 
 # Testing with Ngrok

--- a/_documentation/en/verify/code-snippets/before-you-begin.md
+++ b/_documentation/en/verify/code-snippets/before-you-begin.md
@@ -28,8 +28,8 @@ The following variables are specific to your Nexmo account. You can view them in
 
 Key |	Description
 -- | --
-`NEXMO_API_KEY` | API key.
-`NEXMO_API_SECRET` | API secret.
+`VONAGE_API_KEY` | API key.
+`VONAGE_API_SECRET` | API secret.
 
 ### Numbers
 

--- a/_documentation/en/verify/code-snippets/cancel-verify-request.md
+++ b/_documentation/en/verify/code-snippets/cancel-verify-request.md
@@ -13,8 +13,8 @@ Replace the following variables in the sample code with your own values:
 
 Name | Description
 --|--
-`NEXMO_API_KEY` | Your Nexmo [API key](https://developer.nexmo.com/concepts/guides/authentication#api-key-and-secret)
-`NEXMO_API_SECRET` | Your Nexmo [API secret](https://developer.nexmo.com/concepts/guides/authentication#api-key-and-secret)
+`VONAGE_API_KEY` | Your Vonage [API key](https://developer.nexmo.com/concepts/guides/authentication#api-key-and-secret)
+`VONAGE_API_SECRET` | Your Vonage [API secret](https://developer.nexmo.com/concepts/guides/authentication#api-key-and-secret)
 `REQUEST_ID` | The ID of the Verify request you wish to cancel (this is returned in the API response when you [send a verification code](/verify/code-snippets/send-verify-request))
 
 ```code_snippets

--- a/_documentation/en/verify/code-snippets/check-verify-request.md
+++ b/_documentation/en/verify/code-snippets/check-verify-request.md
@@ -13,8 +13,8 @@ Replace the following variables in the sample code with your own values:
 
 Name | Description
 --|--
-`NEXMO_API_KEY` | Your Nexmo [API key](https://developer.nexmo.com/concepts/guides/authentication#api-key-and-secret)
-`NEXMO_API_SECRET` | Your Nexmo [API secret](https://developer.nexmo.com/concepts/guides/authentication#api-key-and-secret)
+`VONAGE_API_KEY` | Your Vonage [API key](https://developer.nexmo.com/concepts/guides/authentication#api-key-and-secret)
+`VONAGE_API_SECRET` | Your Vonage [API secret](https://developer.nexmo.com/concepts/guides/authentication#api-key-and-secret)
 `REQUEST_ID` | The ID of the Verify request you wish to check (this is returned in the API response when you [send a verification code](/verify/code-snippets/send-verify-request))
 `CODE` | The code the user supplies as having been sent to them
 

--- a/_documentation/en/verify/code-snippets/search-verify-request.md
+++ b/_documentation/en/verify/code-snippets/search-verify-request.md
@@ -11,8 +11,8 @@ Replace the following variables in the sample code with your own values:
 
 Name | Description
 --|--
-`NEXMO_API_KEY` | Your Nexmo [API key](https://developer.nexmo.com/concepts/guides/authentication#api-key-and-secret)
-`NEXMO_API_SECRET` | Your Nexmo [API secret](https://developer.nexmo.com/concepts/guides/authentication#api-key-and-secret)
+`VONAGE_API_KEY` | Your Vonage [API key](https://developer.nexmo.com/concepts/guides/authentication#api-key-and-secret)
+`VONAGE_API_SECRET` | Your Vonage [API secret](https://developer.nexmo.com/concepts/guides/authentication#api-key-and-secret)
 `REQUEST_ID` | The ID of the Verify request you wish to cancel (this is returned in the API response when you [send a verification code](/verify/code-snippets/send-verify-request))
 
 

--- a/_documentation/en/verify/code-snippets/send-verify-psd2-request-with-workflow.md
+++ b/_documentation/en/verify/code-snippets/send-verify-psd2-request-with-workflow.md
@@ -13,8 +13,8 @@ Replace the following variables in the sample code with your own values:
 
 Name | Description
 --|--
-`NEXMO_API_KEY` | Your Nexmo [API key](https://developer.nexmo.com/concepts/guides/authentication#api-key-and-secret)
-`NEXMO_API_SECRET` | Your Nexmo [API secret](https://developer.nexmo.com/concepts/guides/authentication#api-key-and-secret)
+`VONAGE_API_KEY` | Your Vonage [API key](https://developer.nexmo.com/concepts/guides/authentication#api-key-and-secret)
+`VONAGE_API_SECRET` | Your Vonage [API secret](https://developer.nexmo.com/concepts/guides/authentication#api-key-and-secret)
 `RECIPIENT_NUMBER` | The phone number to verify
 `PAYEE` | Included in the message to describe the payment recipient
 `AMOUNT` | How much the payment is for (always in Euro)

--- a/_documentation/en/verify/code-snippets/send-verify-psd2-request.md
+++ b/_documentation/en/verify/code-snippets/send-verify-psd2-request.md
@@ -13,8 +13,8 @@ Replace the following variables in the sample code with your own values:
 
 Name | Description
 --|--
-`NEXMO_API_KEY` | Your Nexmo [API key](https://developer.nexmo.com/concepts/guides/authentication#api-key-and-secret)
-`NEXMO_API_SECRET` | Your Nexmo [API secret](https://developer.nexmo.com/concepts/guides/authentication#api-key-and-secret)
+`VONAGE_API_KEY` | Your Vonage [API key](https://developer.nexmo.com/concepts/guides/authentication#api-key-and-secret)
+`VONAGE_API_SECRET` | Your Vonage [API secret](https://developer.nexmo.com/concepts/guides/authentication#api-key-and-secret)
 `RECIPIENT_NUMBER` | The phone number to verify
 `PAYEE` | Included in the message to describe the payment recipient
 `AMOUNT` | How much the payment is for (always in Euro)

--- a/_documentation/en/verify/code-snippets/send-verify-request-with-workflow.md
+++ b/_documentation/en/verify/code-snippets/send-verify-request-with-workflow.md
@@ -13,8 +13,8 @@ Replace the following variables in the sample code with your own values:
 
 Name | Description
 --|--
-`NEXMO_API_KEY` | Your Nexmo [API key](https://developer.nexmo.com/concepts/guides/authentication#api-key-and-secret)
-`NEXMO_API_SECRET` | Your Nexmo [API secret](https://developer.nexmo.com/concepts/guides/authentication#api-key-and-secret)
+`VONAGE_API_KEY` | Your Vonage [API key](https://developer.nexmo.com/concepts/guides/authentication#api-key-and-secret)
+`VONAGE_API_SECRET` | Your Vonage [API secret](https://developer.nexmo.com/concepts/guides/authentication#api-key-and-secret)
 `RECIPIENT_NUMBER` | The phone number to verify
 `BRAND_NAME` | Included in the message to explain who is confirming the phone number
 `WORKFLOW_ID` | Choose a workflow (number between 1 and 7), these are defined in the [workflows guide](/verify/guides/workflows-and-events)

--- a/_documentation/en/verify/code-snippets/send-verify-request.md
+++ b/_documentation/en/verify/code-snippets/send-verify-request.md
@@ -13,8 +13,8 @@ Replace the following variables in the sample code with your own values:
 
 Name | Description
 --|--
-`NEXMO_API_KEY` | Your Nexmo [API key](https://developer.nexmo.com/concepts/guides/authentication#api-key-and-secret)
-`NEXMO_API_SECRET` | Your Nexmo [API secret](https://developer.nexmo.com/concepts/guides/authentication#api-key-and-secret)
+`VONAGE_API_KEY` | Your Vonage [API key](https://developer.nexmo.com/concepts/guides/authentication#api-key-and-secret)
+`VONAGE_API_SECRET` | Your Vonage [API secret](https://developer.nexmo.com/concepts/guides/authentication#api-key-and-secret)
 `RECIPIENT_NUMBER` | The phone number to verify
 `BRAND_NAME` | Included in the message to explain who is confirming the phone number
 

--- a/_documentation/en/verify/code-snippets/trigger-next-verification-process.md
+++ b/_documentation/en/verify/code-snippets/trigger-next-verification-process.md
@@ -13,8 +13,8 @@ Replace the following variables in the sample code with your own values:
 
 Name | Description
 --|--
-`NEXMO_API_KEY` | Your Nexmo [API key](https://developer.nexmo.com/concepts/guides/authentication#api-key-and-secret)
-`NEXMO_API_SECRET` | Your Nexmo [API secret](https://developer.nexmo.com/concepts/guides/authentication#api-key-and-secret)
+`VONAGE_API_KEY` | Your Vonage [API key](https://developer.nexmo.com/concepts/guides/authentication#api-key-and-secret)
+`VONAGE_API_SECRET` | Your Vonage [API secret](https://developer.nexmo.com/concepts/guides/authentication#api-key-and-secret)
 `REQUEST_ID` | The ID of the Verify request you wish to cancel (this is returned in the API response when you [send a verification code](/verify/code-snippets/send-verify-request))
 
 ```code_snippets

--- a/_documentation/en/voice/voice-api/code-snippets/before-you-begin.md
+++ b/_documentation/en/voice/voice-api/code-snippets/before-you-begin.md
@@ -17,7 +17,7 @@ Please read this information carefully, so you can best use the code snippets.
 1. [Create a Nexmo account](/account/guides/dashboard-management#create-and-configure-a-nexmo-account)
 2. [Rent a Nexmo Number](/numbers/guides/number-management#rent-a-virtual-number)
 3. [Install the Nexmo Command Line tools](/tools)
-4. [Create a Nexmo Application using the command line tools or Dashboard](/concepts/guides/applications#getting-started-with-applications)
+4. [Create a Vonage Application using the command line tools or Dashboard](/concepts/guides/applications#getting-started-with-applications)
 5. [Install the Nexmo Library for your programming language](/tools)
 6. [Set up Ngrok](https://ngrok.com)
 
@@ -71,7 +71,7 @@ The main ones you will meet here are:
 * `/webhooks/recordings` - Nexmo callback POSTs to here. You receive JSON object with recording details.
 * `/webhooks/dtmf` - Nexmo POSTs user DTMF input here in a JSON object.
 
-If you are using Ngrok you will set your webhook URLs in the Nexmo Application object to
+If you are using Ngrok you will set your webhook URLs in the Vonage Application object to
 something like:
 
 * `https://demo.ngrok.io/webhooks/answer`

--- a/_documentation/en/voice/voice-api/code-snippets/before-you-begin.md
+++ b/_documentation/en/voice/voice-api/code-snippets/before-you-begin.md
@@ -33,11 +33,11 @@ The following replaceable information depends on the library and specific call:
 
 Key |	Description
 -- | --
-`NEXMO_API_KEY` | API key.
-`NEXMO_API_SECRET` | API secret.
-`NEXMO_APPLICATION_PRIVATE_KEY_PATH` |  Private key path.
-`NEXMO_APPLICATION_PRIVATE_KEY` | Private key.
-`NEXMO_APPLICATION_ID` | The Nexmo Application ID.
+`VONAGE_API_KEY` | API key.
+`VONAGE_API_SECRET` | API secret.
+`VONAGE_APPLICATION_PRIVATE_KEY_PATH` |  Private key path.
+`VONAGE_APPLICATION_PRIVATE_KEY` | Private key.
+`VONAGE_APPLICATION_ID` | The Vonage Application ID.
 
 ### Numbers
 
@@ -45,7 +45,7 @@ All phone numbers are in E.164 format.
 
 Key |	Description
 -- | --
-`NEXMO_NUMBER` | Replace with your Nexmo Number. E.g. 447700900000
+`VONAGE_NUMBER` | Replace with your Vonage Number. E.g. 447700900000
 `TO_NUMBER` | Replace with the number you are calling. E.g. 447700900001
 `SECOND_NUMBER` | Replace with number you are forwarding to. E.g. 447700900002
 

--- a/_documentation/en/voice/voice-api/code-snippets/connect-an-inbound-call.md
+++ b/_documentation/en/voice/voice-api/code-snippets/connect-an-inbound-call.md
@@ -11,10 +11,10 @@ In this code snippet you see how to connect an inbound call to another person by
 
 Replace the following variables in the example code:
 
-Key |	Description
--- | --
-`NEXMO_NUMBER` |  This is your Nexmo number used for CallerID to the recipient.
-`YOUR_SECOND_NUMBER` |  This is the number to be connected to e.g. 447700900002.
+| Key                  | Description                                                    |
+| -------------------- | -------------------------------------------------------------- |
+| `VONAGE_NUMBER`      | This is your Vonage number used for CallerID to the recipient. |
+| `YOUR_SECOND_NUMBER` | This is the number to be connected to e.g. 447700900002.       |
 
 ```code_snippets
 source: '_examples/voice/connect-an-inbound-call'

--- a/_documentation/en/voice/voice-api/code-snippets/connect-callers-into-a-conference.md
+++ b/_documentation/en/voice/voice-api/code-snippets/connect-callers-into-a-conference.md
@@ -12,8 +12,8 @@ call) by simply connecting the call into the same named
 conference.
 
 Conference names are scoped at the Vonage Application
-level. For example, NexmoApp1 and NexmoApp2 could both have a
-conference called `nexmo-conference` and there would be no problem.
+level. For example, VonageApp1 and VonageApp2 could both have a
+conference called `vonage-conference` and there would be no problem.
 
 ## Example
 

--- a/_documentation/en/voice/voice-api/code-snippets/connect-callers-into-a-conference.md
+++ b/_documentation/en/voice/voice-api/code-snippets/connect-callers-into-a-conference.md
@@ -11,7 +11,7 @@ Multiple inbound calls can be joined into a conversation (conference
 call) by simply connecting the call into the same named
 conference.
 
-Conference names are scoped at the Nexmo Application
+Conference names are scoped at the Vonage Application
 level. For example, NexmoApp1 and NexmoApp2 could both have a
 conference called `nexmo-conference` and there would be no problem.
 
@@ -33,5 +33,5 @@ application:
 ## Try it out
 
 Start your server and make multiple inbound calls to the Nexmo Number
-assigned to this Nexmo Application. The inbound calls will be connected
+assigned to this Vonage Application. The inbound calls will be connected
 into the same conversation (conference).

--- a/_documentation/en/voice/voice-api/code-snippets/download-a-recording.md
+++ b/_documentation/en/voice/voice-api/code-snippets/download-a-recording.md
@@ -20,7 +20,7 @@ source: '_examples/voice/download-a-recording'
 application:
   type: voice
   use_existing: |
-    To fetch a recording you must use the same <code>NEXMO_APPLICATION_ID</code>
+    To fetch a recording you must use the same <code>VONAGE_APPLICATION_ID</code>
     and private key for the application that owns the call that you're trying to download.
 ```
 

--- a/_documentation/en/voice/voice-api/code-snippets/earmuff-a-call.md
+++ b/_documentation/en/voice/voice-api/code-snippets/earmuff-a-call.md
@@ -20,7 +20,7 @@ source: '_examples/voice/earmuff-a-call'
 application:
   type: voice
   use_existing: |
-    Modifying an existing call requires that the <code>UUID</code> provided is a currently active call. To modify a call, you must use the same <code>NEXMO_APPLICATION_ID</code> and private key that were used to create the call.
+    Modifying an existing call requires that the <code>UUID</code> provided is a currently active call. To modify a call, you must use the same <code>VONAGE_APPLICATION_ID</code> and private key that were used to create the call.
 ```
 
 ## Try it out

--- a/_documentation/en/voice/voice-api/code-snippets/make-an-outbound-call-with-ncco.md
+++ b/_documentation/en/voice/voice-api/code-snippets/make-an-outbound-call-with-ncco.md
@@ -16,7 +16,7 @@ Replace the following variables in the example code:
 
 Key |	Description
 -- | --
-`NEXMO_NUMBER` |	Your Nexmo number that the call will be made from. For example `447700900000`.
+`VONAGE_NUMBER` |	Your Vonage number that the call will be made from. For example `447700900000`.
 `TO_NUMBER` |	The number you would like to call to in E.164 format. For example `447700900001`.
 
 ```code_snippets

--- a/_documentation/en/voice/voice-api/code-snippets/make-an-outbound-call.md
+++ b/_documentation/en/voice/voice-api/code-snippets/make-an-outbound-call.md
@@ -14,7 +14,7 @@ Replace the following variables in the example code:
 
 Key |	Description
 -- | --
-`NEXMO_NUMBER` |	Your Nexmo number that the call will be made from. For example `447700900000`.
+`VONAGE_NUMBER` |	Your Vonage number that the call will be made from. For example `447700900000`.
 `TO_NUMBER` |	The number you would like to call to in E.164 format. For example `447700900001`.
 `ANSWER_URL` | The answer URL. For example `https://raw.githubusercontent.com/nexmo-community/ncco-examples/gh-pages/text-to-speech.json`.
 

--- a/_documentation/en/voice/voice-api/code-snippets/mute-a-call.md
+++ b/_documentation/en/voice/voice-api/code-snippets/mute-a-call.md
@@ -21,7 +21,7 @@ source: '_examples/voice/mute-a-call'
 application:
   type: voice
   use_existing: |
-    Modifying an existing call requires that the <code>UUID</code> provided is a currently active call. To modify a call, you must use the same <code>NEXMO_APPLICATION_ID</code> and private key that were used to create the call.
+    Modifying an existing call requires that the <code>UUID</code> provided is a currently active call. To modify a call, you must use the same <code>VONAGE_APPLICATION_ID</code> and private key that were used to create the call.
 ```
 
 ## Try it out

--- a/_documentation/en/voice/voice-api/code-snippets/play-an-audio-stream-into-a-call.md
+++ b/_documentation/en/voice/voice-api/code-snippets/play-an-audio-stream-into-a-call.md
@@ -21,7 +21,7 @@ source: '_examples/voice/play-an-audio-stream-into-a-call'
 application:
   type: voice
   use_existing: |
-    Modifying an existing call requires that the <code>UUID</code> provided is a currently active call. To modify a call, you must use the same <code>NEXMO_APPLICATION_ID</code> and private key that were used to create the call.
+    Modifying an existing call requires that the <code>UUID</code> provided is a currently active call. To modify a call, you must use the same <code>VONAGE_APPLICATION_ID</code> and private key that were used to create the call.
 ```
 
 ## Try it out

--- a/_documentation/en/voice/voice-api/code-snippets/play-dtmf-into-a-call.md
+++ b/_documentation/en/voice/voice-api/code-snippets/play-dtmf-into-a-call.md
@@ -21,7 +21,7 @@ source: '_examples/voice/play-dtmf-into-a-call'
 application:
   type: voice
   use_existing: |
-    Modifying an existing call requires that the <code>UUID</code> provided is a currently active call. To modify a call, you must use the same <code>NEXMO_APPLICATION_ID</code> and private key that were used to create the call.
+    Modifying an existing call requires that the <code>UUID</code> provided is a currently active call. To modify a call, you must use the same <code>VONAGE_APPLICATION_ID</code> and private key that were used to create the call.
 ```
 
 ## Try it out

--- a/_documentation/en/voice/voice-api/code-snippets/play-text-to-speech-into-a-call.md
+++ b/_documentation/en/voice/voice-api/code-snippets/play-text-to-speech-into-a-call.md
@@ -22,7 +22,7 @@ source: '_examples/voice/play-tts-into-a-call'
 application:
   type: voice
   use_existing: |
-    Modifying an existing call requires that the <code>UUID</code> provided is a currently active call. To modify a call, you must use the same <code>NEXMO_APPLICATION_ID</code> and private key that were used to create the call.
+    Modifying an existing call requires that the <code>UUID</code> provided is a currently active call. To modify a call, you must use the same <code>VONAGE_APPLICATION_ID</code> and private key that were used to create the call.
 ```
 
 ## Try it out

--- a/_documentation/en/voice/voice-api/code-snippets/record-a-call-with-split-audio.md
+++ b/_documentation/en/voice/voice-api/code-snippets/record-a-call-with-split-audio.md
@@ -16,7 +16,7 @@ Replace the following variables in the example code:
 
 Key |	Description
 -- | --
-`NEXMO_NUMBER` | The Nexmo Number of the application (the FROM number).
+`VONAGE_NUMBER` | The Vonage number of the application (the FROM number).
 `TO_NUMBER` | The number to connect the call to.
 
 ```code_snippets

--- a/_documentation/en/voice/voice-api/code-snippets/record-a-call.md
+++ b/_documentation/en/voice/voice-api/code-snippets/record-a-call.md
@@ -16,7 +16,7 @@ Replace the following variables in the example code:
 
 Key |	Description
 -- | --
-`NEXMO_NUMBER` | The Nexmo Number of the application (the FROM number).
+`VONAGE_NUMBER` | The Vonage number of the application (the FROM number).
 `TO_NUMBER` | The number to connect the call to.
 
 

--- a/_documentation/en/voice/voice-api/code-snippets/retrieve-info-for-a-call.md
+++ b/_documentation/en/voice/voice-api/code-snippets/retrieve-info-for-a-call.md
@@ -22,7 +22,7 @@ source: '_examples/voice/retrieve-info-for-a-call'
 application:
   type: voice
   use_existing: |
-    To fetch information about a call, you must use the same <code>NEXMO_APPLICATION_ID</code> and private key that were used to create the call.
+    To fetch information about a call, you must use the same <code>VONAGE_APPLICATION_ID</code> and private key that were used to create the call.
 ```
 
 ## Try it out

--- a/_documentation/en/voice/voice-api/code-snippets/retrieve-info-for-all-calls.md
+++ b/_documentation/en/voice/voice-api/code-snippets/retrieve-info-for-all-calls.md
@@ -14,7 +14,7 @@ source: '_examples/voice/retrieve-info-for-all-calls'
 application:
   type: voice
   use_existing: |
-    To fetch information about your calls, you must use the same <code>NEXMO_APPLICATION_ID</code> and private key that were used to create the calls.
+    To fetch information about your calls, you must use the same <code>VONAGE_APPLICATION_ID</code> and private key that were used to create the calls.
 ```
 
 ## Try it out

--- a/_documentation/en/voice/voice-api/code-snippets/transfer-a-call-inline-ncco.md
+++ b/_documentation/en/voice/voice-api/code-snippets/transfer-a-call-inline-ncco.md
@@ -22,7 +22,7 @@ source: '_examples/voice/transfer-a-call-inline-ncco'
 application:
   type: voice
   use_existing: |
-    Modifying an existing call requires that the <code>UUID</code> provided is a currently active call. To modify a call, you must use the same <code>NEXMO_APPLICATION_ID</code> and private key that were used to create the call.
+    Modifying an existing call requires that the <code>UUID</code> provided is a currently active call. To modify a call, you must use the same <code>VONAGE_APPLICATION_ID</code> and private key that were used to create the call.
 ```
 
 ## Try it out

--- a/_documentation/en/voice/voice-api/code-snippets/transfer-a-call.md
+++ b/_documentation/en/voice/voice-api/code-snippets/transfer-a-call.md
@@ -24,7 +24,7 @@ source: '_examples/voice/transfer-a-call'
 application:
   type: voice
   use_existing: |
-    Modifying an existing call requires that the <code>UUID</code> provided is a currently active call. To modify a call, you must use the same <code>NEXMO_APPLICATION_ID</code> and private key that were used to create the call.
+    Modifying an existing call requires that the <code>UUID</code> provided is a currently active call. To modify a call, you must use the same <code>VONAGE_APPLICATION_ID</code> and private key that were used to create the call.
 ```
 
 ## Try it out

--- a/_documentation/en/voice/voice-api/guides/ncco.md
+++ b/_documentation/en/voice/voice-api/guides/ncco.md
@@ -100,7 +100,7 @@ Sometimes you will connect to an endpoint that does not have a ring back tone pr
     },
     {
         "action": "connect",
-        "from": "NEXMO_NUMBER",
+        "from": "VONAGE_NUMBER",
         "ringbackTone": "https://example.com/tones/call.wav",
         "endpoint": [
             {
@@ -126,7 +126,7 @@ In some use cases you might want to execute an NCCO when a call is answered. For
     },
     {
         "action": "connect",
-        "from": "NEXMO_NUMBER",
+        "from": "VONAGE_NUMBER",
         "endpoint": [
             {
                 "type": "phone",
@@ -150,7 +150,7 @@ You can also use `onAnswer` in conjunction with `ringbackTone` so that the calle
     },
     {
         "action": "connect",
-        "from": "NEXMO_NUMBER",
+        "from": "VONAGE_NUMBER",
         "endpoint": [
             {
                 "type": "phone",

--- a/_documentation/en/voice/voice-api/overview.md
+++ b/_documentation/en/voice/voice-api/overview.md
@@ -56,7 +56,7 @@ To get started, choose your language below and replace the following variables i
 
 Key | Description
 -- | --
-`NEXMO_NUMBER` | Your Vonage number that the call will be made from. For example `447700900000`.
+`VONAGE_NUMBER` | Your Vonage number that the call will be made from. For example `447700900000`.
 `TO_NUMBER` | The number you would like to call to in E.164 format. For example `447700900001`.
 
 ```code_snippets


### PR DESCRIPTION
## Description

This updates all of the constants from `NEXMO_*` to `VONAGE_`, and updates the descriptions to reference Vonage instead of Nexmo.

## Deploy Notes

This requires and is built on top of #3202 , as that PR updates to the new code snippets that use these constants.
