### PR TITLE
Update iOS SDK v4.1.0 release notes

### DIFF
--- a/_documentation/en/client-sdk/sdk-documentation/ios/release-notes.md
+++ b/_documentation/en/client-sdk/sdk-documentation/ios/release-notes.md
@@ -6,6 +6,12 @@ navigation_weight: 0
 
 # Release Notes
 
+## 4.1.0  - 2022-02-25
+
+### Added
+
+- `[NXMClient getDeviceId]` to retrieve device identifier.
+
 ## 4.0.6  - 2022-02-15
 
 ### Fixed


### PR DESCRIPTION
iOS SDK v4.1.0 notes added to `release-notes.md`.