### PR TITLE
Voice API docs: Fixing table markdown for NCCO Pay Action Error Prompts

### DIFF
--- a/_documentation/en/voice/voice-api/ncco-reference.md
+++ b/_documentation/en/voice/voice-api/ncco-reference.md
@@ -445,6 +445,7 @@ Option | Description | Required
 
 ### Error Prompts
 Possible errors depend on prompt `type` (see above):
+
 Prompt Type | Error Type | Description 
 -- | -- | --
 `CardNumber` | `InvalidCardType` | The type of the card entered is not in the list of allowed card types


### PR DESCRIPTION
## Description

Fixing markdown for Pay Action Error Prompts table in Voice NCCO documentation, as table wasn't displaying correctly.

## Deploy Notes

Docs update only.
