### PR TITLE
Removed USSC deprecation notice on pages that aren't relevant to the pages

### DIFF
--- a/_documentation/en/dispatch/code-snippets/send-an-mms-with-failover.md
+++ b/_documentation/en/dispatch/code-snippets/send-an-mms-with-failover.md
@@ -4,10 +4,6 @@ title: Send an MMS with failover
 
 # Send an MMS with failover
 
-> **Action Needed For Vonage Customers Using US Shared Short Codes**
->
-> **Effective immediately, Vonage will no longer accept new programs for Shared Short Codes for A2P messaging.** T-Mobile and AT&T's new code of conduct prohibits the use of shared originators for A2P (application to person) traffic. Please migrate any existing Shared Short Code traffic to one of our alternative solutions. To help you with this transition, please use the Vonage [guide to alternatives](https://help.nexmo.com/hc/en-us/articles/360050905592).  Please [contact us](mailto:support@nexmo.com) to migrate to a new solution.
-
 In this example you will send an MMS that can fail over to sending an SMS.
 
 In the Workflow object, message objects can be placed in any order to suit your use case. Each message object must contain a failover object, except for the last message, as there are no more message objects to failover to.

--- a/_documentation/en/messages/code-snippets/mms/send-mms.md
+++ b/_documentation/en/messages/code-snippets/mms/send-mms.md
@@ -5,10 +5,6 @@ meta_title: Send an MMS using the Messages API
 
 # Send an MMS
 
-> **Action Needed For Vonage Customers Using US Shared Short Codes**
->
-> **Effective immediately, Vonage will no longer accept new programs for Shared Short Codes for A2P messaging.** T-Mobile and AT&T's new code of conduct prohibits the use of shared originators for A2P (application to person) traffic. Please migrate any existing Shared Short Code traffic to one of our alternative solutions. To help you with this transition, please use the Vonage [guide to alternatives](https://help.nexmo.com/hc/en-us/articles/360050905592).  Please [contact us](mailto:support@nexmo.com) to migrate to a new solution.
-
 In this code snippet you will see how to send an MMS using the Messages API.
 
 > **IMPORTANT:** Only US Short codes are currently supported for sending MMS.


### PR DESCRIPTION
## Description

During the discussion of the removal of US Shared Short Codes, two pages came to light that didn't require the notice of the deprecation of this feature as they use US Short Codes so can continue after the removal. 

There are no specific deployment requirements with this Pull Request.
