### PR TITLE
Meetings API Doc Updates

### DIFF
--- a/_documentation/en/meetings/code-snippets/create-instant-room.md
+++ b/_documentation/en/meetings/code-snippets/create-instant-room.md
@@ -36,6 +36,10 @@ Field | Required? | Description |
 ``recording_options`` | No | An object containing recording options for the meeting. For example:
 | | | If ``auto_record``=``true``, the session will be recorded. If ``false``, the session will not be recorded.
 | | | If ``record_only_owner``=``true``, all audio in the session will be recorded but only the video of the owner of the room will be recorded. If ``false``, all users in the session will be recorded.
+``join_approval_level`` | No | The level of approval needed to join the meeting in the room.  Must be one of the following:
+| | | `after_owner_only` - Participants will join the meeting only after the host has joined.
+| | | `explicit_approval` - Participants will join the waiting room, and the host will approve / deny them.
+| | | `none` - No approval needed.
 
 ## Request
 
@@ -80,6 +84,8 @@ As this room has not yet expired, ``is_available`` is set to true.
    "metadata":null,
    "type":"instant",
    "expires_at":"2021-10-19T17:54:17.219Z",
+   "expire_after_use": false,
+   "join_approval_level": "abc123",
    "recording_options":{
       "auto_record":true,
       "record_only_owner":true

--- a/_documentation/en/meetings/code-snippets/create-instant-room.md
+++ b/_documentation/en/meetings/code-snippets/create-instant-room.md
@@ -36,7 +36,7 @@ Field | Required? | Description |
 ``recording_options`` | No | An object containing recording options for the meeting. For example:
 | | | If ``auto_record``=``true``, the session will be recorded. If ``false``, the session will not be recorded.
 | | | If ``record_only_owner``=``true``, all audio in the session will be recorded but only the video of the owner of the room will be recorded. If ``false``, all users in the session will be recorded.
-``join_approval_level`` | No | The level of approval needed to join the meeting in the room.  Must be one of the following:
+``join_approval_level`` | No | The level of approval needed to join the meeting.  Must be one of the following:
 | | | `after_owner_only` - Participants will join the meeting only after the host has joined.
 | | | `explicit_approval` - Participants will join the waiting room, and the host will approve / deny them.
 | | | `none` - No approval needed.

--- a/_documentation/en/meetings/code-snippets/create-long-term-room.md
+++ b/_documentation/en/meetings/code-snippets/create-long-term-room.md
@@ -37,6 +37,10 @@ Field | Required? | Description |
 ``recording_options`` | No | An object containing various meeting recording options. For example:
 | | | If ``auto_record``=``true``, the session will be recorded. If ``false``, the session will not be recorded.
 | | | If ``record_only_owner``=``true``, all audio in the session will be recorded but only the video of the owner of the room will be recorded. If ``false``, all users in the session will be recorded.
+``join_approval_level`` | No | The level of approval needed to join the meeting in the room.  Must be one of the following:
+| | | `after_owner_only` - Participants will join the meeting only after the host has joined.
+| | | `explicit_approval` - Participants will join the waiting room, and the host will approve / deny them.
+| | | `none` - No approval needed.
 
 ## Request
 
@@ -67,6 +71,7 @@ You will receive a response similar to the following:
     "metadata": null,
     "type": "long_term",
     "expires_at": "2022-10-21T18:45:50.901Z",
+    "join_approval_level": "abc123",
     "recording_options": {
         "auto_record": true
     },

--- a/_documentation/en/meetings/code-snippets/create-long-term-room.md
+++ b/_documentation/en/meetings/code-snippets/create-long-term-room.md
@@ -37,7 +37,7 @@ Field | Required? | Description |
 ``recording_options`` | No | An object containing various meeting recording options. For example:
 | | | If ``auto_record``=``true``, the session will be recorded. If ``false``, the session will not be recorded.
 | | | If ``record_only_owner``=``true``, all audio in the session will be recorded but only the video of the owner of the room will be recorded. If ``false``, all users in the session will be recorded.
-``join_approval_level`` | No | The level of approval needed to join the meeting in the room.  Must be one of the following:
+``join_approval_level`` | No | The level of approval needed to join the meeting.  Must be one of the following:
 | | | `after_owner_only` - Participants will join the meeting only after the host has joined.
 | | | `explicit_approval` - Participants will join the waiting room, and the host will approve / deny them.
 | | | `none` - No approval needed.

--- a/_documentation/en/meetings/code-snippets/room-management.md
+++ b/_documentation/en/meetings/code-snippets/room-management.md
@@ -28,18 +28,6 @@ curl -X GET 'https://api-eu.vonage.com/beta/meetings/rooms/' \
 -H 'Content-Type: application/json'
 ```
 
-## Room Deletion
-
-You use the ``ID`` to perform a DELETE action on a room:
-
-``` curl
-curl -X DELETE 'https://api-eu.vonage.com/beta/meetings/rooms/b307d837-c0ce-4619-8c5c-70e418ef9693' \
--H 'Authorization: Basic YWFhMDEyOmFiYzEyMzQ1Njc4OQ==' \
--H 'Content-Type: application/json'
-```
-
-> This operation will return a ``204`` status.
-
 ## Expiration Update
 
 The expiration date of a long term room can be updated by using a PATCH action and the room ID. The new date should be included in an object called ``update_details``. Please note that only long term rooms can be updated. 

--- a/_documentation/en/meetings/overview.md
+++ b/_documentation/en/meetings/overview.md
@@ -49,6 +49,7 @@ Take a look at the [Video API](https://tokbox.com/developer/) documentation for 
   * **Recording**: you can start a recording manually during a meeting, or set the meeting to record automatically when sending a request. You can also choose to only record the owner of the room.
   * **Room Management**: you can delete, update or retrieve information about rooms.
   * **Callbacks**: allow you to receive information about a session.
+  * **Waiting Room**: set the level of approval needed to join the meeting. Participants will join the waiting room until either the owner has joined or until the owner has admitted them, depending on the level of approval required.
 
 ## Room Types
 


### PR DESCRIPTION
## Description

Added information on Waiting Rooms to Overview, Create an Instant Room, and Create a Long Term Room pages. [APIDOC-273](https://jira.vonage.com/browse/APIDOC-273). 

Removed information on Room Deletion from the Room Management page, as this is no longer used.
