### PR TITLE
Added message about increasing JVM size

### DIFF
--- a/_tutorials/en/client-sdk/app-to-app/create-project/java.md
+++ b/_tutorials/en/client-sdk/app-to-app/create-project/java.md
@@ -56,6 +56,13 @@ dependencies {
 ```
 
 Enable `jetifier` in the `gradle.properties` file by adding the below line:
-```
+
+```groovy
 android.enableJetifier=true
+```
+
+Finally, you will need to increase the memory allocation for the JVM by editing the `org.gradle.jvmargs` property in your `gradle.properties` file. We recommend this be set to at least 4GB:
+
+```groovy
+org.gradle.jvmargs=-Xmx4096m -Dfile.encoding=UTF-8
 ```

--- a/_tutorials/en/client-sdk/app-to-app/create-project/kotlin.md
+++ b/_tutorials/en/client-sdk/app-to-app/create-project/kotlin.md
@@ -55,6 +55,13 @@ dependencies {
 ```
 
 Enable `jetifier` in the `gradle.properties` file by adding the below line:
-```
+
+```groovy
 android.enableJetifier=true
+```
+
+Finally, you will need to increase the memory allocation for the JVM by editing the `org.gradle.jvmargs` property in your `gradle.properties` file. We recommend this be set to at least 4GB:
+
+```groovy
+org.gradle.jvmargs=-Xmx4096m -Dfile.encoding=UTF-8
 ```

--- a/_tutorials/en/client-sdk/app-to-phone/create-project/java.md
+++ b/_tutorials/en/client-sdk/app-to-phone/create-project/java.md
@@ -55,6 +55,13 @@ dependencies {
 ```
 
 Enable `jetifier` in the `gradle.properties` file by adding the below line:
-```
+
+```groovy
 android.enableJetifier=true
+```
+
+Finally, you will need to increase the memory allocation for the JVM by editing the `org.gradle.jvmargs` property in your `gradle.properties` file. We recommend this be set to at least 4GB:
+
+```groovy
+org.gradle.jvmargs=-Xmx4096m -Dfile.encoding=UTF-8
 ```

--- a/_tutorials/en/client-sdk/app-to-phone/create-project/kotlin.md
+++ b/_tutorials/en/client-sdk/app-to-phone/create-project/kotlin.md
@@ -55,6 +55,13 @@ dependencies {
 ```
 
 Enable `jetifier` in the `gradle.properties` file by adding the below line:
-```
+
+```groovy
 android.enableJetifier=true
+```
+
+Finally, you will need to increase the memory allocation for the JVM by editing the `org.gradle.jvmargs` property in your `gradle.properties` file. We recommend this be set to at least 4GB:
+
+```groovy
+org.gradle.jvmargs=-Xmx4096m -Dfile.encoding=UTF-8
 ```

--- a/_tutorials/en/client-sdk/in-app-messaging/create-project/java.md
+++ b/_tutorials/en/client-sdk/in-app-messaging/create-project/java.md
@@ -55,6 +55,13 @@ dependencies {
 ```
 
 Enable `jetifier` in the `gradle.properties` file by adding the below line:
-```
+
+```groovy
 android.enableJetifier=true
+```
+
+Finally, you will need to increase the memory allocation for the JVM by editing the `org.gradle.jvmargs` property in your `gradle.properties` file. We recommend this be set to at least 4GB:
+
+```groovy
+org.gradle.jvmargs=-Xmx4096m -Dfile.encoding=UTF-8
 ```

--- a/_tutorials/en/client-sdk/in-app-messaging/create-project/kotlin.md
+++ b/_tutorials/en/client-sdk/in-app-messaging/create-project/kotlin.md
@@ -56,6 +56,12 @@ dependencies {
 
 Enable `jetifier` in the `gradle.properties` file by adding the below line:
 
-```
+```groovy
 android.enableJetifier=true
+```
+
+Finally, you will need to increase the memory allocation for the JVM by editing the `org.gradle.jvmargs` property in your `gradle.properties` file. We recommend this be set to at least 4GB:
+
+```groovy
+org.gradle.jvmargs=-Xmx4096m -Dfile.encoding=UTF-8
 ```

--- a/_tutorials/en/client-sdk/phone-to-app/create-project/java.md
+++ b/_tutorials/en/client-sdk/phone-to-app/create-project/java.md
@@ -55,6 +55,13 @@ dependencies {
 ```
 
 Enable `jetifier` in the `gradle.properties` file by adding the below line:
-```
+
+```groovy
 android.enableJetifier=true
+```
+
+Finally, you will need to increase the memory allocation for the JVM by editing the `org.gradle.jvmargs` property in your `gradle.properties` file. We recommend this be set to at least 4GB:
+
+```groovy
+org.gradle.jvmargs=-Xmx4096m -Dfile.encoding=UTF-8
 ```

--- a/_tutorials/en/client-sdk/phone-to-app/create-project/kotlin.md
+++ b/_tutorials/en/client-sdk/phone-to-app/create-project/kotlin.md
@@ -55,6 +55,13 @@ dependencies {
 ```
 
 Enable `jetifier` in the `gradle.properties` file by adding the below line:
-```
+
+```groovy
 android.enableJetifier=true
+```
+
+Finally, you will need to increase the memory allocation for the JVM by editing the `org.gradle.jvmargs` property in your `gradle.properties` file. We recommend this be set to at least 4GB:
+
+```groovy
+org.gradle.jvmargs=-Xmx4096m -Dfile.encoding=UTF-8
 ```


### PR DESCRIPTION
Added missing message across Android guides (both java and kotlin) to highlight the need to increase the JVM size above 4GB to process the webrtc package.
