### PR TITLE
Update Documentation on legs acl path

### DIFF
--- a/_documentation/en/conversation/guides/jwt-acl.md
+++ b/_documentation/en/conversation/guides/jwt-acl.md
@@ -71,6 +71,7 @@ In the previous section, you can see that the `acl` claim has `paths` object con
 | `/*/image/**`| Send and receive images.|
 | `/*/media/**`| Send and receive audio.|
 | `/*/knocking/**`| Start phone calls.|
+| `/*/legs/**`| Prewarm phone calls. |
 | `/*/push/**`| Receive push notifications|
 | `/*/devices/**`| Send push notifications.|
 | `/*/applications/**`| Upload push notification certificate.|
@@ -140,6 +141,7 @@ $claims = [
             '/*/applications/**' => (object) [],
             '/*/push/**' => (object) [],
             '/*/knocking/**' => (object) [],
+            '/*/legs/**' => (object) []
         ]
     ]
 ];


### PR DESCRIPTION
## Description

New upcoming release of JS, Android and IoS sdks will have a new way to setup calls with prewarmed legs. To the client this will be transparent however there is a request now being sent to POST /legs endpoint. This has always been exposed but has not been in the documentation for acl paths so customers may need to add it.

https://nexmoinc.atlassian.net/browse/CSJ-1205

## Deploy Notes

This will need to be released before we can make the official release fo the prewarm leg changes in the sdks. 
