### PR TITLE
exclude client SDK docs from Smartling upload workflows

### DIFF
--- a/.github/workflows/smartling_uploader_180_days.yml
+++ b/.github/workflows/smartling_uploader_180_days.yml
@@ -67,7 +67,7 @@ jobs:
     - id: step1
       name: Check for File Changes
       run: |
-        arr=$(git log --since=180.days --name-only --oneline --diff-filter=AMR --pretty=format: master _documentation/en _tutorials/en _use_cases/en | uniq | awk 'NF')
+        arr=$(git log --since=180.days --name-only --oneline --diff-filter=AMR --pretty=format: master _documentation/en _tutorials/en _use_cases/en ":(exclude)*/client-sdk/*" | uniq | awk 'NF')
         echo ::set-output name=file_changes::"$(echo $(sed 's/\n/ /g' <<< $arr))"
       shell: bash
       env:

--- a/.github/workflows/smartling_uploader_5_days.yml
+++ b/.github/workflows/smartling_uploader_5_days.yml
@@ -67,7 +67,7 @@ jobs:
     - id: step1
       name: Check for File Changes
       run: |
-        arr=$(git log --since=5.days --name-only --oneline --diff-filter=AMR --pretty=format: master _documentation/en _tutorials/en _use_cases/en | uniq | awk 'NF')
+        arr=$(git log --since=5.days --name-only --oneline --diff-filter=AMR --pretty=format: master _documentation/en _tutorials/en _use_cases/en ":(exclude)*/client-sdk/*" | uniq | awk 'NF')
         echo ::set-output name=file_changes::"$(echo $(sed 's/\n/ /g' <<< $arr))"
       shell: bash
       env:


### PR DESCRIPTION
## Description

As the Client SDK docs are beta they are out of scope for auto-translation. This excludes them from the upload workflows.
