### PR TITLE
UPDATE: new API Status widget target URL

### DIFF
--- a/config/business_info.yml
+++ b/config/business_info.yml
@@ -25,7 +25,7 @@ code_snippets:
 footer:
   links:
     status:
-      path: 'https://api.vonagestatus.com/'
+      path: 'https://vonageapi.statuspage.io/'
       text: 'API Status'
     navigation:
       documentation:


### PR DESCRIPTION
### UPDATE
- Update the target URL of the API Status widget to: `https://vonageapi.statuspage.io/`
