### PR TITLE
Remove Adam Culp

### DIFF
--- a/config/team.yml
+++ b/config/team.yml
@@ -1,7 +1,4 @@
 current:
-  - name: 'Adam Culp'
-    email: 'adam.culp@vonage.com'
-    twitter: 'adamculp'
   - name: 'Kelly Andrews'
     email: 'kelly.andrews@vonage.com'
     twitter: 'kellyjandrews'


### PR DESCRIPTION
## Description

Adam Culp has left Vonage - remove him from the team page
