### PR TITLE
move and rename vapi tutorials

### DIFF
--- a/config/tutorials/en/connect-to-a-websocket.yml
+++ b/config/tutorials/en/connect-to-a-websocket.yml
@@ -1,5 +1,5 @@
 
-title: Call a WebSocket
+title: Connect to a WebSocket
 description: Learn how to connect an inbound Voice API call to a WebSocket
 products:
   - voice/voice-api

--- a/config/tutorials/en/connect-to-a-websocket/node.yml
+++ b/config/tutorials/en/connect-to-a-websocket/node.yml
@@ -1,5 +1,5 @@
 ---
-title: Call a WebSocket
+title: Connect to a WebSocket
 description: Connect an inbound call to a WebSocket with the Voice API
 products:
   - voice/voice-api

--- a/config/tutorials/en/connect-to-a-websocket/python.yml
+++ b/config/tutorials/en/connect-to-a-websocket/python.yml
@@ -1,5 +1,5 @@
 ---
-title: Call a WebSocket
+title: Connect to a WebSocket
 description: Connect an inbound call to a WebSocket with the Voice API
 products:
   - voice/voice-api

--- a/config/tutorials/en/ivr.yml
+++ b/config/tutorials/en/ivr.yml
@@ -1,4 +1,4 @@
-title: Build a call menu
+title: Build a Call Menu
 description: Create an interactive voice response (IVR) menu to handle customer calls
 products:
   - voice/voice-api

--- a/config/tutorials/en/ivr/node.yml
+++ b/config/tutorials/en/ivr/node.yml
@@ -1,5 +1,5 @@
 ---
-title: Build a call menu
+title: Build a Call Menu
 description: Create an interactive voice response (IVR) menu to handle customer calls
 products:
   - voice/voice-api

--- a/config/tutorials/en/play-audio.yml
+++ b/config/tutorials/en/play-audio.yml
@@ -1,0 +1,4 @@
+title: Play Audio into a Call
+description: A tutorial showing you how to build an app that will play audio into a PSTN call
+products:
+  - voice/voice-api

--- a/config/tutorials/en/play-audio/dotnet.yml
+++ b/config/tutorials/en/play-audio/dotnet.yml
@@ -1,4 +1,5 @@
-title: How to Play Audio into a Call with .NET
+---
+title: Play Audio into a Call with .NET
 products:
  - voice/voice-api
 description: A tutorial showing you how to build an app that will play audio into a PSTN call

--- a/config/tutorials/en/play-audio/ruby.yml
+++ b/config/tutorials/en/play-audio/ruby.yml
@@ -1,4 +1,5 @@
-title: How to Play Audio into a Call with Ruby
+---
+title: Play Audio into a Call with Ruby
 products:
  - voice/voice-api
 description: A tutorial showing you how to build an app that will play audio into a PSTN call

--- a/config/tutorials/en/voicemail-dotnet.yml
+++ b/config/tutorials/en/voicemail-dotnet.yml
@@ -1,4 +1,4 @@
-title: How to Build a Voicemail with .NET
+title: Build a Voicemail
 products:
  - voice/voice-api
 description: A tutorial showing you how to build an app that records incoming phone calls with .NET


### PR DESCRIPTION
## Description

I renamed the tutorials to be consistent and moved the how to play audio into a multi-language tutorial

![image](https://user-images.githubusercontent.com/15106299/114171039-a53fd700-992b-11eb-87c4-573e16f74c43.png)
![image](https://user-images.githubusercontent.com/15106299/114171063-aec93f00-992b-11eb-9c62-3f40332eb5b2.png)


