### PR TITLE
Remove pull_request event

### DIFF
--- a/.github/workflows/pull_request-pr-edited.yml
+++ b/.github/workflows/pull_request-pr-edited.yml
@@ -1,8 +1,6 @@
 name: PR Edited
 on:
   repository_dispatch: {}
-  pull_request:
-    types: [opened, reopened, synchronize, labeled, closed]
   pull_request_target:
     types: [opened, reopened, synchronize, labeled, closed]
 jobs:


### PR DESCRIPTION
## Description

Using `pull_request_target` allows us to create review apps for forks, so the existing `pull_request` event is no longer needed

## Deploy Notes

N/A