### PR TITLE
Update NPM package install command

### DIFF
--- a/_documentation/en/application/vonage-cli.md
+++ b/_documentation/en/application/vonage-cli.md
@@ -14,7 +14,7 @@ The Vonage CLI allows you to create and manage your Vonage applications. To obta
 The  CLI can be installed with the following command:
 
 ```shell
-npm install -g @vonage/cli
+npm install --location=global @Vonage/cli
 ```
 
 The core CLI includes everything to support Application API V2 on the command line. You can check your installed version with the command:

--- a/_documentation/en/client-sdk/setup/create-your-application.md
+++ b/_documentation/en/client-sdk/setup/create-your-application.md
@@ -28,7 +28,7 @@ Make sure you have the following:
 To install the Vonage CLI, run the following command in a terminal:
 
 ```bash
-npm install -g @vonage/cli @vonage/cli-plugin-conversations
+npm install --location=global @Vonage/cli-plugin-conversations
 ```
 
 Set up the Vonage CLI to use your Vonage API Key and API Secret. You can get these from the [settings page](https://dashboard.nexmo.com/settings) in the Vonage Dashboard.

--- a/_documentation/en/number-insight/overview.md
+++ b/_documentation/en/number-insight/overview.md
@@ -67,7 +67,7 @@ This example shows you how to use the [Vonage CLI](/tools) to access the Number 
 ### Install and set up the Vonage CLI
 
 ```
-$ npm install -g @vonage/cli
+$ npm install --location=global @Vonage/cli
 ```
 
 > Note: Depending on your user permissions, you might need to prefix the above command with `sudo`.

--- a/_partials/reusable/install-vonage-cli.md
+++ b/_partials/reusable/install-vonage-cli.md
@@ -5,7 +5,7 @@ The [Vonage CLI](https://developer.nexmo.com/application/vonage-cli) allows you 
 To install the CLI with NPM run:
 
 ```bash
-npm install -g @vonage/cli
+npm install --location=global @Vonage/cli
 ```
 
 Set up the Vonage CLI to use your Vonage API Key and API Secret. You can get these from the [settings page](https://dashboard.nexmo.com/settings) in the Dashboard.

--- a/_use_cases/en/trancribe-amazon-api.md
+++ b/_use_cases/en/trancribe-amazon-api.md
@@ -30,7 +30,7 @@ This tutorial uses the [Vonage Command line tool](https://github.com/vonage/vona
 Run the following `npm` command at a terminal prompt to install the CLI tool:
 
 ```sh
-npm install -g @vonage/cli
+npm install --location=global @Vonage/cli
 ```
 
 Configure the CLI tool with your `VONAGE_API_KEY` and `VONAGE_API_SECRET`, which you will find in the Developer Dashboard:


### PR DESCRIPTION
## Description

NPM have changed how packages are installed globally. This is to update `npm install -g @Vonage/cli` to `npm install --location=global @Vonage/cli` across all documentation.

[APIDOC-473](https://jira.vonage.com/browse/APIDOC-473). [Review app](https://nexmo-developer-pr-4604.herokuapp.com/).