### PR TITLE
Update iOS SDK v4.0.3 release notes

### DIFF
--- a/_documentation/en/client-sdk/sdk-documentation/ios/release-notes.md
+++ b/_documentation/en/client-sdk/sdk-documentation/ios/release-notes.md
@@ -6,6 +6,12 @@ navigation_weight: 0
 
 # Release Notes
 
+## 4.0.3  - 2021-12-13
+
+### Fixed
+
+- Umbrella header.
+
 ## 4.0.2  - 2021-12-07
 
 ### Fixed


### PR DESCRIPTION
iOS SDK v4.0.3 notes added to `release-notes.md`.