### PR TITLE
Improving docs - giving an example to list available conversations

### DIFF
--- a/_documentation/en/client-sdk/in-app-messaging/guides/inviting-members.md
+++ b/_documentation/en/client-sdk/in-app-messaging/guides/inviting-members.md
@@ -35,7 +35,7 @@ source: _tutorials_tabbed_content/client-sdk/guides/messaging/inviting-members/i
 In order to list all conversations available to a user, we need to make use of the various methods aimed at [pagination](/client-sdk/in-app-messaging/guides/handling-pagination), as the 
 conversations collection is paginated. A simple example to acquired this complete set as a list is available below:
 
-```tabbed_Content
+```tabbed_content
 source: _tutorials_tabbed_content/client-sdk/guides/messaging/inviting-members/listing
 ```
 

--- a/_documentation/en/client-sdk/in-app-messaging/guides/inviting-members.md
+++ b/_documentation/en/client-sdk/in-app-messaging/guides/inviting-members.md
@@ -30,6 +30,14 @@ This guide will introduce you to the following concepts.
 source: _tutorials_tabbed_content/client-sdk/guides/messaging/inviting-members/invited
 ```
 
+## Listing conversations you are a part of
+
+In order to list all conversations available to a user, we need to make use of the various methods aimed at [pagination](/client-sdk/in-app-messaging/guides/handling-pagination), as the 
+conversations collection is paginated. A simple example to acquired this complete set as a list is available below:
+
+```tabbed_Content
+source: _tutorials_tabbed_content/client-sdk/guides/messaging/inviting-members/listing
+```
 
 ## Listening for members who joined a conversation
 ```tabbed_content

--- a/_tutorials_tabbed_content/client-sdk/guides/messaging/inviting-members/listing/javascript.md
+++ b/_tutorials_tabbed_content/client-sdk/guides/messaging/inviting-members/listing/javascript.md
@@ -1,0 +1,56 @@
+---
+title: Javascript
+language: javascript
+menu_weight: 1
+---
+
+```javascript
+/** 
+ *  Debounced iterator to process a paginated dataset
+ *  and return a list of conversations
+ */ 
+function processAndGetNextConversationPage(pageRecord, { current, total }) {
+  return new Promise((resolve, reject) => {
+    const results = Array.from(pageRecord.items.values()) || [];
+    const newCount = current + results.length;
+    if (current >= total) {
+      return resolve(results);
+    }
+    if (!pageRecord.hasNext()) {
+      return resolve(results);
+    }
+    return pageRecord.getNext()
+      .then((newRecord) => processAndGetNextConversationPage(
+        newRecord,
+        { current: newCount, total },
+      ))
+      .then((newResults) => {
+        for (let i = 0; i < newResults.length; i += 1) {
+          results.push(newResults[i]);
+        }
+        return resolve(results);
+      })
+      .catch(reject);
+  });
+}
+
+function listConversations(app, maxTotalRecords) {
+  return new Promise((resolve, reject) => app.getConversations({
+    order: 'asc',
+    page_size: 1,
+  }).then((conversationPage) => processAndGetNextConversationPage(
+    conversationPage,
+    {
+      current: 0,
+      total: maxTotalRecords,
+    },
+  )).then(resolve).catch(reject));
+}
+
+const app = client.login(token)
+.then(() => {
+  listConversations(app, 50)
+    .then(console.log)
+    .catch(console.log);
+});
+```


### PR DESCRIPTION
## Description

While chatting with Luke over Discord, the idea to expand the docs a tiny bit came up, for two reasons:
- There is no concrete example on fully traversing a page iterator and gathering its resource objects (the closest there is is the [pagination](https://developer.nexmo.com/client-sdk/in-app-messaging/guides/handling-pagination) page, which does not actually show that much)
- Creating, joining and leaving conversations have examples, but listing available conversations, something that would be useful when re-syncing app state after a restart (for example) is not mentioned anywhere but in the actual SDK doc if you know where to look.

I've added a small snippet able to gather all available conversations and return them as the success path of a promise, without `async`/`await` (because not everybody has access to the fancy toys ;-) ).

## Deploy Notes

No fundamental changes (it's all markdown!)
