### PR TITLE
Change Nexmo refs in Code Snippet pages to Vonage

### DIFF
--- a/_documentation/en/account/code-snippets/account-balance.md
+++ b/_documentation/en/account/code-snippets/account-balance.md
@@ -5,7 +5,7 @@ navigation_weight: 1
 
 # Get your current account balance
 
-You can check the balance of your Nexmo account at any time by making an API request and receiving the balance of your account in the response.
+You can check the balance of your Vonage account at any time by making an API request and receiving the balance of your account in the response.
 
 ```code_snippets
 source: _examples/account/get-balance

--- a/_documentation/en/account/code-snippets/configure-account.md
+++ b/_documentation/en/account/code-snippets/configure-account.md
@@ -9,11 +9,11 @@ You can programmatically configure the settings for your account, such as the ca
 
 # Example
 
-This example shows how to set the URL that will be called when your Nexmo number receives an SMS.
+This example shows how to set the URL that will be called when your Vonage number receives an SMS.
 
 Key |	Description
 -- | --
-`SMS_CALLBACK_URL` | The publicly-accessible URL that Nexmo should send information to when your Nexmo number receives an SMS
+`SMS_CALLBACK_URL` | The publicly-accessible URL that Vonage should send information to when your Vonage number receives an SMS
 
 ```code_snippets
 source: _examples/account/configure-account

--- a/_documentation/en/dispatch/code-snippets/create-an-application.md
+++ b/_documentation/en/dispatch/code-snippets/create-an-application.md
@@ -1,7 +1,7 @@
 ---
 title: How to create a Vonage Messages and Dispatch Application
 navigation_weight: 3
-description: You can create a Vonage Messages and Dispatch application either in the Dashboard or using the Vonage CLI.
+description: You can create a Vonage Messages and Dispatch application either in the Dashboard or using the Nexmo CLI.
 ---
 
 # How to create a Vonage Messages and Dispatch Application

--- a/_documentation/en/dispatch/code-snippets/create-an-application.md
+++ b/_documentation/en/dispatch/code-snippets/create-an-application.md
@@ -1,10 +1,10 @@
 ---
-title: How to create a Nexmo Messages and Dispatch Application
+title: How to create a Vonage Messages and Dispatch Application
 navigation_weight: 3
-description: You can create a Nexmo Messages and Dispatch application either in the Dashboard or using the Nexmo CLI.
+description: You can create a Vonage Messages and Dispatch application either in the Dashboard or using the Vonage CLI.
 ---
 
-# How to create a Nexmo Messages and Dispatch Application
+# How to create a Vonage Messages and Dispatch Application
 
 ```partial
 source: _partials/reusable/create-a-nexmo-application.md

--- a/_documentation/en/messages/code-snippets/messenger/send-template.md
+++ b/_documentation/en/messages/code-snippets/messenger/send-template.md
@@ -5,7 +5,7 @@ meta_title: Send a message template with Facebook Messenger
 
 # Send a Message Template
 
-In this code snippet you learn how to send a Facebook message template using a Nexmo [custom object](/messages/concepts/custom-objects) message using the Messages API.
+In this code snippet you learn how to send a Facebook message template using a [custom object](/messages/concepts/custom-objects) with the Messages API.
 
 ## Example
 

--- a/_documentation/en/messages/code-snippets/whatsapp/send-audio.md
+++ b/_documentation/en/messages/code-snippets/whatsapp/send-audio.md
@@ -17,7 +17,7 @@ Key | Description
 -- | --
 `BASE_URL` | For production use the base URL is `https://api.nexmo.com/`. For sandbox testing the base URL is `https://messages-sandbox.nexmo.com/`.
 `MESSAGES_API_URL` | For production use the Messages API endpoint is `https://api.nexmo.com/v0.1/messages`. For sandbox testing the Messages API endpoint is `https://messages-sandbox.nexmo.com/v0.1/messages`.
-`WHATSAPP_NUMBER` | The WhatsApp number that has been allocated to you by Nexmo. For sandbox testing the number is `14157386170`.
+`WHATSAPP_NUMBER` | The WhatsApp number that has been allocated to you by Vonage. For sandbox testing the number is `14157386170`.
 `TO_NUMBER` | The phone number you are sending the message to.
 `AUDIO_URL` | The URL of the audio file to send.
 

--- a/_documentation/en/messages/code-snippets/whatsapp/send-button-link.md
+++ b/_documentation/en/messages/code-snippets/whatsapp/send-button-link.md
@@ -5,7 +5,7 @@ meta_title: Send a link button on WhatsApp using the Messages API
 
 # Send a Link Button
 
-In this code snippet you learn how to send a link style button on WhatsApp. This uses Nexmo's [custom object](/messages/concepts/custom-objects) facility. You can reference the WhatsApp developer documentation for the specifics of the [message format](https://developers.facebook.com/docs/whatsapp/api/messages/message-templates/interactive-message-templates).
+In this code snippet you learn how to send a link style button on WhatsApp. This uses Vonage's [custom object](/messages/concepts/custom-objects) facility. You can reference the WhatsApp developer documentation for the specifics of the [message format](https://developers.facebook.com/docs/whatsapp/api/messages/message-templates/interactive-message-templates).
 
 When the message recipient clicks on the link button, they will be prompted for permission to continue to the target link.
 
@@ -17,7 +17,7 @@ Key | Description
 -- | --
 `BASE_URL` | For production use the base URL is `https://api.nexmo.com/`. For sandbox testing the base URL is `https://messages-sandbox.nexmo.com/`.
 `MESSAGES_API_URL` | For production use the Messages API endpoint is `https://api.nexmo.com/v0.1/messages`. For sandbox testing the Messages API endpoint is `https://messages-sandbox.nexmo.com/v0.1/messages`.
-`WHATSAPP_NUMBER` | The WhatsApp number that has been allocated to you by Nexmo. For sandbox testing the number is `14157386170`.
+`WHATSAPP_NUMBER` | The WhatsApp number that has been allocated to you by Vonage. For sandbox testing the number is `14157386170`.
 `TO_NUMBER` | The phone number you are sending the message to.
 `WHATSAPP_TEMPLATE_NAMESPACE` | The namespace ID found in your WhatsApp Business Account. Only templates created in your own namespace will work. Using an template with a namespace outside of your own results in an error code 1022 being returned. For sandbox testing the supported namespace is `9b6b4fcb_da19_4a26_8fe8_78074a91b584`.
 `WHATSAPP_TEMPLATE_NAME` | The name of the template created in your WhatsApp Business Account. For sandbox testing the `verify` template is currently available. Refer to [this table](/messages/concepts/messages-api-sandbox#whatsapp-templates-for-use-with-the-messages-api-sandbox) for new templates as they become available.

--- a/_documentation/en/messages/code-snippets/whatsapp/send-button-quick-reply.md
+++ b/_documentation/en/messages/code-snippets/whatsapp/send-button-quick-reply.md
@@ -5,9 +5,9 @@ meta_title: Send a quick reply button on WhatsApp using the Messages API
 
 # Send a Quick Reply Button
 
-In this code snippet you learn how to send a quick reply style button on WhatsApp. This uses Nexmo's [custom object](/messages/concepts/custom-objects) facility. You can reference the WhatsApp developer docs for the specifics of the [message format](https://developers.facebook.com/docs/whatsapp/api/messages/message-templates/interactive-message-templates).
+In this code snippet you learn how to send a quick reply style button on WhatsApp. This uses Vonage's [custom object](/messages/concepts/custom-objects) facility. You can reference the WhatsApp developer docs for the specifics of the [message format](https://developers.facebook.com/docs/whatsapp/api/messages/message-templates/interactive-message-templates).
 
-When the message recipient clicks on the quick reply button, Nexmo will `POST` relevant data to your inbound message webhook URL.
+When the message recipient clicks on the quick reply button, Vonage will `POST` relevant data to your inbound message webhook URL.
 
 ## Example
 
@@ -17,7 +17,7 @@ Key | Description
 -- | --
 `BASE_URL` | For production use the base URL is `https://api.nexmo.com/`. For sandbox testing the base URL is `https://messages-sandbox.nexmo.com/`.
 `MESSAGES_API_URL` | For production use the Messages API endpoint is `https://api.nexmo.com/v0.1/messages`. For sandbox testing the Messages API endpoint is `https://messages-sandbox.nexmo.com/v0.1/messages`.
-`WHATSAPP_NUMBER` | The WhatsApp number that has been allocated to you by Nexmo. For sandbox testing the number is `14157386170`.
+`WHATSAPP_NUMBER` | The WhatsApp number that has been allocated to you by Vonage. For sandbox testing the number is `14157386170`.
 `TO_NUMBER` | The phone number you are sending the message to.
 `WHATSAPP_TEMPLATE_NAMESPACE` | The namespace ID found in your WhatsApp Business Account. Only templates created in your own namespace will work. Using an template with a namespace outside of your own results in an error code 1022 being returned. For sandbox testing the supported namespace is `9b6b4fcb_da19_4a26_8fe8_78074a91b584`.
 `WHATSAPP_TEMPLATE_NAME` | The name of the template created in your WhatsApp Business Account. For sandbox testing the `verify` template is currently available. Refer to [this table](/messages/concepts/messages-api-sandbox#whatsapp-templates-for-use-with-the-messages-api-sandbox) for new templates as they become available.

--- a/_documentation/en/messages/code-snippets/whatsapp/send-contact.md
+++ b/_documentation/en/messages/code-snippets/whatsapp/send-contact.md
@@ -5,7 +5,7 @@ meta_title: Send a contact on WhatsApp using the Messages API
 
 # Send a Contact
 
-In this code snippet you learn how to send a contact to WhatsApp using the Messages API. This uses Nexmo's [Custom object](/messages/concepts/custom-objects) feature. Further information on the specific message format can be found in the WhatsApp developers [Contacts message](https://developers.facebook.com/docs/whatsapp/api/messages/others#contacts-messages) documentation.
+In this code snippet you learn how to send a contact to WhatsApp using the Messages API. This uses Vonage's [Custom object](/messages/concepts/custom-objects) feature. Further information on the specific message format can be found in the WhatsApp developers [Contacts message](https://developers.facebook.com/docs/whatsapp/api/messages/others#contacts-messages) documentation.
 
 ## Example
 
@@ -15,7 +15,7 @@ Key | Description
 -- | --
 `BASE_URL` | For production use the base URL is `https://api.nexmo.com/`. For sandbox testing the base URL is `https://messages-sandbox.nexmo.com/`.
 `MESSAGES_API_URL` | For production use the Messages API endpoint is `https://api.nexmo.com/v0.1/messages`. For sandbox testing the Messages API endpoint is `https://messages-sandbox.nexmo.com/v0.1/messages`.
-`WHATSAPP_NUMBER` | The WhatsApp number that has been allocated to you by Nexmo. For sandbox testing the number is `14157386170`.
+`WHATSAPP_NUMBER` | The WhatsApp number that has been allocated to you by Vonage. For sandbox testing the number is `14157386170`.
 `TO_NUMBER` | The phone number you are sending the message to.
 
 > **NOTE:** Don't use a leading `+` or `00` when entering a phone number, start with the country code, for example, 447700900000.

--- a/_documentation/en/messages/code-snippets/whatsapp/send-file.md
+++ b/_documentation/en/messages/code-snippets/whatsapp/send-file.md
@@ -17,7 +17,7 @@ Key | Description
 -- | --
 `BASE_URL` | For production use the base URL is `https://api.nexmo.com/`. For sandbox testing the base URL is `https://messages-sandbox.nexmo.com/`.
 `MESSAGES_API_URL` | For production use the Messages API endpoint is `https://api.nexmo.com/v0.1/messages`. For sandbox testing the Messages API endpoint is `https://messages-sandbox.nexmo.com/v0.1/messages`.
-`WHATSAPP_NUMBER` | The WhatsApp number that has been allocated to you by Nexmo. For sandbox testing the number is `14157386170`.
+`WHATSAPP_NUMBER` | The WhatsApp number that has been allocated to you by Vonage. For sandbox testing the number is `14157386170`.
 `TO_NUMBER` | The phone number you are sending the message to.
 `FILE_URL` | The URL of the file to send.
 `FILE_CAPTION` | The text describing the file being sent.

--- a/_documentation/en/messages/code-snippets/whatsapp/send-image.md
+++ b/_documentation/en/messages/code-snippets/whatsapp/send-image.md
@@ -17,7 +17,7 @@ Key | Description
 -- | --
 `BASE_URL` | For production use the base URL is `https://api.nexmo.com/`. For sandbox testing the base URL is `https://messages-sandbox.nexmo.com/`.
 `MESSAGES_API_URL` | For production use the Messages API endpoint is `https://api.nexmo.com/v0.1/messages`. For sandbox testing the Messages API endpoint is `https://messages-sandbox.nexmo.com/v0.1/messages`.
-`WHATSAPP_NUMBER` | The WhatsApp number that has been allocated to you by Nexmo. For sandbox testing the number is `14157386170`.
+`WHATSAPP_NUMBER` | The WhatsApp number that has been allocated to you by Vonage. For sandbox testing the number is `14157386170`.
 `TO_NUMBER` | The phone number you are sending the message to.
 `IMAGE_URL` | The URL of the image to send.
 `IMAGE_CAPTION` | The text describing the image being sent.

--- a/_documentation/en/messages/code-snippets/whatsapp/send-location.md
+++ b/_documentation/en/messages/code-snippets/whatsapp/send-location.md
@@ -5,7 +5,7 @@ meta_title: Send a location on WhatsApp using the Messages API
 
 # Send a Location
 
-In this code snippet you learn how to send a location to WhatsApp using the Messages API. This uses Nexmo's [Custom object](/messages/concepts/custom-objects) feature. Further information on the specific message format can be found in the WhatsApp developers [Location message](https://developers.facebook.com/docs/whatsapp/api/messages/others#location-messages) documentation.
+In this code snippet you learn how to send a location to WhatsApp using the Messages API. This uses Vonage's [Custom object](/messages/concepts/custom-objects) feature. Further information on the specific message format can be found in the WhatsApp developers [Location message](https://developers.facebook.com/docs/whatsapp/api/messages/others#location-messages) documentation.
 
 ## Example
 
@@ -15,7 +15,7 @@ Key | Description
 -- | --
 `BASE_URL` | For production use the base URL is `https://api.nexmo.com/`. For sandbox testing the base URL is `https://messages-sandbox.nexmo.com/`.
 `MESSAGES_API_URL` | For production use the Messages API endpoint is `https://api.nexmo.com/v0.1/messages`. For sandbox testing the Messages API endpoint is `https://messages-sandbox.nexmo.com/v0.1/messages`.
-`WHATSAPP_NUMBER` | The WhatsApp number that has been allocated to you by Nexmo. For sandbox testing the number is `14157386170`.
+`WHATSAPP_NUMBER` | The WhatsApp number that has been allocated to you by Vonage. For sandbox testing the number is `14157386170`.
 `TO_NUMBER` | The phone number you are sending the message to.
 
 > **NOTE:** Don't use a leading `+` or `00` when entering a phone number, start with the country code, for example, 447700900000.

--- a/_documentation/en/messages/code-snippets/whatsapp/send-media-mtm.md
+++ b/_documentation/en/messages/code-snippets/whatsapp/send-media-mtm.md
@@ -26,7 +26,7 @@ Key | Description
 -- | --
 `BASE_URL` | For production use the base URL is `https://api.nexmo.com/`. For sandbox testing the base URL is `https://messages-sandbox.nexmo.com/`.
 `MESSAGES_API_URL` | For production use the Messages API endpoint is `https://api.nexmo.com/v0.1/messages`. For sandbox testing the Messages API endpoint is `https://messages-sandbox.nexmo.com/v0.1/messages`.
-`WHATSAPP_NUMBER` | The WhatsApp number that has been allocated to you by Nexmo. For sandbox testing the number is `14157386170`.
+`WHATSAPP_NUMBER` | The WhatsApp number that has been allocated to you by Vonage. For sandbox testing the number is `14157386170`.
 `TO_NUMBER` | The phone number you are sending the message to.
 `WHATSAPP_TEMPLATE_NAMESPACE` | The namespace ID found in your WhatsApp Business Account. Only templates created in your own namespace will work. Using an template with a namespace outside of your own results in an error code 1022 being returned. For sandbox testing the supported namespace is `9b6b4fcb_da19_4a26_8fe8_78074a91b584`.
 `WHATSAPP_TEMPLATE_NAME` | The name of the template created in your WhatsApp Business Account. For sandbox testing the `verify` template is currently available. Refer to [this table](/messages/concepts/messages-api-sandbox#whatsapp-templates-for-use-with-the-messages-api-sandbox) for new templates as they become available.

--- a/_documentation/en/messages/code-snippets/whatsapp/send-mtm.md
+++ b/_documentation/en/messages/code-snippets/whatsapp/send-mtm.md
@@ -18,7 +18,7 @@ Key | Description
 -- | --
 `BASE_URL` | For production use the base URL is `https://api.nexmo.com/`. For sandbox testing the base URL is `https://messages-sandbox.nexmo.com/`.
 `MESSAGES_API_URL` | For production use the Messages API endpoint is `https://api.nexmo.com/v0.1/messages`. For sandbox testing the Messages API endpoint is `https://messages-sandbox.nexmo.com/v0.1/messages`.
-`WHATSAPP_NUMBER` | The WhatsApp number that has been allocated to you by Nexmo. For sandbox testing the number is `14157386170`.
+`WHATSAPP_NUMBER` | The WhatsApp number that has been allocated to you by Vonage. For sandbox testing the number is `14157386170`.
 `TO_NUMBER` | The phone number you are sending the message to.
 `WHATSAPP_TEMPLATE_NAMESPACE` | The namespace ID found in your WhatsApp Business Account. Only templates created in your own namespace will work. Using an template with a namespace outside of your own results in an error code 1022 being returned. For sandbox testing the supported namespace is `9b6b4fcb_da19_4a26_8fe8_78074a91b584`.
 `WHATSAPP_TEMPLATE_NAME` | The name of the template created in your WhatsApp Business Account. For sandbox testing the `verify` template is currently available. Refer to [this table](/messages/concepts/messages-api-sandbox#whatsapp-templates-for-use-with-the-messages-api-sandbox) for new templates as they become available.

--- a/_documentation/en/messages/code-snippets/whatsapp/send-text.md
+++ b/_documentation/en/messages/code-snippets/whatsapp/send-text.md
@@ -29,7 +29,7 @@ Key | Description
 -- | --
 `BASE_URL` | For production use the base URL is `https://api.nexmo.com/`. For sandbox testing the base URL is `https://messages-sandbox.nexmo.com/`.
 `MESSAGES_API_URL` | For production use the Messages API endpoint is `https://api.nexmo.com/v0.1/messages`. For sandbox testing the Messages API endpoint is `https://messages-sandbox.nexmo.com/v0.1/messages`.
-`WHATSAPP_NUMBER` | The WhatsApp number that has been allocated to you by Nexmo. For sandbox testing the number is `14157386170`.
+`WHATSAPP_NUMBER` | The WhatsApp number that has been allocated to you by Vonage. For sandbox testing the number is `14157386170`.
 `TO_NUMBER` | The phone number you are sending the message to.
 
 > **NOTE:** Don't use a leading `+` or `00` when entering a phone number, start with the country code, for example, 447700900000.

--- a/_documentation/en/messages/code-snippets/whatsapp/send-video.md
+++ b/_documentation/en/messages/code-snippets/whatsapp/send-video.md
@@ -15,7 +15,7 @@ Key | Description
 -- | --
 `BASE_URL` | For production use the base URL is `https://api.nexmo.com/`. For sandbox testing the base URL is `https://messages-sandbox.nexmo.com/`.
 `MESSAGES_API_URL` | For production use the Messages API endpoint is `https://api.nexmo.com/v0.1/messages`. For sandbox testing the Messages API endpoint is `https://messages-sandbox.nexmo.com/v0.1/messages`.
-`WHATSAPP_NUMBER` | The WhatsApp number that has been allocated to you by Nexmo. For sandbox testing the number is `14157386170`.
+`WHATSAPP_NUMBER` | The WhatsApp number that has been allocated to you by Vonage. For sandbox testing the number is `14157386170`.
 `TO_NUMBER` | The WhatsApp number you are sending to.
 `VIDEO_URL` | The link to the video to send. WhatsApp supports `.mp4` and `.3gpp`. Note, only `H.264` video codec and `AAC` audio codecs are supported.
 `VIDEO_CAPTION` | The caption text for the video.

--- a/_documentation/en/messaging/sms/code-snippets/delivery-receipts.md
+++ b/_documentation/en/messaging/sms/code-snippets/delivery-receipts.md
@@ -6,7 +6,7 @@ navigation_weight: 4
 
 # Delivery Receipts
 
-You can verify that a message you sent using Nexmo's SMS API reached your customer by requesting a [delivery receipt](/messaging/sms/guides/delivery-receipts) from the carrier.
+You can verify that a message you sent using the Vonage SMS API reached your customer by requesting a [delivery receipt](/messaging/sms/guides/delivery-receipts) from the carrier.
 
 > **NOTE:** Not all networks and countries support delivery receipts. You can check our knowledge base for some further information on what you [might receive](https://help.nexmo.com/hc/en-us/articles/204014863) if your network does not support delivery receipts. For detailed information on delivery receipts see our [documentation](/messaging/sms/guides/delivery-receipts).
 
@@ -23,7 +23,7 @@ source: '_examples/messaging/sms/delivery-receipts'
 
 ## Configure the webhook endpoint in your Vonage Dashboard
 
-So that Nexmo knows how to access your webhook, you must configure it in your Nexmo account.
+So that Vonage knows how to access your webhook, you must configure it in your Vonage account.
 
 In the code snippets, the webhook is located at `/webhooks/delivery-receipt`. If you are using Ngrok, the webhook you need to configure in your [Vonage Dashboard API Settings page](https://dashboard.nexmo.com/settings) is of the form `https://demo.ngrok.io/webhooks/delivery-receipt`. Replace `demo` with the subdomain provided by Ngrok and enter your endpoint in the field labeled **Webhook URL for Delivery Receipts**:
 
@@ -46,7 +46,7 @@ image: public/screenshots/smsDLRsettings.png
   "price": "0.03330000",
   "scts": "1810251310",
   "status": "delivered",
-  "to": "Nexmo CLI"
+  "to": "Vonage"
 }
 ```
 

--- a/_documentation/en/messaging/sms/code-snippets/receiving-an-sms.md
+++ b/_documentation/en/messaging/sms/code-snippets/receiving-an-sms.md
@@ -18,7 +18,7 @@ source: '_examples/messaging/sms/receiving-an-sms'
 
 ## Configure the webhook endpoint in your Vonage Dashboard
 
-So that Nexmo knows how to access your webhook, you must configure it in your Nexmo account.
+So that Vonage knows how to access your webhook, you must configure it in your Vonage account.
 
 In the code snippets, the webhook is located at `/webhooks/inbound-sms`. If you are using Ngrok, the webhook you need to configure in your [Vonage Dashboard API Settings page](https://dashboard.nexmo.com/settings) is of the form `https://demo.ngrok.io/webhooks/inbound-sms`. Replace `demo` with the subdomain provided by Ngrok and enter your endpoint in the field labeled **Webhook URL for Inbound Message**:
 
@@ -29,7 +29,7 @@ image: public/screenshots/smsInboundWebhook.png
 
 ## Try it out
 
-Now when you send your Nexmo number an SMS you should see it logged in your console. The message object contains the following properties:
+Now when you send your Vonage number an SMS you should see it logged in your console. The message object contains the following properties:
 
 ```json
 {

--- a/_documentation/en/messaging/sms/code-snippets/send-an-sms-with-unicode.md
+++ b/_documentation/en/messaging/sms/code-snippets/send-an-sms-with-unicode.md
@@ -1,12 +1,12 @@
 ---
 title: Send an SMS with Unicode
-description: How to send a Unicode SMS with the Nexmo SMS API
+description: How to send a Unicode SMS with the Vonage SMS API
 navigation_weight: 3
 ---
 
 # Sending an SMS with Unicode
 
-Nexmo's SMS API supports Unicode characters too, which you will need to use when communicating with customers in Chinese, Japanese and Korean.
+The Vonage SMS API supports Unicode characters too, which you will need to use when communicating with customers in Chinese, Japanese and Korean.
 
 To send an SMS that contains Unicode characters, replace the following variables in the example below:
 

--- a/_documentation/en/messaging/sms/code-snippets/send-an-sms.md
+++ b/_documentation/en/messaging/sms/code-snippets/send-an-sms.md
@@ -1,6 +1,6 @@
 ---
 title: Send an SMS
-description: How to send an SMS with the Nexmo SMS API
+description: How to send an SMS with the Vonage SMS API
 navigation_weight: 2
 ---
 

--- a/_documentation/en/number-insight/code-snippets/number-insight-advanced-async.md
+++ b/_documentation/en/number-insight/code-snippets/number-insight-advanced-async.md
@@ -16,7 +16,7 @@ Use this information to determine the risk associated with a number.
 
 > Note that the Advanced API does not provide any extra information about landlines than the [Number Insight Standard API](/number-insight/code-snippets/number-insight-standard). For insights about landline numbers, use the Standard API.
 
-This code snippet shows you how to trigger an **asynchronous** call to the Number Insight API. __This is the approach Nexmo recommends__. You can optionally use the Number Insight Advanced API [synchronously](number-insight-advanced-sync), but be aware that synchronous use can result in timeouts.
+This code snippet shows you how to trigger an **asynchronous** call to the Number Insight API. __This is the approach Vonage recommends__. You can optionally use the Number Insight Advanced API [synchronously](number-insight-advanced-sync), but be aware that synchronous use can result in timeouts.
 
 Before attempting to run the code examples, replace the variable placeholders as instructed in [replaceable variables](before-you-begin#replaceable-variables).
 

--- a/_documentation/en/number-insight/code-snippets/number-insight-advanced-sync.md
+++ b/_documentation/en/number-insight/code-snippets/number-insight-advanced-sync.md
@@ -7,7 +7,7 @@ navigation_weight: 6
 
 This code snippet shows you how to use Number Insight Advanced API synchronously.
 
-> **Note**: Nexmo does not recommend this approach, because it can result in timeouts. In most cases, you should use an [asynchronous call](number-insight-advanced-async) to the Number Insight API.
+> **Note**: Vonage does not recommend this approach, because it can result in timeouts. In most cases, you should use an [asynchronous call](number-insight-advanced-async) to the Number Insight API.
 
 Before attempting to run the code examples, replace the variable placeholders as instructed in [replaceable variables](/number-insight/code-snippets/before-you-begin#replaceable-variables).
 

--- a/_documentation/en/number-insight/code-snippets/number-insight-basic.md
+++ b/_documentation/en/number-insight/code-snippets/number-insight-basic.md
@@ -5,7 +5,7 @@ navigation_weight: 2
 
 # Number Insight Basic
 
-Use Nexmo's Number Insight Basic API to determine:
+Use the Vonage Number Insight Basic API to determine:
 
 * The country where a number is registered
 * The local and international representation of that number

--- a/_documentation/en/numbers/code-snippets/buy.md
+++ b/_documentation/en/numbers/code-snippets/buy.md
@@ -5,11 +5,11 @@ navigation_weight: 3
 
 # Buy a Number
 
-You need to purchase a Nexmo [virtual number]() if you want to:
+You need to purchase a Vonage [virtual number](/concepts/guides/glossary#virtual-number) if you want to:
 
-* Make or receive telephone calls with the [Voice API](https://developer.nexmo.com/voice/voice-api/overview)
-* Receive inbound SMS with the [SMS API](https://developer.nexmo.com/messaging/sms/overview)
-* Use multichannel messaging with the [Messages API](https://developer.nexmo.com/messages/overview)
+* Make or receive telephone calls with the [Voice API](/voice/voice-api/overview)
+* Receive inbound SMS with the [SMS API](/messaging/sms/overview)
+* Use multichannel messaging with the [Messages API](/messages/overview)
 
 This page shows you how to buy a number programmatically.
 

--- a/_documentation/en/numbers/code-snippets/cancel.md
+++ b/_documentation/en/numbers/code-snippets/cancel.md
@@ -5,7 +5,7 @@ navigation_weight: 5
 
 # Cancel a Number
 
-If you no longer require a Nexmo virtual number that you have [purchased]() you can cancel it.
+If you no longer require a Vonage virtual number that you have [purchased]() you can cancel it.
 
 This page shows you how to cancel a number programmatically.
 

--- a/_documentation/en/numbers/code-snippets/list-owned.md
+++ b/_documentation/en/numbers/code-snippets/list-owned.md
@@ -13,8 +13,8 @@ Replace the following variables in the sample code with your own values:
 
 Name | Description
 --|--
-`VONAGE_API_KEY` | Your Vonage [API key](https://developer.nexmo.com/concepts/guides/authentication#api-key-and-secret)
-`VONAGE_API_SECRET` | Your Vonage [API secret](https://developer.nexmo.com/concepts/guides/authentication#api-key-and-secret)
+`VONAGE_API_KEY` | Your Vonage [API key](/concepts/guides/authentication#api-key-and-secret)
+`VONAGE_API_SECRET` | Your Vonage [API secret](/concepts/guides/authentication#api-key-and-secret)
 `NUMBER_SEARCH_CRITERIA` | The filter criteria. For example, numbers containing `234`.
 `NUMBER_SEARCH_PATTERN` | Where the `NUMBER_SEARCH_CRITERIA` should appear in the number: <ul><li>`0` - At the beginning of the number</li><li>`1`- Anywhere in the number</li><li>`2` - At the end of the number</ul>
 

--- a/_documentation/en/numbers/code-snippets/search-available.md
+++ b/_documentation/en/numbers/code-snippets/search-available.md
@@ -13,8 +13,8 @@ Replace the following variables in the sample code with your own values:
 
 Name | Description
 --|--
-`VONAGE_API_KEY` | Your Vonage [API key](https://developer.nexmo.com/concepts/guides/authentication#api-key-and-secret)
-`VONAGE_API_SECRET` | Your Vonage [API secret](https://developer.nexmo.com/concepts/guides/authentication#api-key-and-secret)
+`VONAGE_API_KEY` | Your Vonage [API key](/concepts/guides/authentication#api-key-and-secret)
+`VONAGE_API_SECRET` | Your Vonage [API secret](/concepts/guides/authentication#api-key-and-secret)
 `COUNTRY_CODE` | The two digit country code for the numbers you want to search. For example: `GB` for the United Kingdom.
 `VONAGE_NUMBER_TYPE` | The type of number: `landline`, `mobile-lvn` or `landline-toll-free`
 `VONAGE_NUMBER_FEATURES` | The capabilities of the number: `SMS`, `VOICE` or `SMS,VOICE` for both

--- a/_documentation/en/numbers/code-snippets/update.md
+++ b/_documentation/en/numbers/code-snippets/update.md
@@ -13,15 +13,15 @@ Replace the following variables in the sample code with your own values:
 
 Name | Description
 --|--
-`VONAGE_API_KEY` | Your Vonage [API key](https://developer.nexmo.com/concepts/guides/authentication#api-key-and-secret)
-`VONAGE_API_SECRET` | Your Vonage [API secret](https://developer.nexmo.com/concepts/guides/authentication#api-key-and-secret)
+`VONAGE_API_KEY` | Your Vonage [API key](/concepts/guides/authentication#api-key-and-secret)
+`VONAGE_API_SECRET` | Your Vonage [API secret](/concepts/guides/authentication#api-key-and-secret)
 `COUNTRY_CODE` | The two digit country code for the number you want to update. For example: `GB` for the United Kingdom.
 `VONAGE_NUMBER` | The Vonage virtual number you want to update. Omit the leading zero but include the international dialing code. For example: `447700900000`.
-`SMS_CALLBACK_URL` | An URL-encoded URI to the webhook endpoint that handles inbound messages. Your webhook endpoint must be active before you make this request. Nexmo makes a GET request to the endpoint and checks that it returns a 200 OK response. Set this parameter's value to an empty string to remove the webhook.
+`SMS_CALLBACK_URL` | An URL-encoded URI to the webhook endpoint that handles inbound messages. Your webhook endpoint must be active before you make this request. Vonage makes a GET request to the endpoint and checks that it returns a 200 OK response. Set this parameter's value to an empty string to remove the webhook.
 `VONAGE_APPLICATION_ID` | The ID of the application that handles inbound traffic to this number.
 `VOICE_CALLBACK_TYPE` | The Voice API webhook type: `sip`, `tel` or `app`
 `VOICE_CALLBACK_VALUE` | A SIP URI, telephone number or Application ID, depending on `VOICE_CALLBACK_TYPE`
-`VOICE_STATUS_URL` | A webhook URL for Nexmo to post Voice API status updates to
+`VOICE_STATUS_URL` | A webhook URL for Vonage to POST Voice API status updates to
 
 ```code_snippets
 source: '_examples/numbers/update'

--- a/_documentation/en/verify/code-snippets/check-verify-request.md
+++ b/_documentation/en/verify/code-snippets/check-verify-request.md
@@ -13,8 +13,8 @@ Replace the following variables in the sample code with your own values:
 
 Name | Description
 --|--
-`VONAGE_API_KEY` | Your Vonage [API key](https://developer.nexmo.com/concepts/guides/authentication#api-key-and-secret)
-`VONAGE_API_SECRET` | Your Vonage [API secret](https://developer.nexmo.com/concepts/guides/authentication#api-key-and-secret)
+`VONAGE_API_KEY` | Your Vonage [API key](/concepts/guides/authentication#api-key-and-secret)
+`VONAGE_API_SECRET` | Your Vonage [API secret](/concepts/guides/authentication#api-key-and-secret)
 `REQUEST_ID` | The ID of the Verify request you wish to check (this is returned in the API response when you [send a verification code](/verify/code-snippets/send-verify-request))
 `CODE` | The code the user supplies as having been sent to them
 

--- a/_documentation/en/verify/code-snippets/search-verify-request.md
+++ b/_documentation/en/verify/code-snippets/search-verify-request.md
@@ -11,8 +11,8 @@ Replace the following variables in the sample code with your own values:
 
 Name | Description
 --|--
-`VONAGE_API_KEY` | Your Vonage [API key](https://developer.nexmo.com/concepts/guides/authentication#api-key-and-secret)
-`VONAGE_API_SECRET` | Your Vonage [API secret](https://developer.nexmo.com/concepts/guides/authentication#api-key-and-secret)
+`VONAGE_API_KEY` | Your Vonage [API key](/concepts/guides/authentication#api-key-and-secret)
+`VONAGE_API_SECRET` | Your Vonage [API secret](/concepts/guides/authentication#api-key-and-secret)
 `REQUEST_ID` | The ID of the Verify request you wish to cancel (this is returned in the API response when you [send a verification code](/verify/code-snippets/send-verify-request))
 
 

--- a/_documentation/en/verify/code-snippets/send-verify-psd2-request-with-workflow.md
+++ b/_documentation/en/verify/code-snippets/send-verify-psd2-request-with-workflow.md
@@ -13,8 +13,8 @@ Replace the following variables in the sample code with your own values:
 
 Name | Description
 --|--
-`VONAGE_API_KEY` | Your Vonage [API key](https://developer.nexmo.com/concepts/guides/authentication#api-key-and-secret)
-`VONAGE_API_SECRET` | Your Vonage [API secret](https://developer.nexmo.com/concepts/guides/authentication#api-key-and-secret)
+`VONAGE_API_KEY` | Your Vonage [API key](/concepts/guides/authentication#api-key-and-secret)
+`VONAGE_API_SECRET` | Your Vonage [API secret](/concepts/guides/authentication#api-key-and-secret)
 `RECIPIENT_NUMBER` | The phone number to verify
 `PAYEE` | Included in the message to describe the payment recipient
 `AMOUNT` | How much the payment is for (always in Euro)

--- a/_documentation/en/verify/code-snippets/send-verify-psd2-request.md
+++ b/_documentation/en/verify/code-snippets/send-verify-psd2-request.md
@@ -13,8 +13,8 @@ Replace the following variables in the sample code with your own values:
 
 Name | Description
 --|--
-`VONAGE_API_KEY` | Your Vonage [API key](https://developer.nexmo.com/concepts/guides/authentication#api-key-and-secret)
-`VONAGE_API_SECRET` | Your Vonage [API secret](https://developer.nexmo.com/concepts/guides/authentication#api-key-and-secret)
+`VONAGE_API_KEY` | Your Vonage [API key](/concepts/guides/authentication#api-key-and-secret)
+`VONAGE_API_SECRET` | Your Vonage [API secret](/concepts/guides/authentication#api-key-and-secret)
 `RECIPIENT_NUMBER` | The phone number to verify
 `PAYEE` | Included in the message to describe the payment recipient
 `AMOUNT` | How much the payment is for (always in Euro)

--- a/_documentation/en/verify/code-snippets/send-verify-request-with-workflow.md
+++ b/_documentation/en/verify/code-snippets/send-verify-request-with-workflow.md
@@ -13,8 +13,8 @@ Replace the following variables in the sample code with your own values:
 
 Name | Description
 --|--
-`VONAGE_API_KEY` | Your Vonage [API key](https://developer.nexmo.com/concepts/guides/authentication#api-key-and-secret)
-`VONAGE_API_SECRET` | Your Vonage [API secret](https://developer.nexmo.com/concepts/guides/authentication#api-key-and-secret)
+`VONAGE_API_KEY` | Your Vonage [API key](/concepts/guides/authentication#api-key-and-secret)
+`VONAGE_API_SECRET` | Your Vonage [API secret](/concepts/guides/authentication#api-key-and-secret)
 `RECIPIENT_NUMBER` | The phone number to verify
 `BRAND_NAME` | Included in the message to explain who is confirming the phone number
 `WORKFLOW_ID` | Choose a workflow (number between 1 and 7), these are defined in the [workflows guide](/verify/guides/workflows-and-events)

--- a/_documentation/en/verify/code-snippets/send-verify-request.md
+++ b/_documentation/en/verify/code-snippets/send-verify-request.md
@@ -13,8 +13,8 @@ Replace the following variables in the sample code with your own values:
 
 Name | Description
 --|--
-`VONAGE_API_KEY` | Your Vonage [API key](https://developer.nexmo.com/concepts/guides/authentication#api-key-and-secret)
-`VONAGE_API_SECRET` | Your Vonage [API secret](https://developer.nexmo.com/concepts/guides/authentication#api-key-and-secret)
+`VONAGE_API_KEY` | Your Vonage [API key](/concepts/guides/authentication#api-key-and-secret)
+`VONAGE_API_SECRET` | Your Vonage [API secret](/concepts/guides/authentication#api-key-and-secret)
 `RECIPIENT_NUMBER` | The phone number to verify
 `BRAND_NAME` | Included in the message to explain who is confirming the phone number
 

--- a/_documentation/en/verify/code-snippets/trigger-next-verification-process.md
+++ b/_documentation/en/verify/code-snippets/trigger-next-verification-process.md
@@ -13,8 +13,8 @@ Replace the following variables in the sample code with your own values:
 
 Name | Description
 --|--
-`VONAGE_API_KEY` | Your Vonage [API key](https://developer.nexmo.com/concepts/guides/authentication#api-key-and-secret)
-`VONAGE_API_SECRET` | Your Vonage [API secret](https://developer.nexmo.com/concepts/guides/authentication#api-key-and-secret)
+`VONAGE_API_KEY` | Your Vonage [API key](/concepts/guides/authentication#api-key-and-secret)
+`VONAGE_API_SECRET` | Your Vonage [API secret](/concepts/guides/authentication#api-key-and-secret)
 `REQUEST_ID` | The ID of the Verify request you wish to cancel (this is returned in the API response when you [send a verification code](/verify/code-snippets/send-verify-request))
 
 ```code_snippets


### PR DESCRIPTION
## Description

Many of the descriptions around the code snippets still refer to Nexmo. Changed to Vonage.


