### PR TITLE
Rollback Station version ~> v0.0.138

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem "station", "0.0.139"
+gem "station", "0.0.138"
 
 group :test do
   gem 'rspec'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -410,7 +410,7 @@ GEM
       actionpack (>= 5.2)
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
-    station (0.0.139)
+    station (0.0.138)
       activeadmin (~> 2.7)
       activesupport (~> 6.0)
       algoliasearch (= 1.27.5)
@@ -499,7 +499,7 @@ DEPENDENCIES
   factory_bot
   rack-test
   rspec
-  station (= 0.0.139)
+  station (= 0.0.138)
 
 BUNDLED WITH
    2.2.31

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       - POSTGRES_USER=nexmo_developer
       - POSTGRES_DB=nexmo_developer_production
   web:
-    image: nexmodev/station:v0.0.139
+    image: nexmodev/station:v0.0.138
     volumes:
       - .:/docs
     ports:


### PR DESCRIPTION
## Description

Rollback Station version from v0.0.139 to v0.0.138

<img width="805" alt="image" src="https://user-images.githubusercontent.com/34283479/150367271-f3ea995b-b79f-4a3d-8d24-d9cfd18b39f5.png">

https://vonage.slack.com/archives/C1R9066CC/p1642688834011200