### PR TITLE
Add Legs Path to ACL

### DIFF
--- a/_documentation/en/conversation/guides/jwt-acl.md
+++ b/_documentation/en/conversation/guides/jwt-acl.md
@@ -47,7 +47,8 @@ Once all the claims have been provided, the resulting claims should appear like 
       "/*/media/**": {},
       "/*/applications/**": {},
       "/*/push/**": {},
-      "/*/knocking/**": {}
+      "/*/knocking/**": {},
+      "/*/legs/**": {}
     }
   },
   "application_id": "aaaaaaaa-bbbb-cccc-dddd-0123456789ab"
@@ -102,7 +103,8 @@ const aclPaths = {
     "/*/media/**": {},
     "/*/applications/**": {},
     "/*/push/**": {},
-    "/*/knocking/**": {}
+    "/*/knocking/**": {},
+    "/*/legs/**": {}
   }
 }
 

--- a/_tutorials/en/client-sdk/generate-jwt.md
+++ b/_tutorials/en/client-sdk/generate-jwt.md
@@ -40,7 +40,8 @@ Alternatively, you can use our <a href="/jwt" target="_blank">online JWT generat
       "/*/media/**": {},
       "/*/applications/**": {},
       "/*/push/**": {},
-      "/*/knocking/**": {}
+      "/*/knocking/**": {},
+      "/*/legs/**": {}
   }
 }
 ```

--- a/_tutorials/en/client-sdk/generate-jwts.md
+++ b/_tutorials/en/client-sdk/generate-jwts.md
@@ -40,7 +40,8 @@ Alternatively, you can use our <a href="/jwt" target="_blank">online JWT generat
       "/*/media/**": {},
       "/*/applications/**": {},
       "/*/push/**": {},
-      "/*/knocking/**": {}
+      "/*/knocking/**": {},
+      "/*/legs/**": {}
   }
 }
 ```


### PR DESCRIPTION
## Description

New upcoming release of JS, Android and IoS sdks will have a new way to setup calls with prewarmed legs. To the client this will be transparent however there is a request now being sent to POST /legs endpoint. This has always been exposed but has not been in the documentation for acl paths so customers may need to add it.

https://nexmoinc.atlassian.net/browse/CSJ-1205

## Deploy Notes

This will need to be released before we can make the official release fo the prewarm leg changes in the sdks. 
