### PR TITLE
APIDOC-334: Link changelog to SDK release notes

### DIFF
--- a/_changelogs/client_sdk/Android SDK.md
+++ b/_changelogs/client_sdk/Android SDK.md
@@ -1,6 +1,7 @@
 ---
 version: '4.0.3'
 release: '4 Apr 2022'
+redirect_to: '/client-sdk/sdk-documentation/android/release-notes'
 ---
 # [Android SDK](https://developer.nexmo.com/client-sdk/sdk-documentation/android)
 

--- a/_changelogs/client_sdk/Javascript SDK.md
+++ b/_changelogs/client_sdk/Javascript SDK.md
@@ -1,6 +1,7 @@
 ---
 version: '8.4.1'
 release: '14 Feb 2022'
+redirect_to: '/client-sdk/sdk-documentation/javascript/release-notes'
 ---
 # [Javascript SDK](https://developer.nexmo.com/client-sdk/sdk-documentation/javascript)
 
@@ -18,7 +19,7 @@ release: '14 Feb 2022'
 ## 8.4.0
 ### 21 Jan 2022
 
-*New* 
+*New*
 
 Added new `connectivityReport()` function to get a connectivity report for all Vonage data centers and media servers
 

--- a/_changelogs/client_sdk/iOS SDK.md
+++ b/_changelogs/client_sdk/iOS SDK.md
@@ -1,6 +1,7 @@
 ---
 version: '4.2.1'
 release: '6 Apr 2022'
+redirect_to: '/client-sdk/sdk-documentation/ios/release-notes'
 ---
 # [iOS SDK](https://developer.nexmo.com/client-sdk/sdk-documentation/ios)
 


### PR DESCRIPTION
### ADD
- new frontmatter value `redirect_to` to redirect the changelog if needed

```
---
version: '4.0.3'
release: '4 Apr 2022'
redirect_to: '/client-sdk/sdk-documentation/android/release-notes'
---
```