### PR TITLE
Update iOS SDK v5.0.1 release notes

### DIFF
--- a/_documentation/en/client-sdk/sdk-documentation/ios/release-notes.md
+++ b/_documentation/en/client-sdk/sdk-documentation/ios/release-notes.md
@@ -6,6 +6,13 @@ navigation_weight: 0
 
 # Release Notes
 
+## 5.0.1  - 2022-09-29
+
+### Fixed
+
+- Socket handshake config cleared on logout
+
+
 ## 5.0.0  - 2022-09-01
 
 ### Added


### PR DESCRIPTION
iOS SDK v5.0.1 notes added to `release-notes.md`.