### PR TITLE
Correct 'See More Videos' destination in landing page

### DIFF
--- a/custom/views/static/landing.html.erb
+++ b/custom/views/static/landing.html.erb
@@ -640,7 +640,7 @@
       </div>
 
       <div class="Vlt-col Vlt-col--3of3">
-        <a href="https://www.youtube.com/user/vonage" class="Vlt-btn Vlt-btn--primary Vlt-btn--app Vlt-margin--A-top3" target="_blank" rel="noopener noreferrer">See more videos</a>
+        <a href="https://www.youtube.com/vonagedev" class="Vlt-btn Vlt-btn--primary Vlt-btn--app Vlt-margin--A-top3" target="_blank" rel="noopener noreferrer">See more videos</a>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Description

Changed "**See More Videos**" link at the bottom of https://developer.vonage.com/
<img width="174" alt="image" src="https://user-images.githubusercontent.com/34283479/135477622-1c3ee2e0-7a9b-485f-97b4-42da5e9c2976.png">

**from:** https://www.youtube.com/user/vonage
**to:** https://www.youtube.com/vonagedev
