### PR TITLE
fixed link to webhook section

### DIFF
--- a/_documentation/en/messaging/sms/code-snippets/delivery-receipts.md
+++ b/_documentation/en/messaging/sms/code-snippets/delivery-receipts.md
@@ -13,7 +13,7 @@ You can verify that a message you sent using Nexmo's SMS API reached your custom
 To access the delivery receipt, you need to:
 
 * [Create a webhook endpoint](/messaging/sms/code-snippets/before-you-begin#webhooks) using one of the code examples shown below
-* [Configure the webhook endpoint in your Vonage Dashboard](#configure-the-webhook-endpoint-in-your-nexmo-dashboard)
+* [Configure the webhook endpoint in your Vonage Dashboard](#configure-the-webhook-endpoint-in-your-vonage-dashboard)
 
 > **NOTE:** After you send a message there may be a delay before you receive the delivery receipt.
 

--- a/_documentation/en/messaging/sms/code-snippets/receiving-an-sms.md
+++ b/_documentation/en/messaging/sms/code-snippets/receiving-an-sms.md
@@ -9,7 +9,7 @@ To receive an SMS, you need to:
 
 * [Rent a virtual number](/numbers/guides/number-management#rent-a-virtual-number) to receive messages
 * [Create a webhook endpoint](/messaging/sms/code-snippets/before-you-begin#webhooks) using one of the code examples shown below
-* [Configure the webhook in your Vonage Dashboard](#configure-the-webhook-endpoint-in-your-nexmo-dashboard)
+* [Configure the webhook in your Vonage Dashboard](#configure-the-webhook-endpoint-in-your-vonage-dashboard)
 
 
 ```code_snippets


### PR DESCRIPTION
## Description

Currently when you click on the **Configure the webhook in your Vonage Dashboard** link, it directs you to this URL `https://developer.nexmo.com/messaging/sms/code-snippets/receiving-an-sms#configure-the-webhook-endpoint-in-your-nexmo-dashboard` which no longer exists anymore since the name was changed from Nexmo to Vonage.
## Deploy Notes
N/A
