### PR TITLE
devx-4905

### DIFF
--- a/_documentation/en/application/overview.md
+++ b/_documentation/en/application/overview.md
@@ -126,13 +126,13 @@ When creating or updating an application these can be set directly, or updated a
 
 If these values are not specified when creating or updating the application, then default values are applied. The default values for these timeouts depend on the webhook concerned, as shown in the following table:
 
-Webhook | `connection_timeout` | `socket_timeout`
+Webhook | Default `connection_timeout` | Default `socket_timeout`
 ----|----|----
 `answer` | 1000 | 5000
 `event` | 1000 | 10000
 `fallback` | 1000 | 5000
 
-> *NOTE:* Timeouts are specified in milliseconds.
+> **NOTE:** Timeouts are specified in milliseconds.
 
 There is further explanation of webhook timeouts in the [webhook documentation](/concepts/guides/webhooks#webhook-timeouts).
 

--- a/_documentation/en/application/overview.md
+++ b/_documentation/en/application/overview.md
@@ -85,6 +85,36 @@ Capability | Webhook | API | Example | Description
 `rtc` | `event_url` | [Client SDK](/client-sdk/overview), [Conversation](/conversation/overview) | https://example.com/webhooks/rtcevent | Vonage will send RTC events to this URL.
 `vbc` | None | [Voice endpoint](/voice/voice-api/ncco-reference#connect) | None | Not used
 
+## Webhook timeouts
+
+For the `voice` capability only, you can set timeouts on webhooks. There are two timeouts that can be specified: `connection_timeout` and `socket_timeout`. For example:
+
+``` json
+  "capabilities": {
+    "voice": {
+      "webhooks": {
+        "answer_url": {
+          "address": "https://example.com/webhooks/answer",
+          "http_method": "POST",
+          "connection_timeout": 500,
+          "socket_timeout": 3000
+        },
+        "fallback_answer_url": {
+          "address": "https://fallback.example.com/webhooks/answer",
+          "http_method": "POST",
+          "connection_timeout": 500,
+          "socket_timeout": 3000
+        },
+        "event_url": {
+          "address": "https://example.com/webhooks/event",
+          "http_method": "POST",
+          "connection_timeout": 500,
+          "socket_timeout": 3000
+        }
+      }
+    }
+```
+
 ## Creating applications
 
 There are four main ways to create an application:

--- a/_documentation/en/application/overview.md
+++ b/_documentation/en/application/overview.md
@@ -91,8 +91,8 @@ For the `voice` capability only, you can set timeouts on webhooks. There are two
 
 Parameter | Description
 ----|----
-`connection_timeout` | If Vonage can't connect to the webhook URL, a timeout will occur and Vonage then stops trying to connect to the webhook endpoint.
-`socket_timeout` | If a response from the webhook URL can't be read, then a timeout will occur.
+`connection_timeout` | If Vonage can't connect to the webhook URL, a timeout will occur. Vonage then makes one additional attempt to connect to the webhook endpoint.
+`socket_timeout` | If a response from the webhook URL can't be read, then a timeout will occur. Vonage then makes one additional attempt to read the webhook endpoint.
 
 When creating or updating an application these can be set directly, or updated as required, for example:
 

--- a/_documentation/en/application/overview.md
+++ b/_documentation/en/application/overview.md
@@ -87,12 +87,12 @@ Capability | Webhook | API | Example | Description
 
 ## Webhook timeouts
 
-For the `voice` capability only, you can set timeouts on webhooks. There are two timeouts that can be specified: `connection_timeout` and `socket_timeout`. These are described in the following table:
+For the `voice` capability only, you can set timeouts on webhooks. There are two timeouts that can be specified: `connection_timeout` and `socket_timeout`. These parameters apply to the `answer`, `event`, and `fallback` webhooks, and are specified in milliseconds. The following table provides further information:
 
-Parameter | Description
-----|----
-`connection_timeout` | If Vonage can't connect to the webhook URL, a timeout will occur. Vonage then makes one additional attempt to connect to the webhook endpoint.
-`socket_timeout` | If a response from the webhook URL can't be read, then a timeout will occur. Vonage then makes one additional attempt to read the webhook endpoint.
+Parameter | Example | Description
+----|----|----
+`connection_timeout` | `1000` | If Vonage can't connect to the webhook URL for this specified amount of time, then Vonage makes one additional attempt to connect to the webhook endpoint. This is an integer value specified in millseconds.
+`socket_timeout` | `3000` | If a response from the webhook URL can't be read for this specified amount of time, then Vonage makes one additional attempt to read the webhook endpoint. This is an integer value specified in millseconds.
 
 When creating or updating an application these can be set directly, or updated as required, for example:
 
@@ -123,6 +123,16 @@ When creating or updating an application these can be set directly, or updated a
     }
 ...
 ```
+
+If these values are not specified when creating or updating the applicatiojn, then default values are applied. The default values for these timeouts depend on the webhook concerned, as shown in the following table:
+
+Webook | `connection_timeout` | `socket_timeout`
+----|----|----
+`answer` | 1000 | 5000
+`event` | 1000 | 10000
+`fallback` | 1000 | 5000
+
+> *NOTE:* Timeouts are specified in milliseconds.
 
 There is further explanation of webhook timeouts in the [webhook documentation](/concepts/guides/webhooks#webhook-timeouts).
 

--- a/_documentation/en/application/overview.md
+++ b/_documentation/en/application/overview.md
@@ -91,8 +91,8 @@ For the `voice` capability only, you can set timeouts on webhooks. There are two
 
 Parameter | Example | Description
 ----|----|----
-`connection_timeout` | `1000` | If Vonage can't connect to the webhook URL for this specified amount of time, then Vonage makes one additional attempt to connect to the webhook endpoint. This is an integer value specified in millseconds.
-`socket_timeout` | `3000` | If a response from the webhook URL can't be read for this specified amount of time, then Vonage makes one additional attempt to read the webhook endpoint. This is an integer value specified in millseconds.
+`connection_timeout` | `1000` | If Vonage can't connect to the webhook URL for this specified amount of time, then Vonage makes one additional attempt to connect to the webhook endpoint. This is an integer value specified in milliseconds.
+`socket_timeout` | `3000` | If a response from the webhook URL can't be read for this specified amount of time, then Vonage makes one additional attempt to read the webhook endpoint. This is an integer value specified in milliseconds.
 
 When creating or updating an application these can be set directly, or updated as required, for example:
 
@@ -124,9 +124,9 @@ When creating or updating an application these can be set directly, or updated a
 ...
 ```
 
-If these values are not specified when creating or updating the applicatiojn, then default values are applied. The default values for these timeouts depend on the webhook concerned, as shown in the following table:
+If these values are not specified when creating or updating the application, then default values are applied. The default values for these timeouts depend on the webhook concerned, as shown in the following table:
 
-Webook | `connection_timeout` | `socket_timeout`
+Webhook | `connection_timeout` | `socket_timeout`
 ----|----|----
 `answer` | 1000 | 5000
 `event` | 1000 | 10000

--- a/_documentation/en/application/overview.md
+++ b/_documentation/en/application/overview.md
@@ -87,9 +87,17 @@ Capability | Webhook | API | Example | Description
 
 ## Webhook timeouts
 
-For the `voice` capability only, you can set timeouts on webhooks. There are two timeouts that can be specified: `connection_timeout` and `socket_timeout`. For example:
+For the `voice` capability only, you can set timeouts on webhooks. There are two timeouts that can be specified: `connection_timeout` and `socket_timeout`. These are described in the following table:
+
+Parameter | Description
+----|----
+`connection_timeout` | If Vonage can't connect to the webhook URL, a timeout will occur and Vonage then stops trying to connect to the webhook endpoint.
+`socket_timeout` | If a response from the webhook URL can't be read, then a timeout will occur.
+
+When creating or updating an application these can be set directly, or updated as required, for example:
 
 ``` json
+...
   "capabilities": {
     "voice": {
       "webhooks": {
@@ -113,7 +121,10 @@ For the `voice` capability only, you can set timeouts on webhooks. There are two
         }
       }
     }
+...
 ```
+
+There is further explanation of webhook timeouts in the [webhook documentation](/concepts/guides/webhooks#webhook-timeouts).
 
 ## Creating applications
 


### PR DESCRIPTION
## Description

Adds some words on `connection_timeout` and `socket_timeout` for voice webhooks in the Application overview.

## Review

* [Timeouts](https://nexmo-developer-pr-3392.herokuapp.com/application/overview#webhook-timeouts)
