### PR TITLE
Add redirects for old client-sdk tutorials

### DIFF
--- a/config/redirects.yml
+++ b/config/redirects.yml
@@ -27,6 +27,8 @@
 "/client-sdk/in-app-voice/contact-center-overview": "/use-cases/contact-center-client-sdk"
 "/client-sdk/in-app-voice/getting-started/app-to-app-call": "/client-sdk/tutorials/app-to-app/introduction/"
 "/client-sdk/in-app-voice/getting-started/receive-phone-call": "/client-sdk/tutorials/phone-to-app/introduction"
+"/task/client-sdk/ip-messaging/authenticate-users": "/client-sdk/tutorials/in-app-messaging/client-sdk/in-app-messaging/authenticate-users"
+"/task/client-sdk/ios-in-app-messaging-chat/add-users-to-conversation": "/client-sdk/tutorials/in-app-messaging/client-sdk/in-app-messaging/add-users-to-conversation/"
 "/concepts": "/concepts/overview"
 "/concepts/guides/applications": "/application/overview"
 "/reports/api-reference": "/api/reports"


### PR DESCRIPTION
[DEVX-4912](https://nexmoinc.atlassian.net/browse/DEVX-4912)

The following are 404s and require redirects:

* /task/client-sdk/ip-messaging/authenticate-users
* /task/client-sdk/ios-in-app-messaging-chat/add-users-to-conversation

Redirected second link to a generic tutorial step, as this could be either Swift or Objective C (for iOS) - let the reader decide 😄 