### PR TITLE
update in app chat tutorial add members

### DIFF
--- a/_tutorials/en/client-sdk/in-app-messaging/add-users-to-conversation/java.md
+++ b/_tutorials/en/client-sdk/in-app-messaging/add-users-to-conversation/java.md
@@ -6,10 +6,10 @@ description: Add your two new users as Conversation members
 # Add Users to the Conversation
 
 You must now add your [Users](/conversation/concepts/user) as [Members](/conversation/concepts/member) of the [Conversation](/conversation/concepts/conversation) using Vonage CLI. 
-To add `Alice` to the conversation replace `CONVERSATION_ID` in the command below with your conversation Id generated previously (`CON-...`) and run the command:
+To add Alice to the conversation, replace `CONVERSATION_ID` in the command below with your conversation ID generated previously (`CON-...`) and `ALICE_USER_ID` with the ID generated (`USR-...`) when you created the Alice user in the previous step:
 
 ```sh
-vonage apps:conversations:members:add CONVERSATION_ID Alice
+vonage apps:conversations:members:add CONVERSATION_ID ALICE_USER_ID
 ```
 
 The output is ID of the Member:
@@ -18,9 +18,9 @@ The output is ID of the Member:
 Member added: MEM-aaaaaaa-bbbb-cccc-dddd-0123456789ab
 ```
 
-Now you need to add the second user, `Bob` to the Conversation. Similarly, replace the `CONVERSATION_ID` and execute the command:
+Now you need to add Bob to the Conversation. Similarly, replace the `CONVERSATION_ID` and `BOB_USER_ID` then run the command:
 
 ```sh
-vonage apps:conversations:members:add CONVERSATION_ID Bob
+vonage apps:conversations:members:add CONVERSATION_ID BOB_USER_ID
 Member added: MEM-eeeeeee-...
 ```

--- a/_tutorials/en/client-sdk/in-app-messaging/add-users-to-conversation/kotlin.md
+++ b/_tutorials/en/client-sdk/in-app-messaging/add-users-to-conversation/kotlin.md
@@ -6,10 +6,10 @@ description: Add your two new users as Conversation members
 # Add Users to the Conversation
 
 You must now add your [Users](/conversation/concepts/user) as [Members](/conversation/concepts/member) of the [Conversation](/conversation/concepts/conversation) using Vonage CLI. 
-To add `Alice` to the conversation replace `CONVERSATION_ID` in the command below with your conversation Id generated previously (`CON-...`) and run the command:
+To add Alice to the conversation, replace `CONVERSATION_ID` in the command below with your conversation ID generated previously (`CON-...`) and `ALICE_USER_ID` with the ID generated (`USR-...`) when you created the Alice user in the previous step:
 
 ```sh
-vonage apps:conversations:members:add CONVERSATION_ID Alice
+vonage apps:conversations:members:add CONVERSATION_ID ALICE_USER_ID
 ```
 
 The output is ID of the Member:
@@ -18,9 +18,9 @@ The output is ID of the Member:
 Member added: MEM-aaaaaaa-bbbb-cccc-dddd-0123456789ab
 ```
 
-Now you need to add the second user, `Bob` to the Conversation. Similarly, replace the `CONVERSATION_ID` and execute the command:
+Now you need to add Bob to the Conversation. Similarly, replace the `CONVERSATION_ID` and `BOB_USER_ID` then run the command:
 
 ```sh
-vonage apps:conversations:members:add CONVERSATION_ID Bob
+vonage apps:conversations:members:add CONVERSATION_ID BOB_USER_ID
 Member added: MEM-eeeeeee-...
 ```

--- a/_tutorials/en/client-sdk/in-app-messaging/add-users-to-conversation/objective_c.md
+++ b/_tutorials/en/client-sdk/in-app-messaging/add-users-to-conversation/objective_c.md
@@ -6,10 +6,10 @@ description: Add your two new users as Conversation members
 # Add Users to the Conversation
 
 You must now add your [Users](/conversation/concepts/user) as [Members](/conversation/concepts/member) of the [Conversation](/conversation/concepts/conversation) using Vonage CLI. 
-To add `Alice` to the conversation replace `CONVERSATION_ID` in the command below with your conversation Id generated previously (`CON-...`) and run the command:
+To add Alice to the conversation, replace `CONVERSATION_ID` in the command below with your conversation ID generated previously (`CON-...`) and `ALICE_USER_ID` with the ID generated (`USR-...`) when you created the Alice user in the previous step:
 
 ```sh
-vonage apps:conversations:members:add CONVERSATION_ID Alice
+vonage apps:conversations:members:add CONVERSATION_ID ALICE_USER_ID
 ```
 
 The output is ID of the Member:
@@ -18,9 +18,9 @@ The output is ID of the Member:
 Member added: MEM-aaaaaaa-bbbb-cccc-dddd-0123456789ab
 ```
 
-Now you need to add the second user, `Bob` to the Conversation. Similarly, replace the `CONVERSATION_ID` and execute the command:
+Now you need to add Bob to the Conversation. Similarly, replace the `CONVERSATION_ID` and `BOB_USER_ID` then run the command:
 
 ```sh
-vonage apps:conversations:members:add CONVERSATION_ID Bob
+vonage apps:conversations:members:add CONVERSATION_ID BOB_USER_ID
 Member added: MEM-eeeeeee-...
 ```

--- a/_tutorials/en/client-sdk/in-app-messaging/add-users-to-conversation/swift.md
+++ b/_tutorials/en/client-sdk/in-app-messaging/add-users-to-conversation/swift.md
@@ -6,10 +6,10 @@ description: Add your two new users as Conversation members
 # Add Users to the Conversation
 
 You must now add your [Users](/conversation/concepts/user) as [Members](/conversation/concepts/member) of the [Conversation](/conversation/concepts/conversation) using Vonage CLI. 
-To add `Alice` to the conversation replace `CONVERSATION_ID` in the command below with your conversation Id generated previously (`CON-...`) and run the command:
+To add Alice to the conversation, replace `CONVERSATION_ID` in the command below with your conversation ID generated previously (`CON-...`) and `ALICE_USER_ID` with the ID generated (`USR-...`) when you created the Alice user in the previous step:
 
 ```sh
-vonage apps:conversations:members:add CONVERSATION_ID Alice
+vonage apps:conversations:members:add CONVERSATION_ID ALICE_USER_ID
 ```
 
 The output is ID of the Member:
@@ -18,9 +18,9 @@ The output is ID of the Member:
 Member added: MEM-aaaaaaa-bbbb-cccc-dddd-0123456789ab
 ```
 
-Now you need to add the second user, `Bob` to the Conversation. Similarly, replace the `CONVERSATION_ID` and execute the command:
+Now you need to add Bob to the Conversation. Similarly, replace the `CONVERSATION_ID` and `BOB_USER_ID` then run the command:
 
 ```sh
-vonage apps:conversations:members:add CONVERSATION_ID Bob
+vonage apps:conversations:members:add CONVERSATION_ID BOB_USER_ID
 Member added: MEM-eeeeeee-...
 ```

--- a/config/tutorials/en/in-app-messaging/objective_c.yml
+++ b/config/tutorials/en/in-app-messaging/objective_c.yml
@@ -26,7 +26,7 @@ prerequisites:
 tasks:
   - client-sdk/in-app-messaging/create-application
   - client-sdk/create-conversation
-  - client-sdk/in-app-messaging/create-users
+  - client-sdk/create-users-alice-and-bob
   - client-sdk/in-app-messaging/add-users-to-conversation
   - client-sdk/in-app-messaging/generate-jwts
   - client-sdk/in-app-messaging/create-project

--- a/config/tutorials/en/in-app-messaging/swift.yml
+++ b/config/tutorials/en/in-app-messaging/swift.yml
@@ -28,7 +28,7 @@ prerequisites:
 tasks:
   - client-sdk/in-app-messaging/create-application
   - client-sdk/create-conversation
-  - client-sdk/in-app-messaging/create-users
+  - client-sdk/create-users-alice-and-bob
   - client-sdk/in-app-messaging/add-users-to-conversation
   - client-sdk/in-app-messaging/generate-jwts
   - client-sdk/in-app-messaging/create-project


### PR DESCRIPTION
Vonage CLI uses user ID not user name to add members to conversations

https://vonage.slack.com/archives/C4VE557K7/p1657697709892279