### PR TITLE
Meetings Docs Updates

### DIFF
--- a/_documentation/en/meetings/code-snippets/before-you-begin.md
+++ b/_documentation/en/meetings/code-snippets/before-you-begin.md
@@ -18,10 +18,6 @@ Please read this information carefully, so you can best use the code snippets.
 
 If you don’t have a Vonage account yet, you can get sign up for one here: [Vonage Developers Account](https://ui.idp.vonage.com/ui/auth/registration?icid=tryitfree_adpdocs_nexmodashbdfreetrialsignup_inpagelink).
 
-#### Meetings API Activation
-
-To activate the Meetings API, you need to register with us. Please send an email request, with your API key from the [Vonage API Dashboard](https://dashboard.nexmo.com), to the [Meetings API Team](mailto:meetings-api@vonage.com).
-
 #### Application ID and Private Key
 
 Once you’re logged in to the [Vonage API Dashboard](https://dashboard.nexmo.com), click on Applications and create a new Application. Generate a public and private key and record the private key.

--- a/_documentation/en/meetings/code-snippets/create-instant-room.md
+++ b/_documentation/en/meetings/code-snippets/create-instant-room.md
@@ -12,8 +12,6 @@ How to set up an Instant (default) room using the Meetings API.
 
 * **Vonage Developer Account**: If you do not already have one, sign-up for a free account on the [Vonage Developers Account](https://ui.idp.vonage.com/ui/auth/registration?icid=tryitfree_adpdocs_nexmodashbdfreetrialsignup_inpagelink).
 
-* **Meetings API Activation**: To activate the Meetings API, you must register. Please send an email request to the [Meetings API Team](mailto:meetings-api@vonage.com).
-
 * **Application ID and Secret**: Once you’re logged in to the [Vonage API Dashboard](https://dashboard.nexmo.com), click on Applications and create a new Application. Click  `Generate public and private key` and record the private key. You'll be using the private key with the Application ID to [Generate a JSON Web Token (JWT)](https://developer.vonage.com/jwt). For further details about JWTs, please see [Authentication](/concepts/guides/authentication).
 
 ## Set up POST Request

--- a/_documentation/en/meetings/code-snippets/create-long-term-room.md
+++ b/_documentation/en/meetings/code-snippets/create-long-term-room.md
@@ -12,8 +12,6 @@ How to setup a long term room using the Meetings API.
 
 * **Vonage Developer Account**: If you do not already have one, sign-up for a free account on the [Vonage Developers Account](https://ui.idp.vonage.com/ui/auth/registration?icid=tryitfree_adpdocs_nexmodashbdfreetrialsignup_inpagelink).
 
-* **Meetings API Activation**: To activate the Meetings API, you must register. Please send an email request to the [Meetings API Team](mailto:meetings-api@vonage.com).
-
 * **Application ID and Secret**: Once you’re logged in to the [Vonage API Dashboard](https://dashboard.nexmo.com), click on Applications and create a new Application. Click  `Generate public and private key` and record the private key. You'll be using the private key with the Application ID to [Generate a JSON Web Token (JWT)](https://developer.vonage.com/jwt). For further details about JWTs, please see [Authentication](/concepts/guides/authentication).
 
 ## Setup POST Request

--- a/_documentation/en/meetings/code-snippets/theme-management.md
+++ b/_documentation/en/meetings/code-snippets/theme-management.md
@@ -13,8 +13,6 @@ Use the themes API to create themes with different colors, logos, or texts. Them
 
 * **Vonage Developer Account**: If you do not already have one, sign-up for a free account on the [Vonage Developers Account](https://ui.idp.vonage.com/ui/auth/registration?icid=tryitfree_adpdocs_nexmodashbdfreetrialsignup_inpagelink).
 
-* **Meetings API Activation**: To activate the Meetings API, you must register. Please send an email request to the [Meetings API Team](mailto:meetings-api@vonage.com).
-
 * **Application ID and Secret**: Once you’re logged in to the [Vonage API Dashboard](https://dashboard.nexmo.com), click on Applications and create a new Application. Click  `Generate public and private key` and record the private key. You'll be using the private key with the Application ID to [Generate a JSON Web Token (JWT)](https://developer.vonage.com/jwt). For further details about JWTs, please see [Authentication](/concepts/guides/authentication).
 
 ### Setting Up The Request 

--- a/_documentation/en/meetings/overview.md
+++ b/_documentation/en/meetings/overview.md
@@ -1,14 +1,14 @@
 ---
 title: Overview
 meta_title: Provides an out of the box video solution for low tech users
-description: The Meetings API (Beta) allows you to integrate real-time, high-quality interactive video meetings into your web apps
+description: The Meetings API allows you to integrate real-time, high-quality interactive video meetings into your web apps
 product: meetings
 navigation_weight: 1
 ---
 
 # Meetings API Overview
 
-The Meetings API (Beta) allows you to integrate real-time, high-quality interactive video meetings into your web apps.
+The Meetings API allows you to integrate real-time, high-quality interactive video meetings into your web apps.
 
 > You can try out the Meetings API in the [Vonage API Dashboard](https://dashboard.nexmo.com).
 

--- a/config/navigation.yml
+++ b/config/navigation.yml
@@ -146,7 +146,6 @@ navigation_overrides:
   meetings:
     svg: 'video-conference'
     svgColor: 'purple'
-    label: 'Beta'
   dispatch:
     svg: 'flow'
     svgColor: 'purple'


### PR DESCRIPTION
## Description

Removing references to 'Beta' now that the Meetings API is GA. Also removing all 'Meetings API Activation' sections, as the user no longer has to do this.
