### PR TITLE
Adds code snippet and description to set a text status to seen.

### DIFF
--- a/_documentation/en/client-sdk/in-app-messaging/guides/seen-receipt.md
+++ b/_documentation/en/client-sdk/in-app-messaging/guides/seen-receipt.md
@@ -19,6 +19,13 @@ This guide will make use of the following concepts:
 
 - **Conversation Events** - `text:seen` events that fire on a Conversation, after you are a Member
 
+## Set TextEvent to seen
+
+There is the `seen()` method on a TextEvent that will set its status to seen. The following code snippet will set a text's status to seen once a text event happens in the conversation.
+
+```tabbed_content
+source: _tutorials_tabbed_content/client-sdk/guides/messaging/seen-set-status
+```
 
 ## Text Seen Receipt
 

--- a/_documentation/en/client-sdk/in-app-messaging/guides/seen-receipt.md
+++ b/_documentation/en/client-sdk/in-app-messaging/guides/seen-receipt.md
@@ -21,7 +21,7 @@ This guide will make use of the following concepts:
 
 ## Set Text status to seen
 
-There is the `seen()` method on a TextEvent that will set its status to seen. The following code snippet will set a text's status to seen once a text event happens in the conversation.
+There is the `seen()` method on a `TextEvent` that will set its status to seen. The following code snippet will set a text's status to seen once a text event happens in the conversation.
 
 ```tabbed_content
 source: _tutorials_tabbed_content/client-sdk/guides/messaging/seen-set-status

--- a/_documentation/en/client-sdk/in-app-messaging/guides/seen-receipt.md
+++ b/_documentation/en/client-sdk/in-app-messaging/guides/seen-receipt.md
@@ -19,7 +19,7 @@ This guide will make use of the following concepts:
 
 - **Conversation Events** - `text:seen` events that fire on a Conversation, after you are a Member
 
-## Set TextEvent to seen
+## Set Text status to seen
 
 There is the `seen()` method on a TextEvent that will set its status to seen. The following code snippet will set a text's status to seen once a text event happens in the conversation.
 

--- a/_tutorials_tabbed_content/client-sdk/guides/messaging/seen-receipt/javascript.md
+++ b/_tutorials_tabbed_content/client-sdk/guides/messaging/seen-receipt/javascript.md
@@ -6,6 +6,6 @@ menu_weight: 1
 
 ```javascript
 conversation.on('text:seen', (data, event) => {
-  console.log(event);
+    console.log(event);
 });
 ```

--- a/_tutorials_tabbed_content/client-sdk/guides/messaging/seen-set-status/javascript.md
+++ b/_tutorials_tabbed_content/client-sdk/guides/messaging/seen-set-status/javascript.md
@@ -1,0 +1,18 @@
+---
+title: Javascript
+language: javascript
+menu_weight: 1
+---
+
+```javascript
+conversation.on('text', (sender, event) => {
+    // Can't set your own text status to seen
+    if (conversation.me.id !== event.from) {
+        event.seen().then(() => {
+            console.log("text event status set to seen");
+        }).catch((error)=>{
+            console.error("error setting text event status to seen ", error);
+        });
+    };
+});
+```


### PR DESCRIPTION
## Description

Had a question from a customer about the `text:seen` event not firing. Found a method on the TextEvent that will do that so I added a code example and some details.

Thing is that it's in a tabbed element so I guess the other platforms will need to be added at some point.

Thanks.

