### PR TITLE
Removed [Beta] from Premium TTS references

### DIFF
--- a/_documentation/en/voice/voice-api/guides/text-to-speech.md
+++ b/_documentation/en/voice/voice-api/guides/text-to-speech.md
@@ -70,7 +70,7 @@ Some voice styles come with a premium alternative, which through the use of AI, 
 ]
 ```
 
-> Premium Voices are chargeable. See the [pricing page for more information](https://www.vonage.com/communications-apis/in-app-voice/pricing/).
+> Premium Voices are chargeable. See the [pricing page for more information](https://www.vonage.com/communications-apis/voice/pricing).
 
 
 ### Supported Languages

--- a/_documentation/en/voice/voice-api/guides/text-to-speech.md
+++ b/_documentation/en/voice/voice-api/guides/text-to-speech.md
@@ -54,7 +54,7 @@ NCCO example with specific voice language and style:
 ]
 ```
 
-### Premium Voices [Beta]
+### Premium Voices
 
 Some voice styles come with a premium alternative, which through the use of AI, have a more natural sound. To use a premium voice style, add the `premium` option in your NCCO:
 
@@ -70,7 +70,7 @@ Some voice styles come with a premium alternative, which through the use of AI, 
 ]
 ```
 
-> Premium Voices are currently in available without any extra charge during the [beta](/product-lifecycle/beta) period, but this will change once the beta period ends.
+> Premium Voices are chargeable. See the [pricing page for more information](https://www.vonage.com/communications-apis/in-app-voice/pricing/).
 
 
 ### Supported Languages

--- a/_documentation/en/voice/voice-api/guides/text-to-speech.md
+++ b/_documentation/en/voice/voice-api/guides/text-to-speech.md
@@ -70,7 +70,7 @@ Some voice styles come with a premium alternative, which through the use of AI, 
 ]
 ```
 
-> Premium Voices are chargeable. See the [pricing page for more information](https://www.vonage.com/communications-apis/voice/pricing).
+> Premium Voices are chargeable at a rate of €0.0027 per 100 characters.
 
 
 ### Supported Languages

--- a/_documentation/en/voice/voice-api/ncco-reference.md
+++ b/_documentation/en/voice/voice-api/ncco-reference.md
@@ -203,7 +203,7 @@ You can use the following options to control a *talk* action:
 | `level` | The volume level that the speech is played. This can be any value between `-1` to `1` with `0` being the default.  | No |
 | `language` | The language ([BCP-47](https://tools.ietf.org/html/bcp47) format) for the message you are sending. Default: `en-US`. Possible values are listed in the [Text-To-Speech guide](/voice/voice-api/guides/text-to-speech#supported-languages). | No |
 | `style` | The vocal style (vocal range, tessitura and timbre). Default: `0`. Possible values are listed in the [Text-To-Speech guide](/voice/voice-api/guides/text-to-speech#supported-languages). | No |
-| `premium` [Beta]| Set to `true` to use the premium version of the specified style if available, otherwise the standard version will be used. The default value is `false`. You can find more information about Premium Voices in the [Text-To-Speech guide](/voice/voice-api/guides/text-to-speech#premium-voices-beta). | No |
+| `premium` | Set to `true` to use the premium version of the specified style if available, otherwise the standard version will be used. The default value is `false`. You can find more information about Premium Voices in the [Text-To-Speech guide](/voice/voice-api/guides/text-to-speech#premium-voices). | No |
 
 ## Stream
 The `stream` action allows you to send an audio stream to a Conversation


### PR DESCRIPTION
PR for when Premium TTS goes GA in July.

Pedro, you can see the proposed changes on this staging page here: https://nexmo-developer-pr-4238.herokuapp.com/voice/voice-api/guides/text-to-speech#premium-voices