### PR TITLE
Add custom object for facebook message template

### DIFF
--- a/_documentation/en/messages/concepts/custom-objects.md
+++ b/_documentation/en/messages/concepts/custom-objects.md
@@ -235,7 +235,7 @@ The Messages API message would be transformed to something similar to the follow
 
 Where the custom object, `$CUSTOM_OBJECT`, can be anything from within the [Messenger Message Object](https://developers.facebook.com/docs/messenger-platform/send-messages/templates/).
 
-For example, consider sending media by facebook URL, the `$CUSTOM_OBJECT` format would look like
+For example, consider sending media by Facebook URL, the `$CUSTOM_OBJECT` format would look like
 
 ```json
 "message": {

--- a/_documentation/en/messages/concepts/custom-objects.md
+++ b/_documentation/en/messages/concepts/custom-objects.md
@@ -235,6 +235,52 @@ The Messages API message would be transformed to something similar to the follow
 
 Where the custom object, `$CUSTOM_OBJECT`, can be anything from within the [Messenger Message Object](https://developers.facebook.com/docs/messenger-platform/send-messages/templates/).
 
+For example, consider sending media by facebook URL, the `$CUSTOM_OBJECT` format would look like
+
+```json
+"message": {
+  "attachment": {
+    "type": "template",
+    "payload": {
+      "template_type": "media",
+      "elements": [{
+        "media_type": "<image|video>",
+        "url": "<FACEBOOK_URL>"
+      }]
+    }
+  }
+}
+```
+
+The Nexmo Messages API request format would be:
+
+```json
+{
+    "from": {
+        "type": "messenger",
+        "id": $FB_SENDER_ID
+    },
+    "to": {
+        "type": "messenger",
+        "id": $FB_RECIPIENT_ID
+    },
+    "message": {
+        "attachment": {
+            "type": "template",
+            "payload": {
+                "template_type": "media",
+                "elements": [
+                    {
+                        "media_type": "<image|video>",
+                        "url": "<FACEBOOK_URL>"
+                    }
+                ]
+            }
+        }
+    }
+}
+```
+
 ## See more examples
 
 * [WhatsApp send contact](/messages/code-snippets/whatsapp/send-contact)


### PR DESCRIPTION
## Description

As per [Issue #3222](https://github.com/Nexmo/nexmo-developer/issues/3222), added `$CUSTOM_OBJECT` ( Sending Media using Facebook )  URL in facebook message template
