### PR TITLE
Update concatenation-and-encoding.md

### DIFF
--- a/_documentation/en/messaging/sms/guides/concatenation-and-encoding.md
+++ b/_documentation/en/messaging/sms/guides/concatenation-and-encoding.md
@@ -78,9 +78,9 @@ If you are sending a message with a `type` value of `text` then the following ch
 | Parts | Maximum Characters | Calculation |
 | -- | -- | -- |
 | 1 | 160 | Without UDH 160 characters are available |
-| 2 | 304 | `(160 - 7) * 2 = 306` |
-| 3 | 456 | `(160 - 7) * 3 = 459` |
-| 4 | 608 | `(160 - 7) * 4 = 612` |
+| 2 | 306 | `(160 - 7) * 2 = 306` |
+| 3 | 459 | `(160 - 7) * 3 = 459` |
+| 4 | 612 | `(160 - 7) * 4 = 612` |
 
 If you are sending a message with a `type` of `unicode` then each character in the message requires two bytes.
 


### PR DESCRIPTION
Correction to maximum number of characters used for 2, 3 and 4 messages to match the adjacent calculation column.

## Description

A small text change as the numbers entered into the "maximum characters" columns didn't match the adjacent calculation column. Based on other similar information elsewhere the calculation column is correct so have simply copied the values already presented.

## Deploy Notes

Simple text change
