### PR TITLE
Adds Guide for new methods in JS Client SDK 8.0

### DIFF
--- a/_documentation/en/client-sdk/in-app-messaging/guides/get-member-s-information.md
+++ b/_documentation/en/client-sdk/in-app-messaging/guides/get-member-s-information.md
@@ -1,0 +1,45 @@
+---
+title: Get Member(s) Information
+navigation_weight: 9
+---
+
+# Get Member(s) Information
+
+## Overview
+
+
+This guide covers getting the Members of a Conversation, your Member information and another Member's Information.
+
+Before you begin, make sure you [added the SDK to your app](/client-sdk/setup/add-sdk-to-your-app) and you are able to [create a conversation](/client-sdk/in-app-messaging/guides/simple-conversation).
+
+```partial
+source: _partials/client-sdk/messaging/chat-app-tutorial-note.md
+```
+
+## Get the Members
+
+To get a list of Members of a Conversation that you are also currently a Member:
+
+```tabbed_content
+source: _tutorials_tabbed_content/client-sdk/guides/messaging/get-member-s-information/get-members
+```
+
+## Get your Member
+
+To get your Member's information:
+
+```tabbed_content
+source: _tutorials_tabbed_content/client-sdk/guides/messaging/get-member-s-information/get-my-member
+```
+
+## Get another Member
+
+To get another Member's information (Note: You will need their Member ID):
+
+```tabbed_content
+source: _tutorials_tabbed_content/client-sdk/guides/messaging/get-member-s-information/get-member
+```
+
+## Reference
+
+* [Client SDK Reference - Web](/sdk/client-sdk/javascript)

--- a/_tutorials_tabbed_content/client-sdk/guides/messaging/get-member-s-information/get-member/javascript.md
+++ b/_tutorials_tabbed_content/client-sdk/guides/messaging/get-member-s-information/get-member/javascript.md
@@ -1,0 +1,12 @@
+---
+title: JavaScript
+language: javascript
+---
+
+```javascript
+conversation.getMember("MEM-id").then((member) => {
+    console.log("Member: ", member);
+}).catch((error) => {
+    console.error("error getting member", error);
+});
+```

--- a/_tutorials_tabbed_content/client-sdk/guides/messaging/get-member-s-information/get-members/javascript.md
+++ b/_tutorials_tabbed_content/client-sdk/guides/messaging/get-member-s-information/get-members/javascript.md
@@ -4,7 +4,11 @@ language: javascript
 ---
 
 ```javascript
-conversation.getMembers().then((members_page) => {
+const params = {
+    order: "desc", // default "asc"
+    page_size: 100 // default 10
+}
+conversation.getMembers(params).then((members_page) => {
     members_page.items.forEach(member => {
         console.log("Member: ", member);
     })

--- a/_tutorials_tabbed_content/client-sdk/guides/messaging/get-member-s-information/get-members/javascript.md
+++ b/_tutorials_tabbed_content/client-sdk/guides/messaging/get-member-s-information/get-members/javascript.md
@@ -1,0 +1,14 @@
+---
+title: JavaScript
+language: javascript
+---
+
+```javascript
+conversation.getMembers().then((members_page) => {
+    members_page.items.forEach(member => {
+        console.log("Member: ", member);
+    })
+}).catch((error) => {
+    console.error("error getting the members ", error);
+});
+```

--- a/_tutorials_tabbed_content/client-sdk/guides/messaging/get-member-s-information/get-my-member/javascript.md
+++ b/_tutorials_tabbed_content/client-sdk/guides/messaging/get-member-s-information/get-my-member/javascript.md
@@ -1,0 +1,12 @@
+---
+title: JavaScript
+language: javascript
+---
+
+```javascript
+conversation.getMyMember().then((member) => {
+    console.log("Member: ", member);
+}).catch((error) => {
+    console.error("error getting my member", error);
+});
+```


### PR DESCRIPTION
## Description
There are some new methods in JS Client SDK 8.0 so I added them to the Guides section of the docs. For some reason, it's not being listed in the side navigation. Spoke with Fabian about it.

Not sure if iOS and Android have similar methods. If so, maybe we can add them to the tabbed code snippets?
