### PR TITLE
Convert SMS API blog post (2) to tutorial

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -359,3 +359,5 @@ Yue
 ASP.NET
 VonageApp1
 VonageApp2
+AuthMethods
+servlet

--- a/_tutorials/en/sms-api/nexmo-client-library-java.md
+++ b/_tutorials/en/sms-api/nexmo-client-library-java.md
@@ -1,0 +1,66 @@
+---
+title: Using the Nexmo Client Library for Java
+description: Set up your Gradle project and download the Nexmo Client Library for Java.
+---
+
+# Using the Nexmo Client Library for Java
+
+Create a directory to contain your project. Inside this directory, run `gradle init`. Open the file `build.gradle` and change the contents to the following:
+
+```
+// We're creating a Java Application:
+apply plugin: 'application'
+apply plugin: 'java'
+ 
+// Download dependencies from Maven Central:
+repositories {
+    mavenCentral()
+}
+ 
+// Install the Nexmo Client library:
+dependencies {
+    compile 'com.nexmo:client:2.0.1'
+}
+ 
+// We'll create this class to contain our code:
+mainClassName = "getstarted.SendSMS"
+```
+
+Now, if you open your console in the directory that contains this `build.gradle` file, you can run:
+
+```
+gradle build
+```
+
+This command will download the Nexmo client library and store it for later. It would also compile any source code you have.
+
+Because of the `mainClassName` set in your Gradle `build` file, you need to create a class called `SendSMS` in the package `getstarted`. In production code, you’d want the package to be something like `com.mycoolcompany.smstool`, but this isn’t production code, so `getstarted` will do.
+
+Gradle uses the same directory structure as Maven, so you need to create the following directory structure inside your project directory: `src/main/java/getstarted`.
+
+On macOS and Linux, you can create this path by running:
+
+```
+mkdir -p src/main/java/getstarted
+```
+
+Inside the `getstarted` directory, create a file called `SendSMS.java`, open it in your favorite text editor. Start with some boiler-plate code:
+
+```
+package getstarted;
+ 
+import com.nexmo.client.NexmoClient;
+import com.nexmo.client.auth.AuthMethod;
+import com.nexmo.client.auth.TokenAuthMethod;
+import com.nexmo.client.sms.SmsSubmissionResult;
+import com.nexmo.client.sms.messages.TextMessage;
+ 
+public class SendSMS {
+ 
+    public static void main(String[] args) throws Exception {
+        // Our code will go here!
+    }
+}
+```
+
+All this does is import the necessary parts of the Nexmo client library, and create a method to contain our code. It’s worth running `gradle run` now, which should run your main method.

--- a/_tutorials/en/sms-api/send-sms-with-java.md
+++ b/_tutorials/en/sms-api/send-sms-with-java.md
@@ -1,0 +1,33 @@
+---
+title: Send SMS Messages with Java
+description: Send an SMS message with Vonage in Java.
+---
+
+# Send SMS Messages with Java
+
+Put the following in your `main` method:
+
+```
+AuthMethod auth = new TokenAuthMethod(API_KEY, API_SECRET);
+NexmoClient client = new NexmoClient(auth);
+```
+
+Fill in `API_KEY` and `API_SECRET` with the values you copied from the Vonage API Dashboard. This code creates a NexmoClient object that can be used to send SMS messages. You will need to provide other AuthMethods to be able to make voice calls (which will be covered in another tutorial). 
+
+Now we have a configured client object, we can send an SMS message:
+
+```
+TextMessage message = new TextMessage(FROM_NUMBER, TO_NUMBER, "Hello from Nexmo!");
+SmsSubmissionResult[] responses = client.getSmsClient().submitMessage(message);
+for (SmsSubmissionResult response : responses) {
+    System.out.println(response);
+}
+```
+
+Replace `FROM_NUMBER` and `TO_NUMBER` with strings containing the virtual number you bought, and your own mobile phone number. Once you’ve done that, save and run `gradle run` again. You should see something like this printed to the screen:
+
+`SMS-SUBMIT-RESULT -- STATUS:0 ERR:null DEST:4412341234 MSG-ID:0C0000002D9C9A89 CLIENT-REF:null PRICE:0.0333000`
+
+You should receive a text message. If it didn’t work, check out if something was printed after `ERR:` in the line above, and wait a few more seconds for the message to appear.
+
+> You have now learned how to send an SMS message with Vonage. Following on from this, this tutorial will show you how to build a web service around it.

--- a/_tutorials/en/sms-api/set-up-java-web-service.md
+++ b/_tutorials/en/sms-api/set-up-java-web-service.md
@@ -1,0 +1,102 @@
+---
+title: Building a Web Service to Send SMS
+description: Build a HTTP service and then test it with Postman.
+---
+
+# Building a Web Service to Send SMS
+
+This tutorial will show you how to build a tiny HTTP service and then test it with Postman. 
+
+Open your `build.gradle` and add the following to the top:
+
+```
+apply plugin: 'war'
+apply from: 'https://raw.github.com/akhikhl/gretty/master/pluginScripts/gretty.plugin'
+```
+
+The first line tells Gradle it should build a war file, using source files in `src/main/java` and `src/main/webapp`. The second line adds the ability to fire up your web app straight from Gradle using the Jetty servlet container.
+
+Run `gradle appRun` now. Note that you use `appRun` and not `run` to run the web server. It will take a while the first time, while it downloads some dependencies.
+
+Eventually, you should see something like this:
+
+```
+11:11:59 INFO  Jetty 9.2.15.v20160210 started and listening on port 8080
+11:11:59 INFO  project runs at:
+11:11:59 INFO    http://localhost:8080/project
+Press any key to stop the server.
+<===========--> 87% EXECUTING
+> :appRun
+```
+
+This means Jetty is now running your (empty) web service. Fire up the URL you see, to check it’s running OK. It should look a bit like this:
+
+![Empty web service launched by Jetty](https://www.nexmo.com/wp-content/uploads/2017/04/empty-web.png)
+
+Create a file called `src/main/java/getstarted/SendSMSServlet.java`. It’s going to look similar to the last class:
+
+```
+public class SendSMSServlet extends HttpServlet {
+    private String FROM_NUMBER;
+    private NexmoClient client;
+ 
+    public void init(ServletConfig config) {
+        // Load configuration from the servlet container:
+        FROM_NUMBER = config.getInitParameter("from_number");
+        String api_key = config.getInitParameter("api_key");
+        String api_secret = config.getInitParameter("api_secret");
+ 
+        client = new NexmoClient(new TokenAuthMethod(api_key, api_secret));
+    }
+ 
+    protected void doPost(HttpServletRequest req,
+                      HttpServletResponse resp)
+               throws ServletException,
+                      java.io.IOException {
+        try {
+            // Extract form parameters from the request:
+            String to_number = req.getParameter("to");
+            String message = req.getParameter("message");
+ 
+            SmsSubmissionResult[] responses = client.getSmsClient().submitMessage(
+                new TextMessage(FROM_NUMBER, to_number, message));
+            for (SmsSubmissionResult response : responses) {
+                resp.getWriter().println(response);
+            }
+        } catch (NexmoClientException nce) {
+            throw new ServletException(nce);
+        }
+    }
+}
+```
+
+Configure the servlet in our servlet container by creating the following at `src/main/webapp/WEB-INF/web.xml`:
+
+```
+<web-app>
+    <servlet>
+        <servlet-name>send-sms</servlet-name>
+        <servlet-class>getstarted.SendSMSServlet</servlet-class>
+        <init-param>
+            <param-name>from_number</param-name>
+            <param-value>YOUR_NEXMO_NUMBER</param-value>
+        </init-param>
+        <init-param>
+            <param-name>api_key</param-name>
+            <param-value>YOUR_API_KEY</param-value>
+        </init-param>
+        <init-param>
+            <param-name>api_secret</param-name>
+            <param-value>YOUR_API_SECRET</param-value>
+        </init-param>
+    </servlet>
+    <servlet-mapping>
+        <servlet-name>send-sms</servlet-name>
+        <url-pattern>/*</url-pattern>
+    </servlet-mapping>
+</web-app>
+```
+
+Replace the placeholders with your own values, and then run `gradle appRun`. If everything builds correctly, let’s fire up [Postman](https://www.getpostman.com/) and make a POST request, like this:
+
+![Postman POST request](https://www.nexmo.com/wp-content/uploads/2017/04/postman-request.png)

--- a/config/tutorials/en/receive-sms-with-java.yml
+++ b/config/tutorials/en/receive-sms-with-java.yml
@@ -1,9 +1,41 @@
 ---
 title: Receive SMS Messages with Java
-external_link: https://www.nexmo.com/blog/2017/05/31/receive-sms-messages-java-dr/
 products:
  - messaging/sms
 description: This tutorial walks you through creating a servlet to receive incoming SMS messages from your users. You'll learn how to configure your Nexmo number and account, set up the servlet, and have the incoming messages logged to the console.
 languages:
   - Java
 ---
+introduction: 
+  title: Introduction to this tutorial
+  description: This tutorial shows you how to send an SMS message with nexmo-python.
+  content: |
+    # Introduction
+    The [Vonage SMS API](/messaging/sms/overview) is a service that allows you to send and receive SMS messages anywhere in the world. Vonage provides REST APIs, but it’s much easier to use the Java client library we’ve written for you.
+
+    In this tutorial we’ll cover how to send SMS messages with Java.
+
+    View the [source code on Github](https://github.com/nexmo-community/nexmo-java-quickstart/blob/master/src/main/java/com/nexmo/quickstart/sms/SendMessage.java).
+
+    > Before starting, you will need a basic understanding of Java, Java SDK 1.8 or 1.7 installed, and Gradle for building your project.
+
+    Note that this tutorial also uses a virtual phone number. To purchase one, go to *Numbers > Buy Numbers* and search for one that meets your needs. If you’ve just signed up, the initial cost of a number will be easily covered by your available credit.
+        
+prerequisites:
+- create-nexmo-account
+
+tasks:
+- sms-api/nexmo-client-library-java
+- sms-api/send-sms-with-java
+- sms-api/set-up-java-web-service
+
+conclusion:
+  title: What's next?
+  description: What else can you do with the SMS API?
+  content: |
+    # What's next?
+    You have now successfully built a REST Web service for sending SMS messages. In reality, there are many more things you’d want to do before deploying this, like adding authentication (otherwise anyone could send a message using your Vonage API account!), a nice Web form for posting to the service, and improving the error handling – but this is a good start!
+
+    ## References
+    * [Vonage SMS API Reference](https://docs.nexmo.com/messaging/sms-api/api-reference)
+    * [Nexmo Client Library for Java](https://github.com/nexmo/nexmo-java)


### PR DESCRIPTION
## Description

Converted blog post ["SMS Messages to Java"](https://www.nexmo.com/blog/2017/05/03/send-sms-messages-with-java-dr) into standard tutorial format.

I also updated the `.spelling` file to include a couple of words that didn't originally pass the checks ("servlet" and "AuthMethods".

This commit is related to issue #3225 for Hacktoberfest.