### PR TITLE
Minor updates for the templates section of sandbox docs

### DIFF
--- a/_documentation/en/messages/concepts/messages-api-sandbox.md
+++ b/_documentation/en/messages/concepts/messages-api-sandbox.md
@@ -130,9 +130,11 @@ Once your number or recipient ID is approved, you will use a Messages API Sandbo
 
 At the moment the following WhatsApp templates can be used with the Messages API Sandbox:
 
-Namespace | Name | Template Structure |Languages
-----|----|----|----
-`9b6b4fcb_da19_4a26_8fe8_78074a91b584` | `verify` | Header: `none`<br>Body: `{{1}} code: {{2}}. Valid for {{3}} minutes.`<br>Footer: `none` |`en-US`, `en-GB`, `ko`, `ja`, `it`
-`9b6b4fcb_da19_4a26_8fe8_78074a91b584` | `sandbox_doctor_appointment` | Header: `APPOINTMENT CONFIRMATION`<br>Body: `Your appointment with Doctor {{1}} is now confirmed for the {{2}} at {{3}} and the {{4}}.`Footer: `none`|`en_US`, `en_GB`
-`9b6b4fcb_da19_4a26_8fe8_78074a91b584` | `sandbox_shipping_update` | Header: `Shipping Update`<br>Body:`Your parcel from {{1}} is due to arrive on {{2}} between {{3}} and {{4}}.`<br><br>`Not going to be in? You can either change the date of your delivery or instruct us to leave your parcel in your designated safe place.`<br>Footer:`none`|`en_US`, `en_GB`
-`9b6b4fcb_da19_4a26_8fe8_78074a91b584` | `sandbox_travel_boardingpass` | Header: `image`<br>Body: `Hello {{1}}, your boarding pass for {{2}} Flight {{3}} is now ready`<br>`Please arrive at the gate at least 40 minutes before the scheduled departure time of {{4}}.` | `en_US`, `en_GB`
+Namespace | Name | Languages | Template Structure
+----|----|----|----|----
+`9b6b4fcb_da19_4a26_8fe8_78074a91b584` | `verify` | `en-US`, `en-GB`, `ko`, `ja`, `it` | Header: `none`<br>Body: `{{1}} code: {{2}}. Valid for {{3}} minutes.`<br>Footer: `none` 
+`9b6b4fcb_da19_4a26_8fe8_78074a91b584` | `sandbox_doctors_appointment`|`en_US`, `en_GB` | Header: `APPOINTMENT CONFIRMATION`<br>Body: `Your appointment with Doctor {{1}} is now confirmed for the {{2}} at {{3}} and the {{4}}.`Footer: `none`
+`9b6b4fcb_da19_4a26_8fe8_78074a91b584` | `sandbox_shipping_update`|`en_US`, `en_GB` | Header: `Shipping Update`<br>Body:`Your parcel from {{1}} is due to arrive on {{2}} between {{3}} and {{4}}.`<br><br>`Not going to be in? You can either change the date of your delivery or instruct us to leave your parcel in your designated safe place.`<br>Footer:`none`
+`9b6b4fcb_da19_4a26_8fe8_78074a91b584` | `sandbox_travel_boardingpass` |`en_US`, `en_GB`| Header: `image`<br>Body: `Hello {{1}}, your boarding pass for {{2}} Flight {{3}} is now ready`<br>`Please arrive at the gate at least 40 minutes before the scheduled departure time of {{4}}.`
+
+The `sandbox_doctors_appointment` and `sandbox_shipping_update` templates utilize the [quick-reply button](https://developers.facebook.com/docs/whatsapp/api/messages/message-templates/interactive-message-templates/) feature. The `sandbox_travel_boardingpass` demonstrates the media template feature.


### PR DESCRIPTION
Couple of minor updates to the sandbox template docs

1. fixed a couple of names spelling
2. moved the `languages` column to the left so it wouldn't be cut off (the nature of the template structure makes it overrun to the right - seeing if we can fix it)
3. added a special note at the bottom to specifically call out the features that each template leverages.
