### PR TITLE
Add throttled as a generic API Error

### DIFF
--- a/config/api-errors.yml
+++ b/config/api-errors.yml
@@ -126,3 +126,7 @@ generic_errors:
   throttled:
     description: Too many requests have been made on this endpoint
     resolution: Wait a moment and try again
+
+  invalid-params:
+    description: The value of one of more parameters suppied in the request is invalid
+    resolution: Review the data sent against the API specifications, or check for more information in the error response.

--- a/config/api-errors.yml
+++ b/config/api-errors.yml
@@ -124,8 +124,8 @@ generic_errors:
     resolution: Re-enable the application or create a new application to use
 
   throttled:
-    description: Too many requests have been made on this endpoint
-    resolution: Wait a moment and try again
+    description: You have hit your rate limit for this endpoint
+    resolution: Wait a moment and try again, or check the product rate limit.
 
   invalid-params:
     description: The value of one of more parameters suppied in the request is invalid

--- a/config/api-errors.yml
+++ b/config/api-errors.yml
@@ -122,3 +122,7 @@ generic_errors:
   application-suspended:
     description: This application has been suspended
     resolution: Re-enable the application or create a new application to use
+
+  throttled:
+    description: Too many requests have been made on this endpoint
+    resolution: Wait a moment and try again


### PR DESCRIPTION
## Description

New API endpoints and responses we're rolling out tend to be more HATEOS / RESTful in design, to use HTTP verbs efficiently. We have now come across a number of cases where we could do with a generic Throttled API error response, as this is something likely to be standard across many products. 

This is now also the case for generic Invalid Parameters.

If this is merged, we'll need to update engineering on our specific products to make sure 429 errors link to it
i.e. `https://www.developer.vonage.com/api-errors#throttled`
or `https://www.developer.vonage.com/api-errors#invalid-params`

Note that due to the html ID elements, this does not impact product-specific links as they contain the headers in the URL.