### PR TITLE
Updating code snippet variable values for Messages API sandbox data

### DIFF
--- a/config/code_snippet_variables.yml
+++ b/config/code_snippet_variables.yml
@@ -69,13 +69,13 @@ TO_NUMBER_1.DISPATCH: The phone number you are sending the SMS to.
 TO_NUMBER_2.DISPATCH: The phone number of the second phone. In this example, the workflow will failover to this number if the first message is not read in 60 seconds.
 FB_SENDER_ID: Your Page ID. The `FB_SENDER_ID` is the same as the `to.id` value you received in the inbound messenger event on your Inbound Message Webhook URL.
 VIBER_SERVICE_MESSAGE_ID: Your Viber Service Message ID. For sandbox testing this is 16273.
-WHATSAPP_NUMBER: The WhatsApp number that has been allocated to you by Vonage. For sandbox testing the number is 14157386170.
+WHATSAPP_NUMBER: The WhatsApp number that has been allocated to you by Vonage. For sandbox testing the number is 14157386102.
 
 # Messages API
 FROM_NUMBER.MESSAGES: Replace with number you are sending from. E.g. `447700900002`
 TO_NUMBER.MESSAGES: Replace with the number you are sending to. E.g. `447700900001`
 BASE_URL.MESSAGES: For production use the base URL is `https://api.nexmo.com/`. For sandbox testing the base URL is `https://messages-sandbox.nexmo.com/`.
-MESSAGES_API_URL: There are two versions of the API, each with their own endpoints. For production the previous Messages API endpoint was `https://api.nexmo.com/v0.1/messages`, the new one is `https://api.nexmo.com/v1/messages`. For sandbox testing the Messages API endpoint is `https://messages-sandbox.nexmo.com/v0.1/messages`.
+MESSAGES_API_URL: There are two versions of the API, each with their own endpoints. For production the previous Messages API endpoint was `https://api.nexmo.com/v0.1/messages`, the new one is `https://api.nexmo.com/v1/messages`. For sandbox testing the Messages API endpoint is `https://messages-sandbox.nexmo.com/v0.1/messages` or `https://messages-sandbox.nexmo.com/v1/messages`, depending on which version you have set in the [sandbox dashboard](https://dashboard.nexmo.com/messages/sandbox).
 FB_SENDER_ID.MESSAGES: Your Page ID. The `FB_SENDER_ID` is the same as the `to.id` value you received in the inbound messenger event on your Inbound Message Webhook URL. For sandbox testing this is `107083064136738`.
 AUDIO_URL.MESSENGER.MESSAGES: The link to the audio file to send. Must be MP3 format for Messenger.
 FILE_URL.MESSENGER.MESSAGES: The link to the file to send. Can be ZIP, CSV, PDF or any other type supported by Messenger.


### PR DESCRIPTION
## Description

Updating incorrect/ out-of-date info in the `code_snippet_variables.yml` file in relation to sandbox testing info that gets displayed on the [whatsapp/send-text page](http://localhost:3000/messages/code-snippets/whatsapp/send-text)

## Deploy Notes

Content changes only.
