### PR TITLE
Update iOS SDK v4.0.2 release notes

### DIFF
--- a/_documentation/en/client-sdk/sdk-documentation/ios/release-notes.md
+++ b/_documentation/en/client-sdk/sdk-documentation/ios/release-notes.md
@@ -6,6 +6,12 @@ navigation_weight: 0
 
 # Release Notes
 
+## 4.0.2  - 2021-12-07
+
+### Fixed
+
+- CocoaPods dependencies.
+
 ## 4.0.0  - 2021-12-06
 
 ### Added


### PR DESCRIPTION
iOS SDK v4.0.2 notes added to `release-notes.md`.