### PR TITLE
removed reference to old sample projects

### DIFF
--- a/_documentation/en/client-sdk/overview.md
+++ b/_documentation/en/client-sdk/overview.md
@@ -93,6 +93,5 @@ product: conversation
 
 * [Conversation API](/conversation/overview)
 * [Nexmo CLI](https://github.com/nexmo/nexmo-cli/tree/beta)
-* [Node.JS and Angular Demo](https://github.com/Nexmo/stitch-demo) with an [Android](https://github.com/Nexmo/stitch-demo-android) client demo
 * [Tutorials](/client-sdk/tutorials)
 * [Use Cases](/client-sdk/use-cases)


### PR DESCRIPTION
## Description

Removed references to old sample projects from the end of Client SDK Overview page (https://developer.nexmo.com/client-sdk/overview).

Page to review: https://nexmo-developer-pr-3485.herokuapp.com/client-sdk/overview


## Deploy Notes

no changes.
