### PR TITLE
Remove deprecated errors codes

### DIFF
--- a/_open_api/errors/10dlc.md
+++ b/_open_api/errors/10dlc.md
@@ -15,8 +15,3 @@ Error | Details | Resolution
 `invalid-campaign-data` | There are errors in the campaign data submitted. | Ensure all required fields have values and correct any errors to values in the specified fields.
 `numbers-already linked` | The number you are attempting to link is already linked to another campaign. | You must link a unique number to a campaign. Link a different number to this campaign.
 `invalid-number-data` | There are errors in the number data submitted. | Ensure all required fields have values and correct any errors to values in the specified fields.
-`illegal-sender-address` | The number you are trying to send from is not a US-approved long number or a Vonage number. | Check to ensure the number matches the one from your Vonage dashboard.
-`submission-throttled` | Submission Control throttled due to max volume reached for this period.
-| Once the number of requests drops from its current high, the quota per period will be restored.
-`daily-submission-throttled` | Daily Limit Surpassed - Submission Control throttled due to max volume reached for this period
- | Once the number of requests drops from its current high, the quota per period will be restored.


### PR DESCRIPTION
## Description

This PR is related to this [10DLC](https://github.com/Nexmo/api-specification/pull/558)  spec change
Anthony Landau from the telco dev team confirmed the HTTP endpoints bearing these error messages (as of the time of editing this comment) had been deprecated.
