### PR TITLE
Enable review apps for forks

### DIFF
--- a/.github/workflows/pull_request-pr-edited.yml
+++ b/.github/workflows/pull_request-pr-edited.yml
@@ -3,6 +3,8 @@ on:
   repository_dispatch: {}
   pull_request:
     types: [opened, reopened, synchronize, labeled, closed]
+  pull_request_target:
+    types: [opened, reopened, synchronize, labeled, closed]
 jobs:
   create-review-app:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Description

This enables review apps via the `review-app` label for forks

## Deploy Notes

N/A