### PR TITLE
FIX: bumbed CI ruby version to use 3.0.0 for staging app

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,10 +41,10 @@ jobs:
     - name: Install packages
       run: |
         yarn install --pure-lockfile
-    - name: Set up Ruby 2.7.2
+    - name: Set up Ruby 3.0.0
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 2.7.2
+        ruby-version: 3.0.0
     - name: Ruby gem cache
       uses: actions/cache@v1
       with:

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,7 @@
 source 'https://rubygems.org'
 
+ruby '3.0.0'
+
 gem "station", "0.5.1"
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -486,5 +486,8 @@ DEPENDENCIES
   rspec
   station (= 0.5.1)
 
+RUBY VERSION
+   ruby 3.0.0p0
+
 BUNDLED WITH
    2.2.31


### PR DESCRIPTION
### FIX
- Bumped Ruby Version to `v3.0.0` in our CI to fix staging app error