### PR TITLE
updated tutorials for Messages API v1

### DIFF
--- a/_tutorials/en/messages-dispatch/receive-facebook-message.md
+++ b/_tutorials/en/messages-dispatch/receive-facebook-message.md
@@ -11,23 +11,14 @@ When a Facebook message is sent by a Facebook User to your Facebook Page a callb
 
 ```json
 {
-  "message_uuid":"aaaaaaaa-bbbb-cccc-dddd-0123456789ab",
-  "to":{
-    "type":"messenger",
-    "id":"0000000000000000"
-  },
-  "from":{
-    "type":"messenger",
-    "id":"1111111111111111"
-  },
-  "timestamp":"2020-01-01T14:00:00.000Z",
-  "message":{
-    "content":{
-      "type":"text",
-      "text":"Hello from Facebook Messenger!"
-    }
-  }
+  "channel": "messenger",
+  "message_uuid": "aaaaaaaa-bbbb-cccc-dddd-0123456789ab",
+  "to": "'$FB_RECIPIENT_ID'",
+  "from": "'$FB_SENDER_ID'",
+  "timestamp": "2020-01-01 14:00:00 UTC",
+  "message_type": "text",
+  "text": "Nexmo Verification code: 12345. Valid for 10 minutes."
 }
 ```
 
-You need to extract the `from.id` value here as this is the ID that you need to send a reply.
+You need to extract the `from` value here as this is the ID that you need to send a reply.

--- a/config/code_snippet_variables.yml
+++ b/config/code_snippet_variables.yml
@@ -75,7 +75,7 @@ WHATSAPP_NUMBER: The WhatsApp number that has been allocated to you by Vonage. F
 FROM_NUMBER.MESSAGES: Replace with number you are sending from. E.g. `447700900002`
 TO_NUMBER.MESSAGES: Replace with the number you are sending to. E.g. `447700900001`
 BASE_URL.MESSAGES: For production use the base URL is `https://api.nexmo.com/`. For sandbox testing the base URL is `https://messages-sandbox.nexmo.com/`.
-MESSAGES_API_URL: For production use the Messages API endpoint is `https://api.nexmo.com/v0.1/messages`. For sandbox testing the Messages API endpoint is `https://messages-sandbox.nexmo.com/v0.1/messages`.
+MESSAGES_API_URL: There are two versions of the API, each with their own endpoints. For production the previous Messages API endpoint was `https://api.nexmo.com/v0.1/messages`, the new one is `https://api.nexmo.com/v1/messages`. For sandbox testing the Messages API endpoint is `https://messages-sandbox.nexmo.com/v0.1/messages`.
 FB_SENDER_ID.MESSAGES: Your Page ID. The `FB_SENDER_ID` is the same as the `to.id` value you received in the inbound messenger event on your Inbound Message Webhook URL. For sandbox testing this is `107083064136738`.
 AUDIO_URL.MESSENGER.MESSAGES: The link to the audio file to send. Must be MP3 format for Messenger.
 FILE_URL.MESSENGER.MESSAGES: The link to the file to send. Can be ZIP, CSV, PDF or any other type supported by Messenger.


### PR DESCRIPTION
- Updated tutorial code snippets for `Receive Facebook Message`
- Updated text for `MESSAGES_API_URL` to reference the new endpoint
- Part of Messages API release for November 10, 2021
