### PR TITLE
Corrected wrong heading in Kotlin app-to-app tutorial task

### DIFF
--- a/_tutorials/en/client-sdk/app-to-app/receive-call/kotlin.md
+++ b/_tutorials/en/client-sdk/app-to-app/receive-call/kotlin.md
@@ -3,7 +3,7 @@ title: Receive a call
 description: In this step you learn how to receive an in-app call
 ---
 
-# Make a call
+# Receive a call
 
 Locate the `incomingCallListener` property within the `MainViewModel` class and fill its body:
 


### PR DESCRIPTION
## Description

Fixed an incorrect heading in the Kotlin version of the app-to-app call tutorial


