### PR TITLE
Added link to 10DLC in Troubleshooting section

### DIFF
--- a/_documentation/en/messaging/sms/overview.md
+++ b/_documentation/en/messaging/sms/overview.md
@@ -138,7 +138,7 @@ source: '_examples/messaging/sms/send-an-sms'
 
 If you have problems when making API calls be sure to check the returned [status field](/messaging/sms/guides/troubleshooting-sms) for specific [error codes](/messaging/sms/guides/troubleshooting-sms#sms-api-error-codes).
 
-**Important:** If you are a U.S. customer using the SMS API to send traffic from a +1 Country Code 10 Digit Long Code (10 DLC) into US networks, you must register a brand and campaign in order to get approval for sending. Once approved, you must link a number to the campaign. See [Important 10 DLC guidelines for US customers](#important-10-dlc-guidelines-for-us-customers) for details.
+**Important:** If you are a U.S. customer using the SMS API to send traffic from a +1 Country Code 10 Digit Long Code (10 DLC) into US networks, you must register a brand and campaign in order to get approval for sending. Once approved, you must link a number to the campaign. See [Important 10 DLC guidelines for US customers](#important-10-dlc-guidelines-for-us-customers) for details. For more comprehensive documentation on 10 DLC, see the [10 DLC Support section](/messages/10-dlc/overview).
 
 ## Concepts
 

--- a/_documentation/en/messaging/sms/overview.md
+++ b/_documentation/en/messaging/sms/overview.md
@@ -138,6 +138,8 @@ source: '_examples/messaging/sms/send-an-sms'
 
 If you have problems when making API calls be sure to check the returned [status field](/messaging/sms/guides/troubleshooting-sms) for specific [error codes](/messaging/sms/guides/troubleshooting-sms#sms-api-error-codes).
 
+**Important:** If you are a U.S. customer using the SMS API to send traffic from a +1 Country Code 10 Digit Long Code (10 DLC) into US networks, you must register a brand and campaign in order to get approval for sending. Once approved, you must link a number to the campaign. See [Important 10 DLC guidelines for US customers](#important-10-dlc-guidelines-for-us-customers) for details.
+
 ## Concepts
 
 Before using the Vonage SMS API, familiarize yourself with the following:


### PR DESCRIPTION
## Description

Modified the SMS Overview > Troubleshooting section, adding a link to the 10 DLC documentation further up the page. The reason for adding this is that the customer dashboard links to this section when a user receives an error when using the Try Me feature for the SMS API. If they do not have their number linked to an approved campaign, they will get the error and are referred to the troubleshooting section which does not mention 10 DLC.