### PR TITLE
UPDATE: new Ubuntu version for GitHub CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     services:
       db:
         env:


### PR DESCRIPTION
### Update
- new `Ubuntu` version to fix deprecation error during Github CI
```
 jobs:
   build:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04