### PR TITLE
Lock ubuntu's version.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     services:
       db:
         env:


### PR DESCRIPTION
## Description

Ubuntu-latest was updated
https://github.com/actions/virtual-environments/issues/1816 and one of
our dependencies is incompatible with it. See https://github.com/ffi/ffi/issues/773
Locking its version until a fix is available.