### PR TITLE
VAPI region URL

### DIFF
--- a/_documentation/en/voice/voice-api/guides/troubleshooting.md
+++ b/_documentation/en/voice/voice-api/guides/troubleshooting.md
@@ -31,6 +31,8 @@ You can work around this issue by sending your API request to the correct region
 * https://api-eu-2.nexmo.com (Amsterdam)
 * https://api-sg-1.nexmo.com (Singapore)
 
+API endpoint corresponding to particular call is returned as `region_url` parameter in [Answer webhook](/voice/voice-api/webhook-reference#answer-webhook).
+
 The following are examples of how to override the default hosts using the [Vonage Server SDKs](/tools):
 
 ```tabbed_content

--- a/_documentation/en/voice/voice-api/webhook-reference.md
+++ b/_documentation/en/voice/voice-api/webhook-reference.md
@@ -29,6 +29,7 @@ Field | Example | Description
 `from` | `447700900000` | The number that called `to`. (This could be a landline or mobile number, or another virtual number if the call was made programmatically.)
 `uuid` | `aaaaaaaa-bbbb-cccc-dddd-0123456789ab` | A unique identifier for this call
 `conversation_uuid` | `CON-aaaaaaaa-bbbb-cccc-dddd-0123456789ab` | A unique identifier for this conversation
+`region_url` | `https://api-sg-1.nexmo.com` | Regional API endpoint which should be used to control the call with [REST API](/api/voice#updateCall); see the full list of regions [here](/voice/voice-api/guides/troubleshooting/node#regions)
 `custom_data` | `{ "key": "value" }` | A custom data object, optionally passed as parameter on the `callServer` method when a call is initiated from an application using the [Client SDK](/client-sdk/in-app-voice/guides/make-call/javascript#start-a-server-managed-call)
 
 #### Transmitting additional data with SIP headers


### PR DESCRIPTION
## Description

`region_url` description added to Webhook reference and Troubleshooting guide.