### PR TITLE
Update iOS SDK v3.2.1 release notes

### DIFF
--- a/_documentation/en/client-sdk/sdk-documentation/ios/release-notes.md
+++ b/_documentation/en/client-sdk/sdk-documentation/ios/release-notes.md
@@ -6,6 +6,12 @@ navigation_weight: 0
 
 # Release Notes
 
+## 3.2.1 - 2021-11-08
+
+### Fixed
+
+- Stash events while conversation is downloading to avoid missed events
+
 ## 3.2.0 - 2021-10-19
 
 ### Added


### PR DESCRIPTION
iOS SDK v3.2.1 notes added to `release-notes.md`.