### PR TITLE
revert send-sms reference change

### DIFF
--- a/_examples/messages/sms/send-sms/node.yml
+++ b/_examples/messages/sms/send-sms/node.yml
@@ -4,4 +4,4 @@ dependencies:
 code:
     source: .repos/vonage/vonage-node-code-snippets/messages/send-sms.js
     from_line: 11
-    to_line: 30
+    to_line: 36


### PR DESCRIPTION
## Description
Reverted snippet line change due to deleted file [send-template.js](https://github.com/Vonage/vonage-node-code-snippets/commit/a1b781010a24f8e56b16466ddb9922f2ee8cba58#diff-6720360c89569c03dd61604afe17cf2f9d1894e9d8629f16bbf9806c279ec704) which is still in use
This causes our tests to fail and hence unable to update the .repo submodule meaning the updated reference is now pointing to the wrong line at the moment.