### PR TITLE
fix broken Redact links

### DIFF
--- a/_documentation/en/messaging/sms/message-privacy.md
+++ b/_documentation/en/messaging/sms/message-privacy.md
@@ -35,6 +35,6 @@ A key point of Vonage's immediate Advanced Auto-redact is that the message body 
 
 ## How to set up Auto-redact for your Vonage account
 
-If you wish to activate the Advanced Auto-redact service for your account, please complete the form on [this page](https://info.nexmo.com/RedactAPI.html).
+If you wish to activate the Advanced Auto-redact service for your account, please complete the form on [this page](https://api.support.vonage.com/hc/en-us).
 
 You can find pricing relevant to the Advanced Auto-redact service on the [Vonage pricing](https://www.vonage.com/communications-apis/pricing/) page.

--- a/_documentation/en/redact/overview.md
+++ b/_documentation/en/redact/overview.md
@@ -52,7 +52,7 @@ Vonage provides the Auto-redact service that automatically redacts PII from our 
 
 Please find a relevant pricing for the auto-redact service here: [Vonage Prices](https://www.vonage.com/communications-apis/pricing/).
 
-To request activation of the Auto-redact service for your account, please visit [this page](https://info.nexmo.com/RedactAPI.html).
+To request activation of the Auto-redact service for your account, please visit [this page](https://api.support.vonage.com/hc/en-us).
 
 ### Redact API
 
@@ -64,7 +64,7 @@ It is not possible to make the redaction API request immediately after receiving
 
 The scope of redaction of the Redact API depends on what Vonage communication APIs you were using. The detailed description is provided below.
 
-To request access to the Redact API, please visit [this page](https://info.nexmo.com/RedactAPI.html).
+To request access to the Redact API, please visit [this page](https://api.support.vonage.com/hc/en-us).
 
 To learn more about the Redact API please refer to the [Redact API Reference](/api/redact).
 


### PR DESCRIPTION
## Description
This PR replaces the old Nexmo account request link to the Vonage support page https://api.support.vonage.com/hc/en-us
