### PR TITLE
Remove banner announcing Community Hub

### DIFF
--- a/custom/views/layouts/partials/_notices.html.erb
+++ b/custom/views/layouts/partials/_notices.html.erb
@@ -76,23 +76,10 @@
   visibility: hidden;
 }
 
+.display-none{
+  display: none;
+}
+
 </style>
 
-<div class="banner">
-  <div class="Nxd-logo">
-    <%= image_tag '/images/Vonage_MovingPerson.svg', alt:'Nexmo Developer Logo' %>
 
-    <hr class="Nxd-product__separator">
-    <div class="Vlt-white">
-      <span class="event-name">We're launching a</br> new community</span>
-      <small>May 2021</small>
-    </div>
-  </div>
-  <div class="banner-content">
-    <b>Want to meet other developers using Vonage APIs?</b><br/>
-    Connect with our team, see what others are building, find developer events, learn about contests, and more on our new developer community hub!
-  </div>
-  <div class="banner-cta">
-
-  </div>
-</div>


### PR DESCRIPTION
## Description

Thought this banner was already removed a while back, announcing the new Community Hub, seems it's still here :grimacing:

Removing for now and will be replaced at the appropriate time. 
