### PR TITLE
docs: :pencil: Convert SMS API blog post to tutorial

### DIFF
--- a/_tutorials/en/sms-api/add-send-sms-view.md
+++ b/_tutorials/en/sms-api/add-send-sms-view.md
@@ -1,0 +1,33 @@
+---
+title: Add a Send SMS View
+description: Add a view that renders a Jinja2 template for the web application
+---
+
+# Add a Send SMS View
+
+Add a view that renders a Jinja2 template for the web application. Create this template at `templates/index.html`:
+
+```
+@app.route('/')
+def index():
+    """ A view that renders the Send SMS form. """
+    return render_template('index.html')
+```
+
+The following HTML includes the Bootstrap CSS framework and then renders a form with two fields: `to_number` for taking the destination phone number and `message`, so the user can enter their SMS message.
+
+```
+<h1>Send an SMS</h1>
+ 
+<script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
+<div class="container">
+    <h1>Send an SMS</h1>
+    <form action="/send_sms" method="POST">
+        <div class="form-group"><label for="destination">Phone Number</label>
+            <input id="to_number" class="form-control" name="to_number" type="tel" placeholder="Phone Number" /></div>
+        <div class="form-group"><label for="message">Message</label>
+            <textarea id="message" class="form-control" name="message" placeholder="Your message goes here"></textarea></div>
+        <button class="btn btn-default" type="submit">Send SMS</button>
+    </form>
+</div>
+```

--- a/_tutorials/en/sms-api/add-send-sms-view.md
+++ b/_tutorials/en/sms-api/add-send-sms-view.md
@@ -5,7 +5,7 @@ description: Add a view that renders a Jinja2 template for the web application
 
 # Add a Send SMS View
 
-Add a view that renders a Jinja2 template for the web application. Create this template at `templates/index.html`:
+Add a view that renders a `Jinja2` template for the web application. Create this template at `templates/index.html`:
 
 ```
 @app.route('/')

--- a/_tutorials/en/sms-api/handle-form-post.md
+++ b/_tutorials/en/sms-api/handle-form-post.md
@@ -27,6 +27,6 @@ def send_sms():
     return redirect(url_for('index'))
 ```
 
-If your `FLASK_DEBUG` flag is set to true, then your changes should automatically be reloaded into the running server. Refresh your form, fill in your phone number and a message. Make sure the number is in international format without the ‘+’ at the start. Hit “Send SMS” and check your phone.
+If your `FLASK_DEBUG` flag is set to true, then your changes should automatically be reloaded into the running server. Refresh your form, fill in your phone number and a message. Make sure the number is in international format without the '+' at the start. Hit "Send SMS" and check your phone.
 
 If the application did not work, check out the extra lines in the [sample code](https://github.com/Nexmo/nexmo-python-code-snippets/blob/master/sms/send-an-sms.py) in `server.py` and `index.html` that use Flask’s flash message mechanism to report errors to the user.

--- a/_tutorials/en/sms-api/handle-form-post.md
+++ b/_tutorials/en/sms-api/handle-form-post.md
@@ -1,0 +1,32 @@
+---
+title: Handle the Form Post
+description: Accept the POST request from the form and send an SMS.
+---
+
+# Handle the Form Post
+
+Add the following function to the bottom of your python file, to accept the POST request from the form:
+
+```
+@app.route('/send_sms', methods=['POST'])
+def send_sms():
+    """ A POST endpoint that sends an SMS. """
+ 
+    # Extract the form values:
+    to_number = request.form['to_number']
+    message = request.form['message']
+ 
+    # Send the SMS message:
+    result = nexmo_client.send_message({
+        'from': NEXMO_NUMBER,
+        'to': to_number,
+        'text': message,
+    })
+ 
+    # Redirect the user back to the form:
+    return redirect(url_for('index'))
+```
+
+If your `FLASK_DEBUG` flag is set to true, then your changes should automatically be reloaded into the running server. Refresh your form, fill in your phone number and a message. Make sure the number is in international format without the ‘+’ at the start. Hit “Send SMS” and check your phone.
+
+If the application did not work, check out the extra lines in the [sample code](https://github.com/Nexmo/nexmo-python-code-snippets/blob/master/sms/send-an-sms.py) in `server.py` and `index.html` that use Flask’s flash message mechanism to report errors to the user.

--- a/_tutorials/en/sms-api/install-nexmo-python.md
+++ b/_tutorials/en/sms-api/install-nexmo-python.md
@@ -1,0 +1,15 @@
+---
+title: Install the Nexmo Python Library
+description: Create a virtualenv and install the Nexmo python client library
+---
+
+# Install the Nexmo Python Library
+
+Create a virtualenv and install the Nexmo python client library into it.
+
+```
+$ python3 -m venv venv # use `virtualenv venv` on Python 2
+source venv/bin/activate
+ 
+pip install nexmo
+```

--- a/_tutorials/en/sms-api/install-nexmo-python.md
+++ b/_tutorials/en/sms-api/install-nexmo-python.md
@@ -5,7 +5,7 @@ description: Create a virtualenv and install the Nexmo python client library
 
 # Install the Nexmo Python Library
 
-Create a virtualenv and install the Nexmo python client library into it.
+Create a `virtualenv` and install the Nexmo python client library into it.
 
 ```
 $ python3 -m venv venv # use `virtualenv venv` on Python 2

--- a/_tutorials/en/sms-api/run-flask-server.md
+++ b/_tutorials/en/sms-api/run-flask-server.md
@@ -1,0 +1,36 @@
+---
+title: Run the Flask Server
+description: Configure and run the web application on a Flask server
+---
+
+# Run the Flask Server
+
+Before you can start your server, you’ll need to provide configuration in a `.env` file. Start with the following and fill in your details:
+
+```
+# Do not use this in production:
+FLASK_DEBUG=true
+ 
+# Replace the following with any random value you like:
+FLASK_SECRET_KEY=RANDOM-STRING_CHANGE-THIS-Ea359
+ 
+# Get from https://dashboard.nexmo.com/your-numbers
+NEXMO_NUMBER=447700900025
+ 
+# Get the following from https://dashboard.nexmo.com/settings
+NEXMO_API_KEY=abcd1234
+NEXMO_API_SECRET=abcdef12345678
+```
+
+Now start your app with:
+
+```
+# You may need to change the path below if your Flask app is in a different Python file:
+$ FLASK_APP=smsweb/server.py flask run
+* Serving Flask app "smsweb.server"
+* Running on http://127.0.0.1:5000/ (Press CTRL+C to quit)
+```
+
+Now if you load http://localhost:5000/, you should see something like this:
+
+![SMS Flask application window, showing fields for phone number and message](https://www.nexmo.com/wp-content/uploads/2017/06/smsweb_send.png)

--- a/_tutorials/en/sms-api/send-sms-from-repl.md
+++ b/_tutorials/en/sms-api/send-sms-from-repl.md
@@ -1,0 +1,24 @@
+---
+title: Send an SMS from the Python REPL
+description: Send an SMS from the command line.
+---
+
+# Send an SMS from the Python REPL
+
+First, run python from the command-line, and then enter the three lines below.
+
+```
+>>> import nexmo
+>>> client = nexmo.Client(key='YOUR-API-KEY', secret='YOUR-API-SECRET')
+>>> client.send_message({'from': 'Nexmo', 'to': 'YOUR-PHONE-NUMBER', 'text': 'Hello world'})
+{'message-count': '1', 'messages': [{'to': 'YOUR-PHONE-NUMBER', 'message-id': '0D00000039FFD940', 'status': '0', 'remaining-balance': '14.62306950', 'message-price': '0.03330000', 'network': '12345'}]}
+```
+
+These lines of code perform three actions.
+* The first line imports `nexmo-python`.
+* The second line creates a Nexmo `Client` object, which can be re-used, and knows your Vonage API key and the secret associated with it.
+* The third line actually sends the SMS message.
+
+Hopefully, you received an SMS message! If not, check the contents of the response, the [error messages](https://help.nexmo.com/hc/en-us/articles/204014733-Nexmo-SMS-Delivery-Error-Codes) may be quite helpful.
+
+`send_message` returns a dictionary, which tells you how many messages your SMS was divided into, and how much it cost you to send the message. Longer messages will need to be sent as multiple messages. Vonage will divide these messages up for you, and the SMS client on the phone will automatically reassemble them into the original long message, but this costs more than a short message.

--- a/_tutorials/en/sms-api/set-up-sms-flask.md
+++ b/_tutorials/en/sms-api/set-up-sms-flask.md
@@ -1,0 +1,39 @@
+---
+title: Set up an SMS Sending Flask App
+description: Create a web application that allows you to send an SMS message.
+---
+
+# Build an SMS Sending Flask App
+
+> The rest of this tutorial will show you how to build a small Flask app with a form for a phone number and an SMS message. When you press “Send SMS” it will post to a second view that will send the SMS using the Vonage SMS API.
+
+First, install dependencies. Check out this [sample code](https://github.com/Nexmo/nexmo-python-code-snippets/blob/master/sms/send-an-sms.py) and run `pip install -r requirements.txt`. At the very least, you’ll need to install Flask into your virtualenv.
+
+Create a Nexmo Client object and an empty Flask app. If you would like to create a [12-factor](https://12factor.net/) app, load in configuration from environment variables (check out the helper function in `utils.py` in the sample code).
+
+The problem with loading in environment variables is that it can make running the app a little bit more difficult. Use the [python-dotenv](https://github.com/theskumar/python-dotenv) library to load a `.env` file. It copies the values into the env var dictionary, so you can get the values using `getenv` as you would normally.
+
+```
+from dotenv import load_dotenv
+from flask import Flask, flash, redirect, render_template, request, url_for
+import nexmo
+ 
+from .util import env_var, extract_error
+ 
+# Load environment variables from a .env file:
+load_dotenv('.env')
+ 
+# Load in configuration from environment variables:
+NEXMO_API_KEY = env_var('NEXMO_API_KEY')
+NEXMO_API_SECRET = env_var('NEXMO_API_SECRET')
+NEXMO_NUMBER = env_var('NEXMO_NUMBER')
+ 
+# Create a new Nexmo Client object:
+nexmo_client = nexmo.Client(
+    api_key=NEXMO_API_KEY, api_secret=NEXMO_API_SECRET
+)
+ 
+# Initialize Flask:
+app = Flask(__name__)
+app.config['SECRET_KEY'] = env_var('FLASK_SECRET_KEY')
+```

--- a/_tutorials/en/sms-api/set-up-sms-flask.md
+++ b/_tutorials/en/sms-api/set-up-sms-flask.md
@@ -7,11 +7,11 @@ description: Create a web application that allows you to send an SMS message.
 
 > The rest of this tutorial will show you how to build a small Flask app with a form for a phone number and an SMS message. When you press “Send SMS” it will post to a second view that will send the SMS using the Vonage SMS API.
 
-First, install dependencies. Check out this [sample code](https://github.com/Nexmo/nexmo-python-code-snippets/blob/master/sms/send-an-sms.py) and run `pip install -r requirements.txt`. At the very least, you’ll need to install Flask into your virtualenv.
+First, install dependencies. Check out this [sample code](https://github.com/Nexmo/nexmo-python-code-snippets/blob/master/sms/send-an-sms.py) and run `pip install -r requirements.txt`. At the very least, you’ll need to install Flask into your `virtualenv`.
 
-Create a Nexmo Client object and an empty Flask app. If you would like to create a [12-factor](https://12factor.net/) app, load in configuration from environment variables (check out the helper function in `utils.py` in the sample code).
+Create a Nexmo Client object and an empty Flask app. If you would like to create a [12 factor](https://12factor.net/) app, load in configuration from environment variables (check out the helper function in `utils.py` in the sample code).
 
-The problem with loading in environment variables is that it can make running the app a little bit more difficult. Use the [python-dotenv](https://github.com/theskumar/python-dotenv) library to load a `.env` file. It copies the values into the env var dictionary, so you can get the values using `getenv` as you would normally.
+The problem with loading in environment variables is that it can make running the app a little bit more difficult. Use the [`python-dotenv`](https://github.com/theskumar/python-dotenv) library to load a `.env` file. It copies the values into the `env` var dictionary, so you can get the values using `getenv` as you would normally.
 
 ```
 from dotenv import load_dotenv

--- a/_tutorials/en/sms-api/set-up-sms-flask.md
+++ b/_tutorials/en/sms-api/set-up-sms-flask.md
@@ -5,7 +5,7 @@ description: Create a web application that allows you to send an SMS message.
 
 # Build an SMS Sending Flask App
 
-> The rest of this tutorial will show you how to build a small Flask app with a form for a phone number and an SMS message. When you press “Send SMS” it will post to a second view that will send the SMS using the Vonage SMS API.
+> The rest of this tutorial will show you how to build a small Flask app with a form for a phone number and an SMS message. When you press "Send SMS" it will post to a second view that will send the SMS using the Vonage SMS API.
 
 First, install dependencies. Check out this [sample code](https://github.com/Nexmo/nexmo-python-code-snippets/blob/master/sms/send-an-sms.py) and run `pip install -r requirements.txt`. At the very least, you’ll need to install Flask into your `virtualenv`.
 

--- a/config/tutorials/en/send-sms-with-flask.yml
+++ b/config/tutorials/en/send-sms-with-flask.yml
@@ -1,9 +1,40 @@
----
 title: How to Send SMS Messages with Python, Flask and Nexmo
-external_link: https://www.nexmo.com/blog/2017/06/22/send-sms-messages-python-flask-dr/
+description: This tutorial introduces you to sending SMS with Python, making use of the Nexmo Python library. It starts by showing how to send SMS from the REPL, then goes on to show you how to build a simple flask app with SMS capabilities.
 products:
  - messaging/sms
-description: This tutorial introduces you to sending SMS with Python, making use of the Nexmo Python library. It starts by showing how to send SMS from the REPL, then goes on to show you how to build a simple flask app with SMS capabilities.
 languages:
   - Python
----
+
+introduction: 
+  title: Introduction to this tutorial
+  description: This tutorial shows you how to send an SMS message with nexmo-python.
+  content: |
+    # Introduction
+    The [Vonage SMS API](/messaging/sms/overview) is an HTTP-based API using either XML or JSON to describe how to send an SMS or understand a received SMS. Vonage provides a Python client library called nexmo-python that takes care of a lot of the underlying detail for you.
+
+    > Before starting, make sure you have Python installed. The code here was tested on Python 2.7 and 3.6. If you’re running Python 2, make sure you also have [virtualenv](https://virtualenv.pypa.io/en/stable/) installed.
+
+prerequisites:
+- create-nexmo-account
+
+tasks:
+- sms-api/install-nexmo-python
+- sms-api/send-sms-from-repl
+- sms-api/set-up-sms-flask
+- sms-api/add-send-sms-view
+- sms-api/run-flask-server
+- sms-api/handle-form-post
+
+conclusion:
+  title: What's next?
+  description: What else can you do with the SMS API?
+  content: |
+
+    # What's next?
+    You can do a lot more with the SMS API.
+
+    See [SMS API documentation](/messaging/sms/overview).
+
+    In the meantime for more information on our APIs including [inbound SMS](/messaging/sms/guides/inbound-sms), [Voice](/voice/overview), [2-Factor-Authentication](/verify/overview) and others.
+
+    The original tutorial can be found at this [blog article](https://www.nexmo.com/blog/2017/06/22/send-sms-messages-python-flask-dr) by Mark Smith.


### PR DESCRIPTION
**Converted SMS API blog post into standard tutorial format**

## Description

Converted ["How to send SMS Messages with Python, Flask and Vonage"](https://www.nexmo.com/blog/2017/06/22/send-sms-messages-python-flask-dr) into the standard tutorial format. The steps in the tutorial were divided according to the headings in the original blog post.

This commit is related to issue #3225 .

## Deploy Notes

I created a directory in `tutorials` (`sms-api`) for SMS API tutorials, to make it easier to convert other blog posts into tutorials in the future.
