### PR TITLE
DEVX-4368: Add redirect.

### DIFF
--- a/config/redirects.yml
+++ b/config/redirects.yml
@@ -232,6 +232,7 @@
 "/tutorials/voice-call-websocket-node": "/use-cases/voice-call-websocket-node"
 "/tutorials/voice-call-websocket-python": "/use-cases/voice-call-websocket-python"
 "/tutorials/phone-number-validation": "/use-cases/validate-a-number"
+"/client-sdk/tutorials/objective-c": "/client-sdk/tutorials/objective_c"
 "/account/subaccounts/tutorials": "/use-cases/using-subaccounts"
 "/api/voice/ncco": "/voice/voice-api/ncco-reference"
 "/api/account/secret-management": "/api/account#secret-management"


### PR DESCRIPTION
## Description

Adds redirect from `https://developer.nexmo.com/client-sdk/tutorials/objective-c` to `https://developer.nexmo.com/client-sdk/tutorials/objective_c`
