### PR TITLE
move in app voice on landing page

### DIFF
--- a/config/documentation_page/en/doc_landing.yml
+++ b/config/documentation_page/en/doc_landing.yml
@@ -35,6 +35,14 @@ top-section:
       tutorials_link: none
       icon: "Vlt-icon-call"
 
+    - product_name: "SIP"
+      product_name_link: "/voice/sip/overview"
+      product_description: "Connect voice calls to existing endpoints via the phone network an in-app voice."
+      getting_started_link: "/voice/sip/overview"
+      api_reference_link: "/api/psip"
+      tutorials_link: none
+      icon: "Vlt-icon-plug"
+  
     - product_name: "In-app voice"
       product_name_link: "/client-sdk/in-app-voice/overview"
       product_description: "Build live voice communications into your application"
@@ -42,14 +50,6 @@ top-section:
       api_reference_link: ""
       tutorials_link: none
       icon: "Vlt-icon-condition"
-
-    - product_name: "SIP"
-      product_name_link: "/voice/sip/overview"
-      product_description: "Connect voice calls to existing endpoints via the phone network an in-app voice."
-      getting_started_link: "/voice/sip/overview"
-      api_reference_link: ""
-      tutorials_link: none
-      icon: "Vlt-icon-plug"
 
   - Authentication & Identity:
     - product_name: "Verify API"


### PR DESCRIPTION
Moving the inapp voice card to be in line with the inapp messaging one. Also added link to PSIP API reference 

https://nexmo-developer-pr-4212.herokuapp.com/documentation