### PR TITLE
Update iOS SDK v5.0.0 release notes

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -731,6 +731,7 @@ passthrough
 passcode
 REAL_ESTATE
 notequal
+XCFrameworks
 bitrate
 100ms
 emojis

--- a/_documentation/en/client-sdk/sdk-documentation/ios/release-notes.md
+++ b/_documentation/en/client-sdk/sdk-documentation/ios/release-notes.md
@@ -6,6 +6,12 @@ navigation_weight: 0
 
 # Release Notes
 
+## 5.0.0  - 2022-09-01
+
+### Added
+
+- Support for XCFrameworks for M1
+
 ## 4.3.2  - 2022-07-01
 
 ### Fix


### PR DESCRIPTION
iOS SDK v5.0.0 notes added to `release-notes.md`.