### PR TITLE
Client SDK beta labelling changes - only in-app messaging is now beta

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,8 @@
 source 'https://rubygems.org'
 
-source "https://rubygems.pkg.github.com/nexmo" do
+# source "https://rubygems.pkg.github.com/nexmo" do
   gem "station", "0.0.115"
-end
+# end
 
 group :test do
   gem 'rspec'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,5 @@
 GEM
   remote: https://rubygems.org/
-  remote: https://rubygems.pkg.github.com/nexmo/
   specs:
     actioncable (6.1.3)
       actionpack (= 6.1.3)
@@ -219,7 +218,7 @@ GEM
     mime-types (3.3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2021.0225)
-    mimemagic (0.3.5)
+    mimemagic (0.3.6)
     mini_mime (1.0.2)
     mini_portile2 (2.5.0)
     minitest (5.14.4)
@@ -482,7 +481,7 @@ DEPENDENCIES
   factory_bot
   rack-test
   rspec
-  station (= 0.0.115)!
+  station (= 0.0.115)
 
 BUNDLED WITH
    2.2.3

--- a/_documentation/en/client-sdk/custom-events.md
+++ b/_documentation/en/client-sdk/custom-events.md
@@ -1,5 +1,7 @@
 ---
 title: Custom Events
+meta_title: Add custom metadata to conversations by recording data alongside your text or audio events
+description: This topic provides an overview of the custom events use via the Vonage Client SDK. 
 ---
 
 # Custom Events

--- a/config/navigation.yml
+++ b/config/navigation.yml
@@ -112,15 +112,19 @@ navigation_overrides:
   client-sdk:
     svg: 'queue'
     svgColor: 'teal'
-    label: 'Beta'
     overview:
       navigation_weight: 1
     setup:
       navigation_weight: 2
     configuration:
       navigation_weight: 3  
+    in-app-voice:
+      navigation_weight: 4 
+    in-app-messaging:
+      navigation_weight: 5
+      label: 'Beta'
     custom-events:
-      navigation_weight: 4
+      navigation_weight: 6
     sdk-documentation:
       link: false
       collapsible: false

--- a/custom/views/static/_products.html.erb
+++ b/custom/views/static/_products.html.erb
@@ -359,7 +359,7 @@
       <div class="Vlt-card Vlt-card--plain Vlt-bg-grey-lighter Vlt-article--reverse Vlt-card--image Nxd-card--products">
         <div class="Vlt-card__content">
           <svg class="Vlt-icon Vlt-icon--larger Vlt-purple-dark"><use xlink:href="/symbol/volta-icons.svg#Vlt-icon-microphone" /></svg>
-          <div class="Nxd-card--product__subtitle"><small>CLIENT SDK</small> <div class="Vlt-badge Vlt-badge--small Vlt-badge--green Vlt-badge--transparent">Beta</div></div>
+          <div class="Nxd-card--product__subtitle"><small>CLIENT SDK</small></div>
           <h2>
             <a href="/client-sdk/in-app-voice/overview">
               In-App Voice
@@ -408,11 +408,12 @@
       <div class="Vlt-card Vlt-card--plain Vlt-bg-grey-lighter Vlt-article--reverse Vlt-card--image Nxd-card--products">
         <div class="Vlt-card__content">
           <svg class="Vlt-icon Vlt-icon--larger Vlt-purple-dark"><use xlink:href="/symbol/volta-icons.svg#Vlt-icon-chat" /></svg>
-          <div class="Nxd-card--product__subtitle"><small>CLIENT SDK</small> <div class="Vlt-badge Vlt-badge--small Vlt-badge--green Vlt-badge--transparent">Beta</div></div>
+          <div class="Nxd-card--product__subtitle"><small>CLIENT SDK</small></div>
           <h2>
             <a href="/client-sdk/in-app-messaging/overview">
               In-App Messaging
             </a>
+            <div class="Vlt-badge Vlt-badge--small Vlt-badge--green Vlt-badge--transparent">Beta</div>
           </h2>
           <nav>
             <a href="/client-sdk/in-app-messaging/overview"><svg


### PR DESCRIPTION
## Description

Beta label removed from the Client SDK and moved to in-app messaging only.
Also included, extra metadata for the custom events page.

## Deploy Notes

no changes
