### PR TITLE
bumb Station version ~> v0.4.6 + ADD BLOG_PATH to CI review app

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem "station", "0.4.4"
+gem "station", "0.4.6"
 
 group :test do
   gem 'rspec'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -223,7 +223,7 @@ GEM
     mini_mime (1.1.2)
     mini_portile2 (2.5.3)
     minitest (5.15.0)
-    msgpack (1.5.2)
+    msgpack (1.5.3)
     multi_json (1.15.0)
     multi_xml (0.6.0)
     multipart-post (2.2.3)
@@ -267,10 +267,10 @@ GEM
       hash-deep-merge
       mustermann-contrib (~> 1.1.1)
       nokogiri
-    octokit (4.25.0)
+    octokit (4.25.1)
       faraday (>= 1, < 3)
       sawyer (~> 0.9)
-    oj (3.13.14)
+    oj (3.13.15)
     orm_adapter (0.5.0)
     pg (1.4.1)
     public_suffix (4.0.6)
@@ -394,7 +394,7 @@ GEM
       actionpack (>= 5.2)
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
-    station (0.4.4)
+    station (0.4.6)
       activeadmin (~> 2.7)
       activesupport (~> 6.0)
       algoliasearch (= 1.27.5)
@@ -449,7 +449,7 @@ GEM
     thor (1.2.1)
     tilt (2.0.10)
     titleize (1.4.1)
-    truncato (0.7.11)
+    truncato (0.7.12)
       htmlentities (~> 4.3.1)
       nokogiri (>= 1.7.0, <= 2.0)
     tzinfo (2.0.4)
@@ -484,7 +484,7 @@ DEPENDENCIES
   factory_bot
   rack-test
   rspec
-  station (= 0.4.4)
+  station (= 0.4.6)
 
 BUNDLED WITH
    2.2.31

--- a/app.json
+++ b/app.json
@@ -9,7 +9,8 @@
     "RACK_ENV": { "required": true },
     "RAILS_ENV": { "required": true },
     "OAS_PATH": "/app/_open_api/api_specs/definitions",
-    "DOCS_BASE_PATH": "."
+    "DOCS_BASE_PATH": ".",
+    "BLOG_PATH": "/app/_blog"
   },
   "stack": "heroku-18",
   "formation": {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       - POSTGRES_USER=nexmo_developer
       - POSTGRES_DB=nexmo_developer_production
   web:
-    image: nexmodev/station:v0.4.4
+    image: nexmodev/station:v0.4.6
     volumes:
       - .:/docs
     ports:


### PR DESCRIPTION
## ADD
- `"BLOG_PATH": "/app/_blog"` to access `/BLOG` in review app
- bumb Station version ~> `v0.4.6`