### PR TITLE
DEVX-3067 add decode incoming jwt snippets

### DIFF
--- a/_documentation/en/concepts/guides/webhooks.md
+++ b/_documentation/en/concepts/guides/webhooks.md
@@ -58,6 +58,16 @@ To interact with Vonage webhooks:
 
 Information about your request is then sent to your webhook endpoint.
 
+## Decoding signed webhooks
+
+Signed webhooks are a way to verify that the request is coming from Vonage and its payload has not been tampered with during transit. The [signed webhooks guide](/messages/concepts/signed-webhooks) has more details on its implementation and usage.
+
+The following code snippets show how to decode an incoming JWT signature in a variety of languages:
+
+```code_snippets
+source: '_examples/concepts/guides/decode-jwt/'
+```
+
 ## Testing webhooks locally
 
 In order to test the correct functioning of webhooks on your locally running application, you will need to create a secure tunnel between Vonage and your application. You can do this with a secure tunnel application such as [Ngrok](https://ngrok.com). See the [Testing with Ngrok](/tools/ngrok) topic for more information.

--- a/_examples/concepts/guides/decode-jwt/ruby.yml
+++ b/_examples/concepts/guides/decode-jwt/ruby.yml
@@ -1,0 +1,9 @@
+---
+title: Ruby
+language: ruby
+code:
+    source: .repos/vonage/vonage-ruby-code-snippets/jwt/decode-incoming-jwt.rb
+    from_line: 7
+    to_line: 8
+file_name: decode-incoming-jwt.rb
+run_command: 'ruby decode-incoming-jwt.rb'


### PR DESCRIPTION
## Description

DEVX-3067 Add Decode Incoming JWT snippets in Ruby

This adds the info to the location specified in the Jira ticket.

~~This ticket is blocked, and the CI build will fail, until this [PR](https://github.com/Vonage/vonage-ruby-code-snippets/pull/82) is merged in the Ruby code snippets.~~

## Deploy Notes

Notes regarding deployment the contained body of work. These should note any db migrations, etc.
