### PR TITLE
Redact label in navigation yml changed to beta

### DIFF
--- a/config/navigation.yml
+++ b/config/navigation.yml
@@ -108,7 +108,7 @@ navigation_overrides:
     subaccounts:
       label: 'Beta'
   redact:
-    label: 'Dev Preview'
+    label: 'Beta'
     svg: 'lock'
     svgColor: 'red'
   client-sdk:


### PR DESCRIPTION
## Description

Amended redact badge in developer documentation left nav from Dev Preview to Beta, see screen shots.

## Deploy Notes

Amended navigation.yml redact entry to Beta as per [APIDOC-116](https://jira.vonage.com/browse/APIDOC-116).

<img width="283" alt="Screenshot 2021-12-06 at 10 37 31" src="https://user-images.githubusercontent.com/85564614/144831706-2f256e7d-88c9-40cf-aa24-7d1049963892.png">
<img width="283" alt="Screenshot 2021-12-06 at 10 37 15" src="https://user-images.githubusercontent.com/85564614/144831707-bde50745-f63d-4044-9fef-f2c3b5079cdd.png">
.
