### PR TITLE
add missing env variables

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,3 +16,5 @@ services:
       - db
     environment:
       - POSTGRES_HOST=db
+      - CHANGELOGS_PATH=/docs/_changelogs
+      - BLOG_PATH=/docs/_blog


### PR DESCRIPTION
## Description

When running the dockerized version of ADP the blog and changelog pages are not rendered because the paths are not set in the env section of the compose file. This PR is mean't to fix that.
