### PR TITLE
Fixed ironic spelling mistake in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This repository is the content for <https://developer.nexmo.com>, which includes
 We write the docs in US English and enforce this at build time with a CI check. You can run the check locally using the following command:
 
 ```
-yarn spellchek
+yarn spellcheck
 ```
 
 Or if you're using Docker:


### PR DESCRIPTION
You say spellchek, I say spellcheck.

## Description

README file had an ironic spelling mistake.

